### PR TITLE
fix content when zoom out

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -253,7 +253,7 @@
 </head>
 
 <body>
-    <div id="app"></div>
+    <div id="app" style="flex:1;display:flex;"></div>
     <script type="module" src="/src/main.ts"></script>
 </body>
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,6 +1,13 @@
 /* application */
 
+.app-window-frame {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
 .app {
+  flex: 1;
   height: 100vh;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
fix: page does fill whole window, when zoom out 

ex: zoom 80%
<img width="2000" height="1463" alt="ss 2026-03-02 at 10 43 32" src="https://github.com/user-attachments/assets/686fb4fc-bd18-4a96-bd37-bd57365410a4" />