### PR TITLE
Log fixes

### DIFF
--- a/backend/app_refresh_setup.go
+++ b/backend/app_refresh_setup.go
@@ -227,7 +227,16 @@ func (a *App) sharedLogTargetLimiter() *logstream.GlobalTargetLimiter {
 		return nil
 	}
 	if a.logTargetLimiter == nil {
-		a.logTargetLimiter = logstream.NewGlobalTargetLimiter(config.LogStreamGlobalTargetLimit)
+		limit := defaultLogTargetGlobalLimit
+		a.settingsMu.Lock()
+		if a.appSettings == nil {
+			_ = a.loadAppSettings()
+		}
+		if a.appSettings != nil && a.appSettings.LogTargetGlobalLimit > 0 {
+			limit = clampLogTargetGlobalLimit(a.appSettings.LogTargetGlobalLimit)
+		}
+		a.settingsMu.Unlock()
+		a.logTargetLimiter = logstream.NewGlobalTargetLimiter(limit)
 	}
 	return a.logTargetLimiter
 }

--- a/backend/app_settings.go
+++ b/backend/app_settings.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/luxury-yacht/app/backend/internal/config"
+	"github.com/luxury-yacht/app/backend/internal/podlogs"
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 )
 
@@ -74,7 +75,9 @@ type settingsRefresh struct {
 
 // settingsLogs captures user-configurable pod-logs settings.
 type settingsLogs struct {
-	BufferMaxSize int `json:"bufferMaxSize"` // Max log entries kept in memory per Logs tab
+	BufferMaxSize       int `json:"bufferMaxSize"`       // Max log entries kept in memory per Logs tab
+	TargetPerScopeLimit int `json:"targetPerScopeLimit"` // Max pod/container targets per Logs tab
+	TargetGlobalLimit   int `json:"targetGlobalLimit"`   // Max pod/container targets across all Logs tabs
 }
 
 // Log buffer size bounds. The frontend clamps to the same range in
@@ -84,6 +87,12 @@ const (
 	defaultLogBufferMaxSize = 1000
 	minLogBufferMaxSize     = 100
 	maxLogBufferMaxSize     = 10000
+	defaultLogTargetPerScopeLimit = podlogs.DefaultPerScopeTargetLimit
+	minLogTargetPerScopeLimit     = podlogs.MinPerScopeTargetLimit
+	maxLogTargetPerScopeLimit     = podlogs.MaxPerScopeTargetLimit
+	defaultLogTargetGlobalLimit   = config.LogStreamGlobalTargetLimit
+	minLogTargetGlobalLimit       = 1
+	maxLogTargetGlobalLimit       = 1000
 )
 
 func clampLogBufferMaxSize(size int) int {
@@ -94,6 +103,26 @@ func clampLogBufferMaxSize(size int) int {
 		return maxLogBufferMaxSize
 	}
 	return size
+}
+
+func clampLogTargetPerScopeLimit(limit int) int {
+	if limit < minLogTargetPerScopeLimit {
+		return minLogTargetPerScopeLimit
+	}
+	if limit > maxLogTargetPerScopeLimit {
+		return maxLogTargetPerScopeLimit
+	}
+	return limit
+}
+
+func clampLogTargetGlobalLimit(limit int) int {
+	if limit < minLogTargetGlobalLimit {
+		return minLogTargetGlobalLimit
+	}
+	if limit > maxLogTargetGlobalLimit {
+		return maxLogTargetGlobalLimit
+	}
+	return limit
 }
 
 // settingsKubeconfig captures user-configurable kubeconfig settings.
@@ -118,7 +147,11 @@ func defaultSettingsFile() *settingsFile {
 		Preferences: settingsPreferences{
 			Theme:   "system",
 			Refresh: &settingsRefresh{Auto: true, Background: true, MetricsIntervalMs: defaultMetricsIntervalMs()},
-			Logs:    &settingsLogs{BufferMaxSize: defaultLogBufferMaxSize},
+			Logs: &settingsLogs{
+				BufferMaxSize:       defaultLogBufferMaxSize,
+				TargetPerScopeLimit: defaultLogTargetPerScopeLimit,
+				TargetGlobalLimit:   defaultLogTargetGlobalLimit,
+			},
 
 			GridTablePersistenceMode: "shared",
 			// DefaultObjectPanelPosition and object panel layout defaults are
@@ -150,7 +183,11 @@ func normalizeSettingsFile(settings *settingsFile) *settingsFile {
 		settings.Preferences.Refresh.MetricsIntervalMs = defaultMetricsIntervalMs()
 	}
 	if settings.Preferences.Logs == nil {
-		settings.Preferences.Logs = &settingsLogs{BufferMaxSize: defaultLogBufferMaxSize}
+		settings.Preferences.Logs = &settingsLogs{
+			BufferMaxSize:       defaultLogBufferMaxSize,
+			TargetPerScopeLimit: defaultLogTargetPerScopeLimit,
+			TargetGlobalLimit:   defaultLogTargetGlobalLimit,
+		}
 	}
 	// A zero value from an older settings file means "use the default",
 	// not "truncate every buffer to 0" — clamp after the fact so existing
@@ -159,6 +196,16 @@ func normalizeSettingsFile(settings *settingsFile) *settingsFile {
 		settings.Preferences.Logs.BufferMaxSize = defaultLogBufferMaxSize
 	} else {
 		settings.Preferences.Logs.BufferMaxSize = clampLogBufferMaxSize(settings.Preferences.Logs.BufferMaxSize)
+	}
+	if settings.Preferences.Logs.TargetPerScopeLimit <= 0 {
+		settings.Preferences.Logs.TargetPerScopeLimit = defaultLogTargetPerScopeLimit
+	} else {
+		settings.Preferences.Logs.TargetPerScopeLimit = clampLogTargetPerScopeLimit(settings.Preferences.Logs.TargetPerScopeLimit)
+	}
+	if settings.Preferences.Logs.TargetGlobalLimit <= 0 {
+		settings.Preferences.Logs.TargetGlobalLimit = defaultLogTargetGlobalLimit
+	} else {
+		settings.Preferences.Logs.TargetGlobalLimit = clampLogTargetGlobalLimit(settings.Preferences.Logs.TargetGlobalLimit)
 	}
 	if settings.Preferences.GridTablePersistenceMode == "" {
 		settings.Preferences.GridTablePersistenceMode = "shared"
@@ -331,6 +378,8 @@ func getDefaultAppSettings() *AppSettings {
 		RefreshBackgroundClustersEnabled: true,
 		MetricsRefreshIntervalMs:         defaultMetricsIntervalMs(),
 		LogBufferMaxSize:                 defaultLogBufferMaxSize,
+		LogTargetPerScopeLimit:           defaultLogTargetPerScopeLimit,
+		LogTargetGlobalLimit:             defaultLogTargetGlobalLimit,
 		GridTablePersistenceMode:         "shared",
 	}
 }
@@ -342,8 +391,16 @@ func (a *App) loadAppSettings() error {
 	}
 
 	logBufferMaxSize := defaultLogBufferMaxSize
+	logTargetPerScopeLimit := defaultLogTargetPerScopeLimit
+	logTargetGlobalLimit := defaultLogTargetGlobalLimit
 	if settings.Preferences.Logs != nil && settings.Preferences.Logs.BufferMaxSize > 0 {
 		logBufferMaxSize = clampLogBufferMaxSize(settings.Preferences.Logs.BufferMaxSize)
+	}
+	if settings.Preferences.Logs != nil && settings.Preferences.Logs.TargetPerScopeLimit > 0 {
+		logTargetPerScopeLimit = clampLogTargetPerScopeLimit(settings.Preferences.Logs.TargetPerScopeLimit)
+	}
+	if settings.Preferences.Logs != nil && settings.Preferences.Logs.TargetGlobalLimit > 0 {
+		logTargetGlobalLimit = clampLogTargetGlobalLimit(settings.Preferences.Logs.TargetGlobalLimit)
 	}
 
 	a.appSettings = &AppSettings{
@@ -354,6 +411,8 @@ func (a *App) loadAppSettings() error {
 		RefreshBackgroundClustersEnabled: settings.Preferences.Refresh.Background,
 		MetricsRefreshIntervalMs:         settings.Preferences.Refresh.MetricsIntervalMs,
 		LogBufferMaxSize:                 logBufferMaxSize,
+		LogTargetPerScopeLimit:           logTargetPerScopeLimit,
+		LogTargetGlobalLimit:             logTargetGlobalLimit,
 		GridTablePersistenceMode:         settings.Preferences.GridTablePersistenceMode,
 		DefaultObjectPanelPosition:       settings.Preferences.DefaultObjectPanelPosition,
 		ObjectPanelDockedRightWidth:      settings.Preferences.ObjectPanelDockedRightWidth,
@@ -373,6 +432,10 @@ func (a *App) loadAppSettings() error {
 		LinkColorLight:                   settings.Preferences.LinkColorLight,
 		LinkColorDark:                    settings.Preferences.LinkColorDark,
 		Themes:                           settings.Preferences.Themes,
+	}
+	podlogs.SetPerScopeTargetLimit(logTargetPerScopeLimit)
+	if a.logTargetLimiter != nil {
+		a.logTargetLimiter.SetLimit(logTargetGlobalLimit)
 	}
 	return nil
 }
@@ -399,6 +462,8 @@ func (a *App) saveAppSettings() error {
 		settings.Preferences.Logs = &settingsLogs{}
 	}
 	settings.Preferences.Logs.BufferMaxSize = clampLogBufferMaxSize(a.appSettings.LogBufferMaxSize)
+	settings.Preferences.Logs.TargetPerScopeLimit = clampLogTargetPerScopeLimit(a.appSettings.LogTargetPerScopeLimit)
+	settings.Preferences.Logs.TargetGlobalLimit = clampLogTargetGlobalLimit(a.appSettings.LogTargetGlobalLimit)
 	settings.Preferences.GridTablePersistenceMode = a.appSettings.GridTablePersistenceMode
 	settings.Preferences.DefaultObjectPanelPosition = a.appSettings.DefaultObjectPanelPosition
 	settings.Preferences.ObjectPanelDockedRightWidth = a.appSettings.ObjectPanelDockedRightWidth
@@ -570,6 +635,42 @@ func (a *App) SetLogBufferMaxSize(size int) error {
 	clamped := clampLogBufferMaxSize(size)
 	a.logger.Info(fmt.Sprintf("Log buffer max size changed to: %d", clamped), "Settings")
 	a.appSettings.LogBufferMaxSize = clamped
+	return a.saveAppSettings()
+}
+
+func (a *App) SetLogTargetPerScopeLimit(limit int) error {
+	a.settingsMu.Lock()
+	defer a.settingsMu.Unlock()
+
+	if a.appSettings == nil {
+		if err := a.loadAppSettings(); err != nil {
+			return err
+		}
+	}
+
+	clamped := clampLogTargetPerScopeLimit(limit)
+	a.logger.Info(fmt.Sprintf("Log target per-scope limit changed to: %d", clamped), "Settings")
+	a.appSettings.LogTargetPerScopeLimit = clamped
+	podlogs.SetPerScopeTargetLimit(clamped)
+	return a.saveAppSettings()
+}
+
+func (a *App) SetLogTargetGlobalLimit(limit int) error {
+	a.settingsMu.Lock()
+	defer a.settingsMu.Unlock()
+
+	if a.appSettings == nil {
+		if err := a.loadAppSettings(); err != nil {
+			return err
+		}
+	}
+
+	clamped := clampLogTargetGlobalLimit(limit)
+	a.logger.Info(fmt.Sprintf("Log target global limit changed to: %d", clamped), "Settings")
+	a.appSettings.LogTargetGlobalLimit = clamped
+	if a.logTargetLimiter != nil {
+		a.logTargetLimiter.SetLimit(clamped)
+	}
 	return a.saveAppSettings()
 }
 

--- a/backend/app_settings_test.go
+++ b/backend/app_settings_test.go
@@ -88,6 +88,9 @@ func TestAppSaveAndLoadAppSettingsRoundTrip(t *testing.T) {
 		AutoRefreshEnabled:               false,
 		RefreshBackgroundClustersEnabled: false,
 		MetricsRefreshIntervalMs:         7000,
+		LogBufferMaxSize:                 2500,
+		LogTargetPerScopeLimit:           144,
+		LogTargetGlobalLimit:             180,
 		GridTablePersistenceMode:         "namespaced",
 		DefaultObjectPanelPosition:       "floating",
 		PaletteHueLight:                  200,
@@ -110,6 +113,9 @@ func TestAppSaveAndLoadAppSettingsRoundTrip(t *testing.T) {
 	require.False(t, app.appSettings.AutoRefreshEnabled)
 	require.False(t, app.appSettings.RefreshBackgroundClustersEnabled)
 	require.Equal(t, 7000, app.appSettings.MetricsRefreshIntervalMs)
+	require.Equal(t, 2500, app.appSettings.LogBufferMaxSize)
+	require.Equal(t, 144, app.appSettings.LogTargetPerScopeLimit)
+	require.Equal(t, 180, app.appSettings.LogTargetGlobalLimit)
 	require.Equal(t, "namespaced", app.appSettings.GridTablePersistenceMode)
 	require.Equal(t, "floating", app.appSettings.DefaultObjectPanelPosition)
 	require.Equal(t, 200, app.appSettings.PaletteHueLight)
@@ -232,6 +238,52 @@ func TestAppSetLogBufferMaxSizePersistsAndClamps(t *testing.T) {
 	settings, err := freshApp.GetAppSettings()
 	require.NoError(t, err)
 	require.Equal(t, defaultLogBufferMaxSize, settings.LogBufferMaxSize)
+	require.Equal(t, defaultLogTargetPerScopeLimit, settings.LogTargetPerScopeLimit)
+	require.Equal(t, defaultLogTargetGlobalLimit, settings.LogTargetGlobalLimit)
+}
+
+func TestAppSetLogTargetPerScopeLimitPersistsAndClamps(t *testing.T) {
+	setTestConfigEnv(t)
+
+	app := newTestAppWithDefaults(t)
+	require.NoError(t, app.SetLogTargetPerScopeLimit(144))
+	require.Equal(t, 144, app.appSettings.LogTargetPerScopeLimit)
+
+	app.appSettings = nil
+	require.NoError(t, app.loadAppSettings())
+	require.Equal(t, 144, app.appSettings.LogTargetPerScopeLimit)
+
+	entries := app.logger.GetEntries()
+	require.NotEmpty(t, entries)
+	require.Contains(t, entries[len(entries)-1].Message, "Log target per-scope limit changed to: 144")
+
+	require.NoError(t, app.SetLogTargetPerScopeLimit(0))
+	require.Equal(t, minLogTargetPerScopeLimit, app.appSettings.LogTargetPerScopeLimit)
+
+	require.NoError(t, app.SetLogTargetPerScopeLimit(999_999))
+	require.Equal(t, maxLogTargetPerScopeLimit, app.appSettings.LogTargetPerScopeLimit)
+}
+
+func TestAppSetLogTargetGlobalLimitPersistsAndClamps(t *testing.T) {
+	setTestConfigEnv(t)
+
+	app := newTestAppWithDefaults(t)
+	require.NoError(t, app.SetLogTargetGlobalLimit(180))
+	require.Equal(t, 180, app.appSettings.LogTargetGlobalLimit)
+
+	app.appSettings = nil
+	require.NoError(t, app.loadAppSettings())
+	require.Equal(t, 180, app.appSettings.LogTargetGlobalLimit)
+
+	entries := app.logger.GetEntries()
+	require.NotEmpty(t, entries)
+	require.Contains(t, entries[len(entries)-1].Message, "Log target global limit changed to: 180")
+
+	require.NoError(t, app.SetLogTargetGlobalLimit(0))
+	require.Equal(t, minLogTargetGlobalLimit, app.appSettings.LogTargetGlobalLimit)
+
+	require.NoError(t, app.SetLogTargetGlobalLimit(999_999))
+	require.Equal(t, maxLogTargetGlobalLimit, app.appSettings.LogTargetGlobalLimit)
 }
 
 func TestAppSetGridTablePersistenceModePersists(t *testing.T) {

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -98,7 +98,7 @@ const (
 	LogStreamKeepAliveInterval = 15 * time.Second
 
 	// LogStreamGlobalTargetLimit caps resolved pod/container targets across all active log scopes.
-	LogStreamGlobalTargetLimit = 72
+	LogStreamGlobalTargetLimit = 200
 
 	// EventStreamKeepAliveInterval controls how often keepalive messages are emitted for event streams.
 	EventStreamKeepAliveInterval = 15 * time.Second

--- a/backend/internal/podlogs/containers.go
+++ b/backend/internal/podlogs/containers.go
@@ -21,6 +21,7 @@ type ContainerSelectionOptions struct {
 	IncludeInit      bool
 	IncludeEphemeral bool
 	StateFilter      ContainerStateFilter
+	Selection        ScopeSelection
 }
 
 type ContainerRef struct {
@@ -37,6 +38,17 @@ func (c ContainerRef) DisplayName() string {
 		return fmt.Sprintf("%s (debug)", c.Name)
 	default:
 		return c.Name
+	}
+}
+
+func (c ContainerRef) SelectionValue() string {
+	switch {
+	case c.IsInit:
+		return SelectedInitPrefix + c.Name
+	case c.IsEphemeral:
+		return SelectedDebugPrefix + c.Name
+	default:
+		return SelectedContainerPrefix + c.Name
 	}
 }
 
@@ -92,6 +104,9 @@ func EnumerateContainersWithOptions(pod *corev1.Pod, options ContainerSelectionO
 	var containers []ContainerRef
 
 	appendIfMatches := func(container ContainerRef) {
+		if !options.Selection.MatchContainer(container) {
+			return
+		}
 		if !isAll {
 			if MatchContainerFilter(container, filter) {
 				containers = append(containers, container)

--- a/backend/internal/podlogs/selection.go
+++ b/backend/internal/podlogs/selection.go
@@ -1,0 +1,86 @@
+package podlogs
+
+import "strings"
+
+const (
+	SelectedPodPrefix       = "pod:"
+	SelectedInitPrefix      = "init:"
+	SelectedContainerPrefix = "container:"
+	SelectedDebugPrefix     = "debug:"
+)
+
+// ScopeSelection captures explicit pod/container selections from the object-panel logs UI.
+// When present, these selections narrow the backend target set before per-scope/global caps.
+type ScopeSelection struct {
+	selectedPods       map[string]struct{}
+	selectedContainers map[ContainerRef]struct{}
+}
+
+func ParseScopeSelection(values []string) ScopeSelection {
+	selection := ScopeSelection{}
+	for _, rawValue := range values {
+		value := strings.TrimSpace(rawValue)
+		if value == "" {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(value, SelectedPodPrefix):
+			podName := strings.TrimSpace(strings.TrimPrefix(value, SelectedPodPrefix))
+			if podName == "" {
+				continue
+			}
+			if selection.selectedPods == nil {
+				selection.selectedPods = make(map[string]struct{})
+			}
+			selection.selectedPods[podName] = struct{}{}
+		case strings.HasPrefix(value, SelectedInitPrefix):
+			name := strings.TrimSpace(strings.TrimPrefix(value, SelectedInitPrefix))
+			if name == "" {
+				continue
+			}
+			if selection.selectedContainers == nil {
+				selection.selectedContainers = make(map[ContainerRef]struct{})
+			}
+			selection.selectedContainers[ContainerRef{Name: name, IsInit: true}] = struct{}{}
+		case strings.HasPrefix(value, SelectedDebugPrefix):
+			name := strings.TrimSpace(strings.TrimPrefix(value, SelectedDebugPrefix))
+			if name == "" {
+				continue
+			}
+			if selection.selectedContainers == nil {
+				selection.selectedContainers = make(map[ContainerRef]struct{})
+			}
+			selection.selectedContainers[ContainerRef{Name: name, IsEphemeral: true}] = struct{}{}
+		case strings.HasPrefix(value, SelectedContainerPrefix):
+			name := strings.TrimSpace(strings.TrimPrefix(value, SelectedContainerPrefix))
+			if name == "" {
+				continue
+			}
+			if selection.selectedContainers == nil {
+				selection.selectedContainers = make(map[ContainerRef]struct{})
+			}
+			selection.selectedContainers[ContainerRef{Name: name}] = struct{}{}
+		}
+	}
+	return selection
+}
+
+func (s ScopeSelection) IsZero() bool {
+	return len(s.selectedPods) == 0 && len(s.selectedContainers) == 0
+}
+
+func (s ScopeSelection) MatchPod(podName string) bool {
+	if len(s.selectedPods) == 0 {
+		return true
+	}
+	_, ok := s.selectedPods[podName]
+	return ok
+}
+
+func (s ScopeSelection) MatchContainer(container ContainerRef) bool {
+	if len(s.selectedContainers) == 0 {
+		return true
+	}
+	_, ok := s.selectedContainers[container]
+	return ok
+}

--- a/backend/internal/podlogs/targets.go
+++ b/backend/internal/podlogs/targets.go
@@ -47,7 +47,7 @@ type SelectedTarget struct {
 }
 
 func (t SelectedTarget) Key() string {
-	return t.Namespace + "/" + t.PodName + "/" + t.Container.Name
+	return t.Namespace + "/" + t.PodName + "/" + t.Container.SelectionValue()
 }
 
 func SelectTargets(

--- a/backend/internal/podlogs/targets.go
+++ b/backend/internal/podlogs/targets.go
@@ -115,8 +115,14 @@ func BuildTargetLimitWarnings(selectedCount, totalCount int) []string {
 	if totalCount <= selectedCount || selectedCount <= 0 {
 		return nil
 	}
+	limit := GetPerScopeTargetLimit()
+	hiddenCount := totalCount - selectedCount
 	return []string{
-		fmt.Sprintf("Showing logs for %d of %d pod/container targets. Refine filters to view more.", selectedCount, totalCount),
+		fmt.Sprintf(
+			"Logs are hidden for %d containers because the per-tab limit of %d was reached. Using filters to reduce the number of containers may clear this message.",
+			hiddenCount,
+			limit,
+		),
 	}
 }
 

--- a/backend/internal/podlogs/targets.go
+++ b/backend/internal/podlogs/targets.go
@@ -7,7 +7,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-const DefaultPerScopeTargetLimit = 24
+const DefaultPerScopeTargetLimit = 96
 
 type SelectedTarget struct {
 	Namespace string

--- a/backend/internal/podlogs/targets.go
+++ b/backend/internal/podlogs/targets.go
@@ -3,11 +3,42 @@ package podlogs
 import (
 	"fmt"
 	"sort"
+	"sync/atomic"
 
 	corev1 "k8s.io/api/core/v1"
 )
 
-const DefaultPerScopeTargetLimit = 96
+const DefaultPerScopeTargetLimit = 100
+const (
+	MinPerScopeTargetLimit = 1
+	MaxPerScopeTargetLimit = 1000
+)
+
+var currentPerScopeTargetLimit atomic.Int64
+
+func init() {
+	currentPerScopeTargetLimit.Store(DefaultPerScopeTargetLimit)
+}
+
+func clampPerScopeTargetLimit(limit int) int {
+	if limit < MinPerScopeTargetLimit {
+		return MinPerScopeTargetLimit
+	}
+	if limit > MaxPerScopeTargetLimit {
+		return MaxPerScopeTargetLimit
+	}
+	return limit
+}
+
+func GetPerScopeTargetLimit() int {
+	return clampPerScopeTargetLimit(int(currentPerScopeTargetLimit.Load()))
+}
+
+func SetPerScopeTargetLimit(limit int) int {
+	clamped := clampPerScopeTargetLimit(limit)
+	currentPerScopeTargetLimit.Store(int64(clamped))
+	return clamped
+}
 
 type SelectedTarget struct {
 	Namespace string
@@ -29,7 +60,7 @@ func SelectTargets(
 	}
 
 	if limit <= 0 {
-		limit = DefaultPerScopeTargetLimit
+		limit = GetPerScopeTargetLimit()
 	}
 
 	type rankedTarget struct {

--- a/backend/refresh/logstream/handler.go
+++ b/backend/refresh/logstream/handler.go
@@ -165,9 +165,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// tab switches/reconnect handshakes, so sending the first real
 		// snapshot with Reset=false causes the entire initial batch to be
 		// appended on remount.
-		Reset:       true,
-		Entries:     initial,
-		Warnings:    warningPayload(warnings, false),
+		Reset:    true,
+		Entries:  initial,
+		Warnings: warningPayload(warnings, false),
 	}
 	sequence++
 	if err := writeEvent(w, f, event); err != nil {
@@ -207,12 +207,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	lastDelivery := time.Now()
 
 	var (
-		batch                  []Entry
-		batchTimer             *time.Timer
-		pendingDropped         int
-		selectionWarnings      = append([]string(nil), warnings...)
-		emittedWarnings        = append([]string(nil), warnings...)
-		transportDropObserved  bool
+		batch                 []Entry
+		batchTimer            *time.Timer
+		pendingDropped        int
+		selectionWarnings     = append([]string(nil), warnings...)
+		emittedWarnings       = append([]string(nil), warnings...)
+		transportDropObserved bool
 	)
 
 	emitWarningUpdate := func() bool {
@@ -430,6 +430,7 @@ func parseOptions(r *http.Request) (Options, error) {
 	podFilter := strings.TrimSpace(r.URL.Query().Get("pod"))
 	podInclude := strings.TrimSpace(r.URL.Query().Get("podInclude"))
 	podExclude := strings.TrimSpace(r.URL.Query().Get("podExclude"))
+	selectedFilters := trimQueryValues(r.URL.Query()["selectedFilter"])
 	container := strings.TrimSpace(r.URL.Query().Get("container"))
 	includeInit := parseBoolQueryWithDefault(r, "includeInit", true)
 	includeEphemeral := parseBoolQueryWithDefault(r, "includeEphemeral", true)
@@ -453,6 +454,7 @@ func parseOptions(r *http.Request) (Options, error) {
 	if err != nil {
 		return Options{}, fmt.Errorf("invalid pod filter: %w", err)
 	}
+	selection := podlogs.ParseScopeSelection(selectedFilters)
 	return Options{
 		ClusterID: func() string {
 			if len(clusterIDs) == 1 {
@@ -466,6 +468,8 @@ func parseOptions(r *http.Request) (Options, error) {
 		PodFilter:        podFilter,
 		PodInclude:       podInclude,
 		PodExclude:       podExclude,
+		SelectedFilters:  selectedFilters,
+		Selection:        selection,
 		Container:        container,
 		IncludeInit:      includeInit,
 		IncludeEphemeral: includeEphemeral,
@@ -478,6 +482,21 @@ func parseOptions(r *http.Request) (Options, error) {
 		// Keep the original scope for client-side keying.
 		ScopeString: rawScope,
 	}, nil
+}
+
+func trimQueryValues(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	trimmed := make([]string, 0, len(values))
+	for _, value := range values {
+		next := strings.TrimSpace(value)
+		if next == "" {
+			continue
+		}
+		trimmed = append(trimmed, next)
+	}
+	return trimmed
 }
 
 func parseBoolQueryWithDefault(r *http.Request, key string, defaultValue bool) bool {

--- a/backend/refresh/logstream/handler_test.go
+++ b/backend/refresh/logstream/handler_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/luxury-yacht/app/backend/internal/podlogs"
 	"github.com/luxury-yacht/app/backend/refresh/telemetry"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -54,6 +55,7 @@ func TestParseOptions(t *testing.T) {
 				"pod":              []string{"web-123"},
 				"podInclude":       []string{"^web-"},
 				"podExclude":       []string{"-canary$"},
+				"selectedFilter":   []string{"pod:web-2", "debug:debug-abc"},
 				"container":        []string{"app"},
 				"includeInit":      []string{"false"},
 				"includeEphemeral": []string{"false"},
@@ -153,6 +155,13 @@ func TestParseOptions(t *testing.T) {
 		}
 		if opts.Container != tt.container {
 			t.Fatalf("%s: expected container %q, got %q", tt.name, tt.container, opts.Container)
+		}
+		if tt.name == "custom tail and filters" {
+			require.Equal(t, []string{"pod:web-2", "debug:debug-abc"}, opts.SelectedFilters)
+			require.True(t, opts.Selection.MatchPod("web-2"))
+			require.False(t, opts.Selection.MatchPod("web-1"))
+			require.True(t, opts.Selection.MatchContainer(podlogs.ContainerRef{Name: "debug-abc", IsEphemeral: true}))
+			require.False(t, opts.Selection.MatchContainer(podlogs.ContainerRef{Name: "app"}))
 		}
 		expectedIncludeInit := tt.includeInit
 		if _, ok := tt.query["includeInit"]; !ok {

--- a/backend/refresh/logstream/handler_test.go
+++ b/backend/refresh/logstream/handler_test.go
@@ -487,12 +487,12 @@ func TestServeHTTPEmitsErrorEvent(t *testing.T) {
 
 func TestComposeStreamWarningsDistinguishesTransportDrops(t *testing.T) {
 	warnings := composeStreamWarnings(
-		[]string{"Showing logs for 24 of 25 pod/container targets. Refine filters to view more."},
+		[]string{"Logs are hidden for 1 containers because the per-tab limit of 24 was reached. Using filters to reduce the number of containers may clear this message."},
 		true,
 	)
 
 	require.Equal(t, []string{
-		"Showing logs for 24 of 25 pod/container targets. Refine filters to view more.",
+		"Logs are hidden for 1 containers because the per-tab limit of 24 was reached. Using filters to reduce the number of containers may clear this message.",
 		transportDropWarning,
 	}, warnings)
 

--- a/backend/refresh/logstream/limiter.go
+++ b/backend/refresh/logstream/limiter.go
@@ -35,6 +35,22 @@ func NewGlobalTargetLimiter(limit int) *GlobalTargetLimiter {
 	}
 }
 
+func (l *GlobalTargetLimiter) SetLimit(limit int) {
+	if l == nil {
+		return
+	}
+	if limit <= 0 {
+		limit = config.LogStreamGlobalTargetLimit
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.total == limit {
+		return
+	}
+	l.total = limit
+	l.recomputeLocked()
+}
+
 func (l *GlobalTargetLimiter) StartSession(clusterID, scope string) *TargetSession {
 	if l == nil {
 		return nil

--- a/backend/refresh/logstream/limiter.go
+++ b/backend/refresh/logstream/limiter.go
@@ -218,15 +218,16 @@ func keysToSet(keys []string) map[string]struct{} {
 	return out
 }
 
-func buildGlobalTargetLimitWarnings(selectedCount, totalCount int) []string {
+func buildGlobalTargetLimitWarnings(selectedCount, totalCount, limit int) []string {
 	if totalCount <= selectedCount || selectedCount < 0 {
 		return nil
 	}
+	hiddenCount := totalCount - selectedCount
 	return []string{
 		fmt.Sprintf(
-			"Showing logs for %d of %d selected pod/container targets due to the global log stream cap.",
-			selectedCount,
-			totalCount,
+			"Logs are hidden for %d containers because the global limit of %d was reached. Using filters to reduce the number of containers may clear this message.",
+			hiddenCount,
+			limit,
 		),
 	}
 }

--- a/backend/refresh/logstream/limiter_test.go
+++ b/backend/refresh/logstream/limiter_test.go
@@ -83,12 +83,12 @@ func TestGlobalTargetLimiterNotifyOnRebalance(t *testing.T) {
 }
 
 func TestBuildGlobalTargetLimitWarnings(t *testing.T) {
-	warnings := buildGlobalTargetLimitWarnings(2, 4)
+	warnings := buildGlobalTargetLimitWarnings(2, 4, 72)
 	if len(warnings) != 1 {
 		t.Fatalf("expected one warning, got %d", len(warnings))
 	}
-	if warnings[0] == "" {
-		t.Fatal("expected non-empty warning message")
+	if warnings[0] != "Logs are hidden for 2 containers because the global limit of 72 was reached. Using filters to reduce the number of containers may clear this message." {
+		t.Fatalf("unexpected warning: %q", warnings[0])
 	}
 }
 

--- a/backend/refresh/logstream/streamer.go
+++ b/backend/refresh/logstream/streamer.go
@@ -89,7 +89,11 @@ func (s *Streamer) tail(ctx context.Context, opts Options, limiterSession *Targe
 	if limiterSession != nil {
 		allowedKeys, globalSkipped := limiterSession.UpdateDesired(targetKeys(selectedTargets))
 		selectedTargets = filterTargetsByKeys(selectedTargets, allowedKeys)
-		warnings = append(warnings, buildGlobalTargetLimitWarnings(len(selectedTargets), len(selectedTargets)+globalSkipped)...)
+		globalLimit := config.LogStreamGlobalTargetLimit
+		if limiterSession != nil && limiterSession.limiter != nil {
+			globalLimit = limiterSession.limiter.total
+		}
+		warnings = append(warnings, buildGlobalTargetLimitWarnings(len(selectedTargets), len(selectedTargets)+globalSkipped, globalLimit)...)
 		if globalSkipped > 0 {
 			skippedTargets += globalSkipped
 			skipReason = "global target cap"
@@ -171,6 +175,10 @@ func (s *Streamer) run(
 		targetCancels   = make(map[string]context.CancelFunc)
 		currentWarnings = append([]string(nil), initialWarnings...)
 	)
+	var limiterNotify <-chan struct{}
+	if limiterSession != nil {
+		limiterNotify = limiterSession.Notify()
+	}
 
 	// Ensure all followContainer goroutines exit before run returns so callers can safely close channels.
 	defer func() {
@@ -247,7 +255,11 @@ func (s *Streamer) run(
 		if limiterSession != nil {
 			allowedKeys, globalSkipped := limiterSession.UpdateDesired(targetKeys(selectedTargets))
 			selectedTargets = filterTargetsByKeys(selectedTargets, allowedKeys)
-			warnings = append(warnings, buildGlobalTargetLimitWarnings(len(selectedTargets), perScopeCount)...)
+			globalLimit := config.LogStreamGlobalTargetLimit
+			if limiterSession != nil && limiterSession.limiter != nil {
+				globalLimit = limiterSession.limiter.total
+			}
+			warnings = append(warnings, buildGlobalTargetLimitWarnings(len(selectedTargets), perScopeCount, globalLimit)...)
 			_ = globalSkipped
 		}
 		desiredTargets := make(map[string]containerTarget, len(selectedTargets))
@@ -311,13 +323,19 @@ func (s *Streamer) run(
 	replacePodInventory(initialPods)
 
 	if strings.ToLower(opts.Kind) == "pod" {
-		<-ctx.Done()
-		mu.Lock()
-		for _, cancel := range targetCancels {
-			cancel()
+		for {
+			select {
+			case <-ctx.Done():
+				mu.Lock()
+				for _, cancel := range targetCancels {
+					cancel()
+				}
+				mu.Unlock()
+				return
+			case <-limiterNotify:
+				reconcileTargets()
+			}
 		}
-		mu.Unlock()
-		return
 	}
 
 	cronCache := make(map[string]bool)
@@ -354,7 +372,7 @@ func (s *Streamer) run(
 			continue
 		}
 
-		err = s.consumeWatch(ctx, watcher, opts, cronCache, updatePod, removePod)
+		err = s.consumeWatch(ctx, watcher, opts, cronCache, limiterNotify, reconcileTargets, updatePod, removePod)
 		watcher.Stop()
 		if err == nil || ctx.Err() != nil {
 			mu.Lock()
@@ -432,6 +450,8 @@ func (s *Streamer) consumeWatch(
 	watcher watch.Interface,
 	opts Options,
 	cronCache map[string]bool,
+	limiterNotify <-chan struct{},
+	reconcileTargets func(),
 	startPod func(*corev1.Pod),
 	stopPod func(string),
 ) error {
@@ -443,6 +463,10 @@ func (s *Streamer) consumeWatch(
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
+		case <-limiterNotify:
+			if reconcileTargets != nil {
+				reconcileTargets()
+			}
 		case event, ok := <-result:
 			if !ok {
 				return errors.New("watch channel closed")

--- a/backend/refresh/logstream/streamer.go
+++ b/backend/refresh/logstream/streamer.go
@@ -67,7 +67,7 @@ func (s *Streamer) tail(ctx context.Context, opts Options, limiterSession *Targe
 			IncludeEphemeral: opts.IncludeEphemeral,
 			StateFilter:      opts.ContainerState,
 		},
-		podlogs.DefaultPerScopeTargetLimit,
+		podlogs.GetPerScopeTargetLimit(),
 	)
 	warnings := podlogs.BuildTargetLimitWarnings(len(selectedTargets), totalTargets)
 	skippedTargets := totalTargets - len(selectedTargets)
@@ -222,7 +222,7 @@ func (s *Streamer) run(
 			IncludeInit:      opts.IncludeInit,
 			IncludeEphemeral: opts.IncludeEphemeral,
 			StateFilter:      opts.ContainerState,
-		}, podlogs.DefaultPerScopeTargetLimit)
+		}, podlogs.GetPerScopeTargetLimit())
 		perScopeCount := len(selectedTargets)
 		totalTargets := countTargets(pods, podlogs.ContainerSelectionOptions{
 			Filter:           opts.Container,

--- a/backend/refresh/logstream/streamer.go
+++ b/backend/refresh/logstream/streamer.go
@@ -39,15 +39,25 @@ func NewStreamer(client kubernetes.Interface, logger Logger, recorder *telemetry
 }
 
 type containerTarget struct {
-	namespace string
-	pod       string
-	container string
-	isInit    bool
-	state     *containerState
+	namespace   string
+	pod         string
+	container   string
+	isInit      bool
+	isEphemeral bool
+	state       *containerState
 }
 
 func (t containerTarget) key() string {
-	return fmt.Sprintf("%s/%s/%s", t.namespace, t.pod, t.container)
+	return fmt.Sprintf(
+		"%s/%s/%s",
+		t.namespace,
+		t.pod,
+		podlogs.ContainerRef{
+			Name:        t.container,
+			IsInit:      t.isInit,
+			IsEphemeral: t.isEphemeral,
+		}.SelectionValue(),
+	)
 }
 
 // tail gathers the initial log history for the given options and prepares container state.
@@ -66,6 +76,7 @@ func (s *Streamer) tail(ctx context.Context, opts Options, limiterSession *Targe
 			IncludeInit:      opts.IncludeInit,
 			IncludeEphemeral: opts.IncludeEphemeral,
 			StateFilter:      opts.ContainerState,
+			Selection:        opts.Selection,
 		},
 		podlogs.GetPerScopeTargetLimit(),
 	)
@@ -222,6 +233,7 @@ func (s *Streamer) run(
 			IncludeInit:      opts.IncludeInit,
 			IncludeEphemeral: opts.IncludeEphemeral,
 			StateFilter:      opts.ContainerState,
+			Selection:        opts.Selection,
 		}, podlogs.GetPerScopeTargetLimit())
 		perScopeCount := len(selectedTargets)
 		totalTargets := countTargets(pods, podlogs.ContainerSelectionOptions{
@@ -229,6 +241,7 @@ func (s *Streamer) run(
 			IncludeInit:      opts.IncludeInit,
 			IncludeEphemeral: opts.IncludeEphemeral,
 			StateFilter:      opts.ContainerState,
+			Selection:        opts.Selection,
 		})
 		warnings := podlogs.BuildTargetLimitWarnings(perScopeCount, totalTargets)
 		if limiterSession != nil {
@@ -453,6 +466,9 @@ func (s *Streamer) consumeWatch(
 			if opts.PodFilter != "" && pod.Name != opts.PodFilter {
 				continue
 			}
+			if !opts.Selection.MatchPod(pod.Name) {
+				continue
+			}
 			switch event.Type {
 			case watch.Added, watch.Modified:
 				startPod(pod)
@@ -540,11 +556,12 @@ func (s *Streamer) followContainer(ctx context.Context, target containerTarget, 
 				continue
 			}
 			entry := Entry{
-				Timestamp: timestamp,
-				Pod:       target.pod,
-				Container: target.container,
-				Line:      content,
-				IsInit:    target.isInit,
+				Timestamp:   timestamp,
+				Pod:         target.pod,
+				Container:   target.container,
+				Line:        content,
+				IsInit:      target.isInit,
+				IsEphemeral: target.isEphemeral,
 			}
 
 			if timestamp != "" {
@@ -659,7 +676,7 @@ func (s *Streamer) listPods(ctx context.Context, opts Options) ([]*corev1.Pod, s
 		if err != nil {
 			return nil, "", fmt.Errorf("logstream: get pod %s/%s: %w", opts.Namespace, opts.Name, err)
 		}
-		return filterPodsByName([]*corev1.Pod{pod}, opts.PodFilter, opts.PodNameFilter), "", nil
+		return filterPodsByName([]*corev1.Pod{pod}, opts.PodFilter, opts.PodNameFilter, opts.Selection), "", nil
 	case "deployment", "replicaset", "statefulset", "daemonset":
 		selector, err := s.selectorForWorkload(ctx, opts)
 		if err != nil {
@@ -669,14 +686,14 @@ func (s *Streamer) listPods(ctx context.Context, opts Options) ([]*corev1.Pod, s
 		if err != nil {
 			return nil, "", fmt.Errorf("logstream: list pods for %s %s/%s: %w", kind, opts.Namespace, opts.Name, err)
 		}
-		return filterPodsByName(podPointers(pods.Items), opts.PodFilter, opts.PodNameFilter), selector, nil
+		return filterPodsByName(podPointers(pods.Items), opts.PodFilter, opts.PodNameFilter, opts.Selection), selector, nil
 	case "job":
 		selector := labels.Set{"job-name": opts.Name}.AsSelector().String()
 		pods, err := s.client.CoreV1().Pods(opts.Namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
 		if err != nil {
 			return nil, "", fmt.Errorf("logstream: list pods for job %s/%s: %w", opts.Namespace, opts.Name, err)
 		}
-		return filterPodsByName(podPointers(pods.Items), opts.PodFilter, opts.PodNameFilter), selector, nil
+		return filterPodsByName(podPointers(pods.Items), opts.PodFilter, opts.PodNameFilter, opts.Selection), selector, nil
 	case "cronjob":
 		jobs, err := s.client.BatchV1().Jobs(opts.Namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
@@ -700,18 +717,23 @@ func (s *Streamer) listPods(ctx context.Context, opts Options) ([]*corev1.Pod, s
 		}
 		// Return empty selector so the pod watch sees pods from future Jobs.
 		// consumeWatch filters by CronJob ownership via podBelongsToCronJob.
-		return filterPodsByName(podPointers(list.Items), opts.PodFilter, opts.PodNameFilter), "", nil
+		return filterPodsByName(podPointers(list.Items), opts.PodFilter, opts.PodNameFilter, opts.Selection), "", nil
 	default:
 		return nil, "", fmt.Errorf("logstream: unsupported workload kind %q", opts.Kind)
 	}
 }
 
-func filterPodsByName(pods []*corev1.Pod, exactFilter string, podNameFilter podlogs.PodNameFilter) []*corev1.Pod {
+func filterPodsByName(
+	pods []*corev1.Pod,
+	exactFilter string,
+	podNameFilter podlogs.PodNameFilter,
+	selection podlogs.ScopeSelection,
+) []*corev1.Pod {
 	exactFilter = strings.TrimSpace(exactFilter)
 	if len(pods) == 0 {
 		return pods
 	}
-	if exactFilter == "" && podNameFilter.IsZero() {
+	if exactFilter == "" && podNameFilter.IsZero() && selection.IsZero() {
 		return pods
 	}
 	filtered := make([]*corev1.Pod, 0, len(pods))
@@ -723,6 +745,9 @@ func filterPodsByName(pods []*corev1.Pod, exactFilter string, podNameFilter podl
 			continue
 		}
 		if !podNameFilter.IsZero() && !podNameFilter.Match(pod.Name) {
+			continue
+		}
+		if !selection.MatchPod(pod.Name) {
 			continue
 		}
 		filtered = append(filtered, pod)
@@ -774,11 +799,12 @@ func buildTargetsFromPod(pod *corev1.Pod, options podlogs.ContainerSelectionOpti
 	var targets []containerTarget
 	for _, containerRef := range podlogs.EnumerateContainersWithOptions(pod, options) {
 		targets = append(targets, containerTarget{
-			namespace: pod.Namespace,
-			pod:       pod.Name,
-			container: containerRef.Name,
-			isInit:    containerRef.IsInit,
-			state:     &containerState{},
+			namespace:   pod.Namespace,
+			pod:         pod.Name,
+			container:   containerRef.Name,
+			isInit:      containerRef.IsInit,
+			isEphemeral: containerRef.IsEphemeral,
+			state:       &containerState{},
 		})
 	}
 	return targets
@@ -793,10 +819,11 @@ func selectRuntimeTargets(
 	runtimeTargets := make([]containerTarget, 0, len(selectedTargets))
 	for _, selected := range selectedTargets {
 		runtimeTargets = append(runtimeTargets, containerTarget{
-			namespace: selected.Namespace,
-			pod:       selected.PodName,
-			container: selected.Container.Name,
-			isInit:    selected.Container.IsInit,
+			namespace:   selected.Namespace,
+			pod:         selected.PodName,
+			container:   selected.Container.Name,
+			isInit:      selected.Container.IsInit,
+			isEphemeral: selected.Container.IsEphemeral,
 		})
 	}
 	return runtimeTargets, totalTargets
@@ -880,11 +907,12 @@ func (s *Streamer) fetchContainerTail(ctx context.Context, target containerTarge
 			continue
 		}
 		entries = append(entries, Entry{
-			Timestamp: timestamp,
-			Pod:       target.pod,
-			Container: target.container,
-			Line:      content,
-			IsInit:    target.isInit,
+			Timestamp:   timestamp,
+			Pod:         target.pod,
+			Container:   target.container,
+			Line:        content,
+			IsInit:      target.isInit,
+			IsEphemeral: target.isEphemeral,
 		})
 	}
 	if err := scanner.Err(); err != nil && !errors.Is(err, io.EOF) {

--- a/backend/refresh/logstream/streamer_test.go
+++ b/backend/refresh/logstream/streamer_test.go
@@ -2,6 +2,7 @@ package logstream
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -405,7 +406,16 @@ func TestConsumeWatchReturnsErrorOnWatchErrorEvent(t *testing.T) {
 	resultCh := make(chan error, 1)
 
 	go func() {
-		resultCh <- streamer.consumeWatch(ctx, fw, Options{}, map[string]bool{}, func(*corev1.Pod) {}, func(string) {})
+		resultCh <- streamer.consumeWatch(
+			ctx,
+			fw,
+			Options{},
+			map[string]bool{},
+			nil,
+			nil,
+			func(*corev1.Pod) {},
+			func(string) {},
+		)
 	}()
 
 	fw.ch <- watch.Event{
@@ -438,6 +448,54 @@ func TestWaitForReconnect(t *testing.T) {
 	}
 	if time.Since(start) < 4*time.Millisecond {
 		t.Fatal("expected waitForReconnect to respect the delay")
+	}
+}
+
+func TestConsumeWatchReconcilesTargetsOnLimiterNotification(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	streamer := NewStreamer(fake.NewClientset(), nil, nil)
+	fw := &fakeWatch{ch: make(chan watch.Event)}
+	limiterNotify := make(chan struct{}, 1)
+	reconciled := make(chan struct{}, 1)
+	resultCh := make(chan error, 1)
+
+	go func() {
+		resultCh <- streamer.consumeWatch(
+			ctx,
+			fw,
+			Options{},
+			map[string]bool{},
+			limiterNotify,
+			func() {
+				select {
+				case reconciled <- struct{}{}:
+				default:
+				}
+			},
+			func(*corev1.Pod) {},
+			func(string) {},
+		)
+	}()
+
+	limiterNotify <- struct{}{}
+
+	select {
+	case <-reconciled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for limiter rebalance to trigger reconciliation")
+	}
+
+	cancel()
+
+	select {
+	case err := <-resultCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected consumeWatch to return context cancellation, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for consumeWatch to return")
 	}
 }
 
@@ -566,7 +624,16 @@ func TestCronJobWatchPicksUpFutureJob(t *testing.T) {
 
 	resultCh := make(chan error, 1)
 	go func() {
-		resultCh <- streamer.consumeWatch(ctx, fw, Options{Kind: "cronjob", Namespace: "default", Name: "cron"}, map[string]bool{}, startPod, stopPod)
+		resultCh <- streamer.consumeWatch(
+			ctx,
+			fw,
+			Options{Kind: "cronjob", Namespace: "default", Name: "cron"},
+			map[string]bool{},
+			nil,
+			nil,
+			startPod,
+			stopPod,
+		)
 	}()
 
 	// Deliver a pod from the future Job via the watch.

--- a/backend/refresh/logstream/streamer_test.go
+++ b/backend/refresh/logstream/streamer_test.go
@@ -88,7 +88,7 @@ func TestSelectRuntimeTargetsKeepsPerScopeCapWhenPodsGrow(t *testing.T) {
 	if total != 2 {
 		t.Fatalf("expected total target count 2, got %d", total)
 	}
-	if keys := runtimeTargetKeys(selected); strings.Join(keys, ",") != "default/web-1/app,default/web-2/app" {
+	if keys := runtimeTargetKeys(selected); strings.Join(keys, ",") != "default/web-1/container:app,default/web-2/container:app" {
 		t.Fatalf("unexpected initial target keys: %v", keys)
 	}
 
@@ -100,7 +100,7 @@ func TestSelectRuntimeTargetsKeepsPerScopeCapWhenPodsGrow(t *testing.T) {
 	if len(selected) != 2 {
 		t.Fatalf("expected capped selection of 2 targets after pod growth, got %d", len(selected))
 	}
-	if keys := runtimeTargetKeys(selected); strings.Join(keys, ",") != "default/web-1/app,default/web-2/app" {
+	if keys := runtimeTargetKeys(selected); strings.Join(keys, ",") != "default/web-1/container:app,default/web-2/container:app" {
 		t.Fatalf("unexpected capped target keys after pod growth: %v", keys)
 	}
 }
@@ -116,7 +116,7 @@ func TestSelectRuntimeTargetsRefillsAfterPodRemoval(t *testing.T) {
 	if total != 3 {
 		t.Fatalf("expected total target count 3, got %d", total)
 	}
-	if keys := runtimeTargetKeys(selected); strings.Join(keys, ",") != "default/web-1/app,default/web-2/app" {
+	if keys := runtimeTargetKeys(selected); strings.Join(keys, ",") != "default/web-1/container:app,default/web-2/container:app" {
 		t.Fatalf("unexpected initial capped target keys: %v", keys)
 	}
 
@@ -124,7 +124,7 @@ func TestSelectRuntimeTargetsRefillsAfterPodRemoval(t *testing.T) {
 	if total != 2 {
 		t.Fatalf("expected total target count 2 after pod removal, got %d", total)
 	}
-	if keys := runtimeTargetKeys(selected); strings.Join(keys, ",") != "default/web-2/app,default/web-3/app" {
+	if keys := runtimeTargetKeys(selected); strings.Join(keys, ",") != "default/web-2/container:app,default/web-3/container:app" {
 		t.Fatalf("expected selection to refill after pod removal, got %v", keys)
 	}
 }

--- a/backend/refresh/logstream/types.go
+++ b/backend/refresh/logstream/types.go
@@ -31,6 +31,8 @@ type Options struct {
 	PodFilter        string
 	PodInclude       string
 	PodExclude       string
+	SelectedFilters  []string
+	Selection        podlogs.ScopeSelection
 	Container        string
 	IncludeInit      bool
 	IncludeEphemeral bool
@@ -45,11 +47,12 @@ type Options struct {
 
 // Entry mirrors the log line payload sent to clients.
 type Entry struct {
-	Timestamp string `json:"timestamp"`
-	Pod       string `json:"pod"`
-	Container string `json:"container"`
-	Line      string `json:"line"`
-	IsInit    bool   `json:"isInit"`
+	Timestamp   string `json:"timestamp"`
+	Pod         string `json:"pod"`
+	Container   string `json:"container"`
+	Line        string `json:"line"`
+	IsInit      bool   `json:"isInit"`
+	IsEphemeral bool   `json:"isEphemeral,omitempty"`
 }
 
 // EventPayload is the SSE message envelope emitted to clients.

--- a/backend/resources/pods/logs.go
+++ b/backend/resources/pods/logs.go
@@ -63,7 +63,7 @@ func (s *Service) LogFetcher(req types.LogFetchRequest) types.LogFetchResponse {
 			IncludeEphemeral: boolValueOrDefault(req.IncludeEphemeral, true),
 			StateFilter:      containerState,
 		},
-		podlogs.DefaultPerScopeTargetLimit,
+		podlogs.GetPerScopeTargetLimit(),
 	)
 	warnings := podlogs.BuildTargetLimitWarnings(len(targets), totalTargets)
 
@@ -125,6 +125,37 @@ func (s *Service) PodContainers(namespace, podName string) ([]string, error) {
 	for _, container := range podlogs.EnumerateContainers(pod, "") {
 		containers = append(containers, container.DisplayName())
 	}
+	return containers, nil
+}
+
+// LogScopeContainers returns the unique display names for all containers addressed by the scope.
+func (s *Service) LogScopeContainers(scope string) ([]string, error) {
+	if s.deps.KubernetesClient == nil {
+		return nil, fmt.Errorf("kubernetes client not initialized")
+	}
+
+	pods, err := s.resolveTargetPodObjects(types.LogFetchRequest{Scope: scope}, podlogs.PodNameFilter{})
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]struct{})
+	containers := make([]string, 0)
+	for _, pod := range pods {
+		if pod == nil {
+			continue
+		}
+		for _, container := range podlogs.EnumerateContainers(pod, "") {
+			displayName := container.DisplayName()
+			if _, ok := seen[displayName]; ok {
+				continue
+			}
+			seen[displayName] = struct{}{}
+			containers = append(containers, displayName)
+		}
+	}
+
+	sort.Strings(containers)
 	return containers, nil
 }
 

--- a/backend/resources/pods/logs.go
+++ b/backend/resources/pods/logs.go
@@ -46,12 +46,13 @@ func (s *Service) LogFetcher(req types.LogFetchRequest) types.LogFetchResponse {
 	if err != nil {
 		return types.LogFetchResponse{Error: fmt.Sprintf("invalid pod filter: %v", err)}
 	}
+	selection := podlogs.ParseScopeSelection(req.SelectedFilters)
 	containerState, err := podlogs.ParseContainerStateFilter(req.ContainerState)
 	if err != nil {
 		return types.LogFetchResponse{Error: fmt.Sprintf("invalid container state filter: %v", err)}
 	}
 
-	pods, err := s.resolveTargetPodObjects(req, podNameFilter)
+	pods, err := s.resolveTargetPodObjects(req, podNameFilter, selection)
 	if err != nil {
 		return types.LogFetchResponse{Error: err.Error()}
 	}
@@ -62,6 +63,7 @@ func (s *Service) LogFetcher(req types.LogFetchRequest) types.LogFetchResponse {
 			IncludeInit:      boolValueOrDefault(req.IncludeInit, true),
 			IncludeEphemeral: boolValueOrDefault(req.IncludeEphemeral, true),
 			StateFilter:      containerState,
+			Selection:        selection,
 		},
 		podlogs.GetPerScopeTargetLimit(),
 	)
@@ -75,6 +77,7 @@ func (s *Service) LogFetcher(req types.LogFetchRequest) types.LogFetchResponse {
 			target.PodName,
 			target.Container.Name,
 			target.Container.IsInit,
+			target.Container.IsEphemeral,
 			req.TailLines,
 			req.Previous,
 			req.SinceSeconds,
@@ -134,7 +137,7 @@ func (s *Service) LogScopeContainers(scope string) ([]string, error) {
 		return nil, fmt.Errorf("kubernetes client not initialized")
 	}
 
-	pods, err := s.resolveTargetPodObjects(types.LogFetchRequest{Scope: scope}, podlogs.PodNameFilter{})
+	pods, err := s.resolveTargetPodObjects(types.LogFetchRequest{Scope: scope}, podlogs.PodNameFilter{}, podlogs.ScopeSelection{})
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +228,8 @@ func (s *Service) resolveTargetPods(req types.LogFetchRequest) ([]string, error)
 	if err != nil {
 		return nil, fmt.Errorf("invalid pod filter: %w", err)
 	}
-	pods, err := s.resolveTargetPodObjects(req, podNameFilter)
+	selection := podlogs.ParseScopeSelection(req.SelectedFilters)
+	pods, err := s.resolveTargetPodObjects(req, podNameFilter, selection)
 	if err != nil {
 		return nil, err
 	}
@@ -238,12 +242,19 @@ func (s *Service) resolveTargetPods(req types.LogFetchRequest) ([]string, error)
 	return names, nil
 }
 
-func (s *Service) resolveTargetPodObjects(req types.LogFetchRequest, podNameFilter podlogs.PodNameFilter) ([]*corev1.Pod, error) {
+func (s *Service) resolveTargetPodObjects(
+	req types.LogFetchRequest,
+	podNameFilter podlogs.PodNameFilter,
+	selection podlogs.ScopeSelection,
+) ([]*corev1.Pod, error) {
 	target, err := s.resolveLogTarget(req)
 	if err != nil {
 		return nil, err
 	}
 	if target.PodName != "" {
+		if !selection.MatchPod(target.PodName) {
+			return nil, nil
+		}
 		pod, err := s.deps.KubernetesClient.CoreV1().Pods(target.Namespace).Get(s.ctx(), target.PodName, metav1.GetOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("failed to get pod: %w", err)
@@ -254,12 +265,17 @@ func (s *Service) resolveTargetPodObjects(req types.LogFetchRequest, podNameFilt
 	if err != nil {
 		return nil, err
 	}
-	return filterPodsByName(pods, req.PodFilter, podNameFilter), nil
+	return filterPodsByName(pods, req.PodFilter, podNameFilter, selection), nil
 }
 
-func filterPodsByName(pods []*corev1.Pod, exactFilter string, podNameFilter podlogs.PodNameFilter) []*corev1.Pod {
+func filterPodsByName(
+	pods []*corev1.Pod,
+	exactFilter string,
+	podNameFilter podlogs.PodNameFilter,
+	selection podlogs.ScopeSelection,
+) []*corev1.Pod {
 	exactFilter = strings.TrimSpace(exactFilter)
-	if exactFilter == "" && podNameFilter.IsZero() {
+	if exactFilter == "" && podNameFilter.IsZero() && selection.IsZero() {
 		return pods
 	}
 	filtered := make([]*corev1.Pod, 0, len(pods))
@@ -271,6 +287,9 @@ func filterPodsByName(pods []*corev1.Pod, exactFilter string, podNameFilter podl
 			continue
 		}
 		if !podNameFilter.IsZero() && !podNameFilter.Match(pod.Name) {
+			continue
+		}
+		if !selection.MatchPod(pod.Name) {
 			continue
 		}
 		filtered = append(filtered, pod)
@@ -386,7 +405,7 @@ func (s *Service) fetchPodLogs(namespace, podName, container string, tailLines i
 	var entries []types.PodLogEntry
 	var containerErrors []error
 	for _, containerRef := range podlogs.EnumerateContainers(pod, container) {
-		containerEntries, err := s.fetchContainerLogs(namespace, podName, containerRef.Name, containerRef.IsInit, tailLines, previous, sinceSeconds, lineFilter)
+		containerEntries, err := s.fetchContainerLogs(namespace, podName, containerRef.Name, containerRef.IsInit, containerRef.IsEphemeral, tailLines, previous, sinceSeconds, lineFilter)
 		if err != nil {
 			s.logWarn(fmt.Sprintf("Failed to fetch logs for container %s/%s: %v", podName, containerRef.Name, err))
 			containerErrors = append(containerErrors, fmt.Errorf("container %s: %w", containerRef.Name, err))
@@ -402,7 +421,7 @@ func (s *Service) fetchPodLogs(namespace, podName, container string, tailLines i
 	return entries, nil
 }
 
-func (s *Service) fetchContainerLogs(namespace, podName, containerName string, isInit bool, tailLines int, previous bool, sinceSeconds int64, lineFilter podlogs.LineFilter) ([]types.PodLogEntry, error) {
+func (s *Service) fetchContainerLogs(namespace, podName, containerName string, isInit bool, isEphemeral bool, tailLines int, previous bool, sinceSeconds int64, lineFilter podlogs.LineFilter) ([]types.PodLogEntry, error) {
 	logOptions := &corev1.PodLogOptions{
 		Container:  containerName,
 		Timestamps: true,
@@ -449,11 +468,12 @@ func (s *Service) fetchContainerLogs(namespace, podName, containerName string, i
 		}
 
 		entries = append(entries, types.PodLogEntry{
-			Timestamp: timestamp,
-			Pod:       podName,
-			Container: containerName,
-			Line:      logLine,
-			IsInit:    isInit,
+			Timestamp:   timestamp,
+			Pod:         podName,
+			Container:   containerName,
+			Line:        logLine,
+			IsInit:      isInit,
+			IsEphemeral: isEphemeral,
 		})
 	}
 

--- a/backend/resources/pods/logs_test.go
+++ b/backend/resources/pods/logs_test.go
@@ -479,7 +479,7 @@ func TestFetchContainerLogsParsesTimestamps(t *testing.T) {
 		KubernetesClient: client,
 	})
 
-	entries, err := service.fetchContainerLogs("default", "demo", "app", false, 50, false, 0, podlogs.LineFilter{})
+	entries, err := service.fetchContainerLogs("default", "demo", "app", false, false, 50, false, 0, podlogs.LineFilter{})
 	require.NoError(t, err)
 	require.Len(t, entries, 2)
 	require.Equal(t, "2024-01-01T00:00:00Z", entries[0].Timestamp)
@@ -519,7 +519,7 @@ func TestFetchContainerLogsSwallowsCommonErrors(t *testing.T) {
 				KubernetesClient: client,
 			})
 
-			entries, err := service.fetchContainerLogs("default", "demo", "app", false, 10, true, 5, podlogs.LineFilter{})
+			entries, err := service.fetchContainerLogs("default", "demo", "app", false, false, 10, true, 5, podlogs.LineFilter{})
 			require.NoError(t, err)
 			require.Empty(t, entries)
 		})
@@ -544,7 +544,7 @@ func TestFetchContainerLogsUnexpectedErrorPropagates(t *testing.T) {
 		KubernetesClient: client,
 	})
 
-	_, err := service.fetchContainerLogs("default", "demo", "app", false, 10, false, 0, podlogs.LineFilter{})
+	_, err := service.fetchContainerLogs("default", "demo", "app", false, false, 10, false, 0, podlogs.LineFilter{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "forbidden")
 }
@@ -681,7 +681,7 @@ func TestFetchContainerLogsScannerError(t *testing.T) {
 		KubernetesClient: client,
 	})
 
-	_, err := service.fetchContainerLogs("default", "demo", "app", false, 10, false, 0, podlogs.LineFilter{})
+	_, err := service.fetchContainerLogs("default", "demo", "app", false, false, 10, false, 0, podlogs.LineFilter{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "read failure")
 }
@@ -704,7 +704,7 @@ func TestFetchContainerLogsHandlesOversizedLine(t *testing.T) {
 		KubernetesClient: client,
 	})
 
-	entries, err := service.fetchContainerLogs("default", "demo", "app", false, 10, false, 0, podlogs.LineFilter{})
+	entries, err := service.fetchContainerLogs("default", "demo", "app", false, false, 10, false, 0, podlogs.LineFilter{})
 	require.NoError(t, err)
 	require.Len(t, entries, 1)
 	require.Equal(t, longLine, entries[0].Line)
@@ -974,7 +974,7 @@ func TestLogFetcherUsesSharedCappedTargetSelection(t *testing.T) {
 	require.Equal(t, podCount, total)
 	expectedKeys := make([]string, 0, len(expectedTargets))
 	for _, target := range expectedTargets {
-		expectedKeys = append(expectedKeys, target.Key())
+		expectedKeys = append(expectedKeys, fmt.Sprintf("%s/%s/%s", target.Namespace, target.PodName, target.Container.Name))
 	}
 
 	require.Equal(t, expectedKeys, requestedKeys)
@@ -984,6 +984,66 @@ func TestLogFetcherUsesSharedCappedTargetSelection(t *testing.T) {
 		resp.Warnings[0],
 		fmt.Sprintf("%d of %d", podlogs.DefaultPerScopeTargetLimit, podCount),
 	)
+}
+
+func TestLogFetcherAppliesSelectedFiltersBeforeTargetLimit(t *testing.T) {
+	defer func(orig int) {
+		podlogs.SetPerScopeTargetLimit(orig)
+	}(podlogs.GetPerScopeTargetLimit())
+	defer func(orig func(corev1client.PodInterface, context.Context, string, *corev1.PodLogOptions) (io.ReadCloser, error)) {
+		logStreamFunc = orig
+	}(logStreamFunc)
+
+	podlogs.SetPerScopeTargetLimit(1)
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+		},
+	}
+	pods := []runtime.Object{deployment}
+	for _, podName := range []string{"web-1", "web-2", "web-3"} {
+		pods = append(pods, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      podName,
+				Namespace: "default",
+				Labels:    map[string]string{"app": "web"},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "app"}},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				}},
+			},
+		})
+	}
+
+	client := fake.NewClientset(pods...)
+	logStreamFunc = func(_ corev1client.PodInterface, _ context.Context, podName string, _ *corev1.PodLogOptions) (io.ReadCloser, error) {
+		return io.NopCloser(strings.NewReader(fmt.Sprintf("2024-01-01T00:00:00Z %s log", podName))), nil
+	}
+
+	service := NewService(common.Dependencies{
+		Context:          context.Background(),
+		Logger:           testsupport.NoopLogger{},
+		KubernetesClient: client,
+	})
+
+	resp := service.LogFetcher(types.LogFetchRequest{
+		Namespace:       "default",
+		WorkloadKind:    "deployment",
+		WorkloadName:    "web",
+		SelectedFilters: []string{"pod:web-3"},
+	})
+	require.Empty(t, resp.Error)
+	require.Len(t, resp.Entries, 1)
+	require.Equal(t, "web-3", resp.Entries[0].Pod)
+	require.Empty(t, resp.Warnings)
 }
 
 func TestLogFetcherSortsWhenTimestampMissing(t *testing.T) {

--- a/backend/resources/pods/logs_test.go
+++ b/backend/resources/pods/logs_test.go
@@ -905,7 +905,11 @@ func TestLogFetcherWarnsWhenTargetLimitExceeded(t *testing.T) {
 	require.Contains(
 		t,
 		resp.Warnings[0],
-		fmt.Sprintf("%d of %d", podlogs.DefaultPerScopeTargetLimit, containerCount),
+		fmt.Sprintf(
+			"Logs are hidden for %d containers because the per-tab limit of %d was reached.",
+			containerCount-podlogs.DefaultPerScopeTargetLimit,
+			podlogs.DefaultPerScopeTargetLimit,
+		),
 	)
 }
 
@@ -982,7 +986,11 @@ func TestLogFetcherUsesSharedCappedTargetSelection(t *testing.T) {
 	require.Contains(
 		t,
 		resp.Warnings[0],
-		fmt.Sprintf("%d of %d", podlogs.DefaultPerScopeTargetLimit, podCount),
+		fmt.Sprintf(
+			"Logs are hidden for %d containers because the per-tab limit of %d was reached.",
+			podCount-podlogs.DefaultPerScopeTargetLimit,
+			podlogs.DefaultPerScopeTargetLimit,
+		),
 	)
 }
 

--- a/backend/resources/pods/logs_test.go
+++ b/backend/resources/pods/logs_test.go
@@ -212,6 +212,39 @@ func TestPodContainersIncludesEphemeral(t *testing.T) {
 	require.Equal(t, []string{"app", "debug-abc (debug)"}, containers)
 }
 
+func TestLogScopeContainersWorkloadReturnsUniqueDisplayNames(t *testing.T) {
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+		},
+	}
+	podOne := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "web-1", Namespace: "default", Labels: map[string]string{"app": "web"}},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{{Name: "init-a"}},
+			Containers:     []corev1.Container{{Name: "app"}, {Name: "sidecar"}},
+		},
+	}
+	podTwo := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "web-2", Namespace: "default", Labels: map[string]string{"app": "web"}},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{{Name: "init-a"}},
+			Containers:     []corev1.Container{{Name: "app"}, {Name: "other"}},
+		},
+	}
+	client := fake.NewClientset(deployment, podOne, podTwo)
+
+	service := NewService(common.Dependencies{
+		Context:          context.Background(),
+		KubernetesClient: client,
+	})
+
+	containers, err := service.LogScopeContainers("cluster-a|default:apps/v1:deployment:web")
+	require.NoError(t, err)
+	require.Equal(t, []string{"app", "init-a (init)", "other", "sidecar"}, containers)
+}
+
 func TestResolveTargetPodsDeployment(t *testing.T) {
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"},
@@ -845,8 +878,9 @@ func TestLogFetcherWarnsWhenTargetLimitExceeded(t *testing.T) {
 		logStreamFunc = orig
 	}(logStreamFunc)
 
-	containers := make([]corev1.Container, 0, 25)
-	for i := 0; i < 25; i++ {
+	containerCount := podlogs.DefaultPerScopeTargetLimit + 1
+	containers := make([]corev1.Container, 0, containerCount)
+	for i := 0; i < containerCount; i++ {
 		containers = append(containers, corev1.Container{Name: fmt.Sprintf("c-%02d", i)})
 	}
 	pod := &corev1.Pod{
@@ -868,7 +902,11 @@ func TestLogFetcherWarnsWhenTargetLimitExceeded(t *testing.T) {
 	require.Empty(t, resp.Error)
 	require.Len(t, resp.Entries, podlogs.DefaultPerScopeTargetLimit)
 	require.Len(t, resp.Warnings, 1)
-	require.Contains(t, resp.Warnings[0], "24 of 25")
+	require.Contains(
+		t,
+		resp.Warnings[0],
+		fmt.Sprintf("%d of %d", podlogs.DefaultPerScopeTargetLimit, containerCount),
+	)
 }
 
 func TestLogFetcherUsesSharedCappedTargetSelection(t *testing.T) {
@@ -884,8 +922,9 @@ func TestLogFetcherUsesSharedCappedTargetSelection(t *testing.T) {
 	}
 
 	objects := []runtime.Object{deployment}
-	podObjects := make([]*corev1.Pod, 0, 25)
-	for i := 0; i < 25; i++ {
+	podCount := podlogs.DefaultPerScopeTargetLimit + 1
+	podObjects := make([]*corev1.Pod, 0, podCount)
+	for i := 0; i < podCount; i++ {
 		pod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fmt.Sprintf("web-%02d", i),
@@ -932,7 +971,7 @@ func TestLogFetcherUsesSharedCappedTargetSelection(t *testing.T) {
 		podlogs.DefaultContainerSelection(""),
 		podlogs.DefaultPerScopeTargetLimit,
 	)
-	require.Equal(t, 25, total)
+	require.Equal(t, podCount, total)
 	expectedKeys := make([]string, 0, len(expectedTargets))
 	for _, target := range expectedTargets {
 		expectedKeys = append(expectedKeys, target.Key())
@@ -940,7 +979,11 @@ func TestLogFetcherUsesSharedCappedTargetSelection(t *testing.T) {
 
 	require.Equal(t, expectedKeys, requestedKeys)
 	require.Len(t, resp.Warnings, 1)
-	require.Contains(t, resp.Warnings[0], "24 of 25")
+	require.Contains(
+		t,
+		resp.Warnings[0],
+		fmt.Sprintf("%d of %d", podlogs.DefaultPerScopeTargetLimit, podCount),
+	)
 }
 
 func TestLogFetcherSortsWhenTimestampMissing(t *testing.T) {

--- a/backend/resources/types/types.go
+++ b/backend/resources/types/types.go
@@ -88,32 +88,34 @@ type Theme struct {
 
 // PodLogEntry represents a single log line with metadata
 type PodLogEntry struct {
-	Timestamp string `json:"timestamp"` // RFC3339Nano format
-	Pod       string `json:"pod"`
-	Container string `json:"container"`
-	Line      string `json:"line"`
-	IsInit    bool   `json:"isInit"` // Whether this is from an init container
+	Timestamp   string `json:"timestamp"` // RFC3339Nano format
+	Pod         string `json:"pod"`
+	Container   string `json:"container"`
+	Line        string `json:"line"`
+	IsInit      bool   `json:"isInit"`                // Whether this is from an init container
+	IsEphemeral bool   `json:"isEphemeral,omitempty"` // Whether this is from an ephemeral/debug container
 }
 
 // LogFetchRequest represents parameters for fetching logs
 type LogFetchRequest struct {
-	Scope            string `json:"scope,omitempty"`
-	Namespace        string `json:"namespace"`
-	WorkloadName     string `json:"workloadName,omitempty"`
-	WorkloadKind     string `json:"workloadKind,omitempty"` // deployment, daemonset, etc.
-	PodName          string `json:"podName,omitempty"`
-	PodFilter        string `json:"podFilter,omitempty"`
-	PodInclude       string `json:"podInclude,omitempty"`
-	PodExclude       string `json:"podExclude,omitempty"`
-	Container        string `json:"container,omitempty"` // empty means all containers
-	IncludeInit      *bool  `json:"includeInit,omitempty"`
-	IncludeEphemeral *bool  `json:"includeEphemeral,omitempty"`
-	ContainerState   string `json:"containerState,omitempty"`
-	Include          string `json:"include,omitempty"`
-	Exclude          string `json:"exclude,omitempty"`
-	Previous         bool   `json:"previous"`
-	TailLines        int    `json:"tailLines"`
-	SinceSeconds     int64  `json:"sinceSeconds,omitempty"`
+	Scope            string   `json:"scope,omitempty"`
+	Namespace        string   `json:"namespace"`
+	WorkloadName     string   `json:"workloadName,omitempty"`
+	WorkloadKind     string   `json:"workloadKind,omitempty"` // deployment, daemonset, etc.
+	PodName          string   `json:"podName,omitempty"`
+	PodFilter        string   `json:"podFilter,omitempty"`
+	PodInclude       string   `json:"podInclude,omitempty"`
+	PodExclude       string   `json:"podExclude,omitempty"`
+	SelectedFilters  []string `json:"selectedFilters,omitempty"`
+	Container        string   `json:"container,omitempty"` // empty means all containers
+	IncludeInit      *bool    `json:"includeInit,omitempty"`
+	IncludeEphemeral *bool    `json:"includeEphemeral,omitempty"`
+	ContainerState   string   `json:"containerState,omitempty"`
+	Include          string   `json:"include,omitempty"`
+	Exclude          string   `json:"exclude,omitempty"`
+	Previous         bool     `json:"previous"`
+	TailLines        int      `json:"tailLines"`
+	SinceSeconds     int64    `json:"sinceSeconds,omitempty"`
 }
 
 // LogFetchResponse represents the response from LogFetcher

--- a/backend/resources/types/types.go
+++ b/backend/resources/types/types.go
@@ -36,6 +36,8 @@ type AppSettings struct {
 	RefreshBackgroundClustersEnabled bool     `json:"refreshBackgroundClustersEnabled"` // Refresh inactive clusters in the background
 	MetricsRefreshIntervalMs         int      `json:"metricsRefreshIntervalMs"`         // Metrics refresh interval (ms)
 	LogBufferMaxSize                 int      `json:"logBufferMaxSize"`                 // Max log entries kept in memory per Logs tab (100-10000)
+	LogTargetPerScopeLimit           int      `json:"logTargetPerScopeLimit"`           // Max pod/container log targets per Logs tab (1-1000)
+	LogTargetGlobalLimit             int      `json:"logTargetGlobalLimit"`             // Max pod/container log targets across all log tabs (1-1000)
 	GridTablePersistenceMode         string   `json:"gridTablePersistenceMode"`         // "shared" or "namespaced"
 	DefaultObjectPanelPosition       string   `json:"defaultObjectPanelPosition"`       // "right", "bottom", or "floating"
 	ObjectPanelDockedRightWidth      int      `json:"objectPanelDockedRightWidth"`      // Default width when docked right (px)

--- a/backend/resources_pods.go
+++ b/backend/resources_pods.go
@@ -44,6 +44,15 @@ func (a *App) GetPodContainers(clusterID, namespace, podName string) ([]string, 
 	return service.PodContainers(namespace, podName)
 }
 
+func (a *App) GetLogScopeContainers(clusterID, scope string) ([]string, error) {
+	deps, _, err := a.resolveClusterDependencies(clusterID)
+	if err != nil {
+		return nil, err
+	}
+	service := pods.NewService(deps)
+	return service.LogScopeContainers(scope)
+}
+
 // CreateDebugContainer adds an ephemeral debug container to a running pod.
 func (a *App) CreateDebugContainer(clusterID string, req DebugContainerRequest) (*DebugContainerResponse, error) {
 	deps, _, err := a.resolveClusterDependencies(clusterID)

--- a/docs/development/container-logs.md
+++ b/docs/development/container-logs.md
@@ -24,7 +24,7 @@ Both paths share the same core target-resolution behavior:
 - resolve matching pods for that pod or workload
 - enumerate regular, init, and ephemeral containers
 - include all container states by default
-- optionally narrow to one exact container when the current UI selects exactly one container in single-pod mode
+- apply explicit pod/container selections from the current Object Panel tab before target caps
 - apply deterministic target ordering
 - enforce target caps and emit warnings when the result is degraded
 
@@ -39,6 +39,7 @@ Each entry contains:
 - `container`
 - `line`
 - `isInit`
+- `isEphemeral`
 
 The frontend derives everything else from that payload.
 
@@ -69,8 +70,8 @@ Current fetch behavior:
 
 The backend protects log fan-out in two places:
 
-- per-scope cap: `24` resolved pod/container targets
-- global cap: `72` resolved pod/container targets across all active scopes
+- per-scope cap: `100` resolved pod/container targets
+- global cap: `200` resolved pod/container targets across all active scopes
 
 Selection is deterministic:
 
@@ -80,7 +81,7 @@ Selection is deterministic:
 
 When a cap is hit, the backend emits a warning such as:
 
-- `Showing logs for 24 of 25 pod/container targets. Refine filters to view more.`
+- `Showing logs for 100 of 125 pod/container targets. Refine filters to view more.`
 
 The global limiter is shared across clusters and rebalances capacity so one cluster does not monopolize the full budget.
 
@@ -144,8 +145,9 @@ Notes:
 - the `Pods` section is omitted for single-pod logs
 - the `Init Containers` header is omitted when there are no init containers
 - `Select all` / `Select none` come from the shared multi-select dropdown component
-- selected pod/container filters currently narrow results in the frontend viewer
-- the only backend narrowing used by the current UI is exact single-container selection in single-pod mode
+- selected pod/container filters are sent to both live streaming and manual fetch
+- backend target resolution applies those selections before per-tab/global caps
+- this means narrowing the selector can reveal pods/containers that were previously excluded by the cap
 
 ### Search model
 
@@ -298,13 +300,3 @@ The frontend intentionally preserves per-tab log state across transient remounts
 ### 5. The current UI is intentionally simpler than the backend contract
 
 The backend still supports more source-side filter knobs than the Object Panel exposes. That is deliberate. If you add new UI controls, document clearly whether they are frontend-only narrowing or true backend-side target reduction.
-
-### 6. Tech debt: workload selector narrowing is still mostly client-side
-
-The current grouped `All Logs` selector is not a full source-side workload selector yet.
-
-- workload pod/init/container selections mostly narrow the visible result set in the frontend
-- the current backend stream/fetch narrowing used by the Object Panel is limited to exact single-container selection in single-pod mode
-- as a result, workload fan-out, target-cap warnings, and backend load can still reflect the broader workload even when the UI appears narrowly filtered
-
-If this selector is expanded further, the next cleanup step is to make workload pod/container selections participate in backend target resolution rather than only post-transport filtering.

--- a/docs/plans/todos.md
+++ b/docs/plans/todos.md
@@ -1,7 +1,5 @@
 # TODO
 
-- large numbers of pods are not picked up by the log viewer
-
 - can we get node logs?
 
 - Allow remove of default kubeconfig path, if not the last

--- a/docs/plans/todos.md
+++ b/docs/plans/todos.md
@@ -1,5 +1,7 @@
 # TODO
 
+- large numbers of pods are not picked up by the log viewer
+
 - can we get node logs?
 
 - Allow remove of default kubeconfig path, if not the last

--- a/frontend/src/core/events/eventBus.ts
+++ b/frontend/src/core/events/eventBus.ts
@@ -82,6 +82,8 @@ export interface AppEvents {
   'settings:theme': string;
   'settings:metrics-interval': number;
   'settings:log-buffer-size': number;
+  'settings:log-target-per-scope-limit': number;
+  'settings:log-target-global-limit': number;
   'settings:palette-tint': {
     theme: 'light' | 'dark';
     hue: number;

--- a/frontend/src/core/refresh/streaming/logStreamManager.test.ts
+++ b/frontend/src/core/refresh/streaming/logStreamManager.test.ts
@@ -306,7 +306,7 @@ describe('LogStreamManager', () => {
     expect(errorHandlerMock.handle).not.toHaveBeenCalled();
   });
 
-  test('startStream appends cached pod and container filters to the stream URL', async () => {
+  test('startStream appends cached selection filters to the stream URL', async () => {
     class MockEventSource {
       static instances: MockEventSource[] = [];
       listeners: Record<string, (evt?: any) => void> = {};
@@ -322,7 +322,7 @@ describe('LogStreamManager', () => {
     (globalThis as any).EventSource = MockEventSource as any;
 
     setLogStreamScopeParams(SCOPE, {
-      container: 'app',
+      selectedFilters: ['pod:web-2', 'container:app'],
     });
 
     const { LogStreamManager } = await import('./logStreamManager');
@@ -333,7 +333,7 @@ describe('LogStreamManager', () => {
     expect(MockEventSource.instances).toHaveLength(1);
     const streamURL = new URL(MockEventSource.instances[0]!.url);
     expect(streamURL.searchParams.get('scope')).toBe(SCOPE);
-    expect(streamURL.searchParams.get('container')).toBe('app');
+    expect(streamURL.searchParams.getAll('selectedFilter')).toEqual(['pod:web-2', 'container:app']);
   });
 
   test('refreshOnce rejects and marks error when the stream fails', async () => {

--- a/frontend/src/core/refresh/streaming/logStreamManager.ts
+++ b/frontend/src/core/refresh/streaming/logStreamManager.ts
@@ -29,6 +29,7 @@ interface StreamEventPayload {
     container?: string;
     line?: string;
     isInit?: boolean;
+    isEphemeral?: boolean;
   }>;
   warnings?: string[];
   error?: string;
@@ -138,6 +139,9 @@ class LogStreamConnection {
       const streamParams = getLogStreamScopeParams(this.scope);
       if (streamParams?.container) {
         url.searchParams.set('container', streamParams.container);
+      }
+      for (const selectedFilter of streamParams?.selectedFilters ?? []) {
+        url.searchParams.append('selectedFilter', selectedFilter);
       }
 
       const eventSource = new EventSource(url.toString());
@@ -382,6 +386,7 @@ export class LogStreamManager {
       container: entry.container ?? '',
       line: entry.line ?? '',
       isInit: Boolean(entry.isInit),
+      isEphemeral: Boolean(entry.isEphemeral),
       _seq: ++this.seqCounter,
     }));
 

--- a/frontend/src/core/refresh/types.ts
+++ b/frontend/src/core/refresh/types.ts
@@ -648,6 +648,7 @@ export interface ObjectLogEntry {
   container: string;
   line: string;
   isInit: boolean;
+  isEphemeral?: boolean;
   /** Monotonically increasing sequence ID assigned by the frontend for stable rendering keys. */
   _seq?: number;
 }

--- a/frontend/src/core/settings/appPreferences.test.ts
+++ b/frontend/src/core/settings/appPreferences.test.ts
@@ -52,8 +52,7 @@ vi.mock('@wailsjs/go/backend/App', () => ({
   SetTheme: (...args: unknown[]) => appMocks.SetTheme(...args),
   SetUseShortResourceNames: (...args: unknown[]) => appMocks.SetUseShortResourceNames(...args),
   SetLogBufferMaxSize: (...args: unknown[]) => appMocks.SetLogBufferMaxSize(...args),
-  SetLogTargetPerScopeLimit: (...args: unknown[]) =>
-    appMocks.SetLogTargetPerScopeLimit(...args),
+  SetLogTargetPerScopeLimit: (...args: unknown[]) => appMocks.SetLogTargetPerScopeLimit(...args),
   SetLogTargetGlobalLimit: (...args: unknown[]) => appMocks.SetLogTargetGlobalLimit(...args),
 }));
 

--- a/frontend/src/core/settings/appPreferences.test.ts
+++ b/frontend/src/core/settings/appPreferences.test.ts
@@ -11,6 +11,8 @@ import {
   getBackgroundRefreshEnabled,
   getGridTablePersistenceMode,
   getLogBufferMaxSize,
+  getLogTargetGlobalLimit,
+  getLogTargetPerScopeLimit,
   getMetricsRefreshIntervalMs,
   getPaletteTint,
   getThemePreference,
@@ -19,12 +21,18 @@ import {
   LOG_BUFFER_DEFAULT_SIZE,
   LOG_BUFFER_MAX_SIZE,
   LOG_BUFFER_MIN_SIZE,
+  LOG_TARGET_GLOBAL_DEFAULT,
+  LOG_TARGET_GLOBAL_MAX,
+  LOG_TARGET_PER_SCOPE_DEFAULT,
+  LOG_TARGET_PER_SCOPE_MAX,
   resetAppPreferencesCacheForTesting,
   setAccentColor,
   setAutoRefreshEnabled,
   setBackgroundRefreshEnabled,
   setGridTablePersistenceMode,
   setLogBufferMaxSize,
+  setLogTargetGlobalLimit,
+  setLogTargetPerScopeLimit,
   setPaletteTint,
   setThemePreference,
   setUseShortResourceNames,
@@ -35,6 +43,8 @@ const appMocks = vi.hoisted(() => ({
   SetTheme: vi.fn(),
   SetUseShortResourceNames: vi.fn(),
   SetLogBufferMaxSize: vi.fn(),
+  SetLogTargetPerScopeLimit: vi.fn(),
+  SetLogTargetGlobalLimit: vi.fn(),
 }));
 
 vi.mock('@wailsjs/go/backend/App', () => ({
@@ -42,6 +52,9 @@ vi.mock('@wailsjs/go/backend/App', () => ({
   SetTheme: (...args: unknown[]) => appMocks.SetTheme(...args),
   SetUseShortResourceNames: (...args: unknown[]) => appMocks.SetUseShortResourceNames(...args),
   SetLogBufferMaxSize: (...args: unknown[]) => appMocks.SetLogBufferMaxSize(...args),
+  SetLogTargetPerScopeLimit: (...args: unknown[]) =>
+    appMocks.SetLogTargetPerScopeLimit(...args),
+  SetLogTargetGlobalLimit: (...args: unknown[]) => appMocks.SetLogTargetGlobalLimit(...args),
 }));
 
 describe('appPreferences', () => {
@@ -51,7 +64,11 @@ describe('appPreferences', () => {
     appMocks.SetTheme.mockReset();
     appMocks.SetUseShortResourceNames.mockReset();
     appMocks.SetLogBufferMaxSize.mockReset();
+    appMocks.SetLogTargetPerScopeLimit.mockReset();
+    appMocks.SetLogTargetGlobalLimit.mockReset();
     appMocks.SetLogBufferMaxSize.mockResolvedValue(undefined);
+    appMocks.SetLogTargetPerScopeLimit.mockResolvedValue(undefined);
+    appMocks.SetLogTargetGlobalLimit.mockResolvedValue(undefined);
     (window as any).go = {
       backend: {
         App: {
@@ -59,6 +76,8 @@ describe('appPreferences', () => {
           SetBackgroundRefreshEnabled: vi.fn().mockResolvedValue(undefined),
           SetGridTablePersistenceMode: vi.fn().mockResolvedValue(undefined),
           SetLogBufferMaxSize: vi.fn().mockResolvedValue(undefined),
+          SetLogTargetPerScopeLimit: vi.fn().mockResolvedValue(undefined),
+          SetLogTargetGlobalLimit: vi.fn().mockResolvedValue(undefined),
           SetPaletteTint: vi.fn().mockResolvedValue(undefined),
           SetAccentColor: vi.fn().mockResolvedValue(undefined),
         },
@@ -77,6 +96,8 @@ describe('appPreferences', () => {
       autoRefreshEnabled: false,
       refreshBackgroundClustersEnabled: false,
       metricsRefreshIntervalMs: 7000,
+      logTargetPerScopeLimit: 144,
+      logTargetGlobalLimit: 180,
       gridTablePersistenceMode: 'namespaced',
       paletteHueLight: 220,
       paletteSaturationLight: 50,
@@ -95,6 +116,8 @@ describe('appPreferences', () => {
     expect(getAutoRefreshEnabled()).toBe(false);
     expect(getBackgroundRefreshEnabled()).toBe(false);
     expect(getMetricsRefreshIntervalMs()).toBe(7000);
+    expect(getLogTargetPerScopeLimit()).toBe(144);
+    expect(getLogTargetGlobalLimit()).toBe(180);
     expect(getGridTablePersistenceMode()).toBe('namespaced');
     expect(getPaletteTint('light')).toEqual({ hue: 220, saturation: 50, brightness: -15 });
     expect(getPaletteTint('dark')).toEqual({ hue: 120, saturation: 40, brightness: 10 });
@@ -277,5 +300,65 @@ describe('appPreferences', () => {
     await hydrateAppPreferences({ force: true });
     setLogBufferMaxSize(999_999);
     expect(getLogBufferMaxSize()).toBe(LOG_BUFFER_MAX_SIZE);
+  });
+
+  it('hydrates log target limits from backend settings', async () => {
+    appMocks.GetAppSettings.mockResolvedValue({
+      theme: 'system',
+      logTargetPerScopeLimit: 144,
+      logTargetGlobalLimit: 180,
+    });
+    await hydrateAppPreferences({ force: true });
+    expect(getLogTargetPerScopeLimit()).toBe(144);
+    expect(getLogTargetGlobalLimit()).toBe(180);
+  });
+
+  it('defaults log target limits when the backend payload is missing the fields', async () => {
+    appMocks.GetAppSettings.mockResolvedValue({ theme: 'system' });
+    await hydrateAppPreferences({ force: true });
+    expect(getLogTargetPerScopeLimit()).toBe(LOG_TARGET_PER_SCOPE_DEFAULT);
+    expect(getLogTargetGlobalLimit()).toBe(LOG_TARGET_GLOBAL_DEFAULT);
+  });
+
+  it('setLogTargetPerScopeLimit round-trips an in-range value through the cache and backend', async () => {
+    appMocks.GetAppSettings.mockResolvedValue({ theme: 'system' });
+    await hydrateAppPreferences({ force: true });
+
+    setLogTargetPerScopeLimit(144);
+    expect(getLogTargetPerScopeLimit()).toBe(144);
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    expect(appMocks.SetLogTargetPerScopeLimit).toHaveBeenCalledWith(144);
+  });
+
+  it('setLogTargetPerScopeLimit defaults zero and clamps large values', async () => {
+    appMocks.GetAppSettings.mockResolvedValue({ theme: 'system' });
+    await hydrateAppPreferences({ force: true });
+
+    setLogTargetPerScopeLimit(0);
+    expect(getLogTargetPerScopeLimit()).toBe(LOG_TARGET_PER_SCOPE_DEFAULT);
+
+    setLogTargetPerScopeLimit(999_999);
+    expect(getLogTargetPerScopeLimit()).toBe(LOG_TARGET_PER_SCOPE_MAX);
+  });
+
+  it('setLogTargetGlobalLimit round-trips an in-range value through the cache and backend', async () => {
+    appMocks.GetAppSettings.mockResolvedValue({ theme: 'system' });
+    await hydrateAppPreferences({ force: true });
+
+    setLogTargetGlobalLimit(180);
+    expect(getLogTargetGlobalLimit()).toBe(180);
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    expect(appMocks.SetLogTargetGlobalLimit).toHaveBeenCalledWith(180);
+  });
+
+  it('setLogTargetGlobalLimit defaults zero and clamps large values', async () => {
+    appMocks.GetAppSettings.mockResolvedValue({ theme: 'system' });
+    await hydrateAppPreferences({ force: true });
+
+    setLogTargetGlobalLimit(0);
+    expect(getLogTargetGlobalLimit()).toBe(LOG_TARGET_GLOBAL_DEFAULT);
+
+    setLogTargetGlobalLimit(999_999);
+    expect(getLogTargetGlobalLimit()).toBe(LOG_TARGET_GLOBAL_MAX);
   });
 });

--- a/frontend/src/core/settings/appPreferences.ts
+++ b/frontend/src/core/settings/appPreferences.ts
@@ -15,6 +15,8 @@ import {
   ApplyTheme,
   MatchThemeForCluster,
   SetLogBufferMaxSize as SetLogBufferMaxSizeBackend,
+  SetLogTargetGlobalLimit as SetLogTargetGlobalLimitBackend,
+  SetLogTargetPerScopeLimit as SetLogTargetPerScopeLimitBackend,
 } from '@wailsjs/go/backend/App';
 import { types } from '@wailsjs/go/models';
 import { eventBus } from '@/core/events';
@@ -30,6 +32,8 @@ interface AppPreferences {
   refreshBackgroundClustersEnabled: boolean;
   metricsRefreshIntervalMs: number;
   logBufferMaxSize: number;
+  logTargetPerScopeLimit: number;
+  logTargetGlobalLimit: number;
   gridTablePersistenceMode: GridTablePersistenceMode;
   defaultObjectPanelPosition: ObjectPanelPosition;
   objectPanelDockedRightWidth: number;
@@ -57,6 +61,8 @@ interface AppSettingsPayload {
   refreshBackgroundClustersEnabled?: boolean;
   metricsRefreshIntervalMs?: number;
   logBufferMaxSize?: number;
+  logTargetPerScopeLimit?: number;
+  logTargetGlobalLimit?: number;
   gridTablePersistenceMode?: string;
   defaultObjectPanelPosition?: string;
   objectPanelDockedRightWidth?: number;
@@ -90,6 +96,12 @@ const DEFAULT_METRICS_REFRESH_INTERVAL_MS = 5000;
 export const LOG_BUFFER_MIN_SIZE = 100;
 export const LOG_BUFFER_MAX_SIZE = 10000;
 export const LOG_BUFFER_DEFAULT_SIZE = 1000;
+export const LOG_TARGET_PER_SCOPE_MIN = 1;
+export const LOG_TARGET_PER_SCOPE_MAX = 1000;
+export const LOG_TARGET_PER_SCOPE_DEFAULT = 100;
+export const LOG_TARGET_GLOBAL_MIN = 1;
+export const LOG_TARGET_GLOBAL_MAX = 1000;
+export const LOG_TARGET_GLOBAL_DEFAULT = 200;
 
 const DEFAULT_PREFERENCES: AppPreferences = {
   theme: 'system',
@@ -98,6 +110,8 @@ const DEFAULT_PREFERENCES: AppPreferences = {
   refreshBackgroundClustersEnabled: true,
   metricsRefreshIntervalMs: DEFAULT_METRICS_REFRESH_INTERVAL_MS,
   logBufferMaxSize: LOG_BUFFER_DEFAULT_SIZE,
+  logTargetPerScopeLimit: LOG_TARGET_PER_SCOPE_DEFAULT,
+  logTargetGlobalLimit: LOG_TARGET_GLOBAL_DEFAULT,
   paletteHueLight: 0,
   paletteSaturationLight: 0,
   paletteBrightnessLight: 0,
@@ -165,6 +179,26 @@ const normalizeLogBufferMaxSize = (value?: number): number => {
   return floored;
 };
 
+const normalizeLogTargetPerScopeLimit = (value?: number): number => {
+  if (value == null || Number.isNaN(value) || value <= 0) {
+    return LOG_TARGET_PER_SCOPE_DEFAULT;
+  }
+  const floored = Math.floor(value);
+  if (floored < LOG_TARGET_PER_SCOPE_MIN) return LOG_TARGET_PER_SCOPE_MIN;
+  if (floored > LOG_TARGET_PER_SCOPE_MAX) return LOG_TARGET_PER_SCOPE_MAX;
+  return floored;
+};
+
+const normalizeLogTargetGlobalLimit = (value?: number): number => {
+  if (value == null || Number.isNaN(value) || value <= 0) {
+    return LOG_TARGET_GLOBAL_DEFAULT;
+  }
+  const floored = Math.floor(value);
+  if (floored < LOG_TARGET_GLOBAL_MIN) return LOG_TARGET_GLOBAL_MIN;
+  if (floored > LOG_TARGET_GLOBAL_MAX) return LOG_TARGET_GLOBAL_MAX;
+  return floored;
+};
+
 const emitPreferenceChanges = (previous: AppPreferences, next: AppPreferences): void => {
   if (previous.theme !== next.theme) {
     eventBus.emit('settings:theme', next.theme);
@@ -183,6 +217,12 @@ const emitPreferenceChanges = (previous: AppPreferences, next: AppPreferences): 
   }
   if (previous.logBufferMaxSize !== next.logBufferMaxSize) {
     eventBus.emit('settings:log-buffer-size', next.logBufferMaxSize);
+  }
+  if (previous.logTargetPerScopeLimit !== next.logTargetPerScopeLimit) {
+    eventBus.emit('settings:log-target-per-scope-limit', next.logTargetPerScopeLimit);
+  }
+  if (previous.logTargetGlobalLimit !== next.logTargetGlobalLimit) {
+    eventBus.emit('settings:log-target-global-limit', next.logTargetGlobalLimit);
   }
   if (previous.gridTablePersistenceMode !== next.gridTablePersistenceMode) {
     eventBus.emit('gridtable:persistence-mode', next.gridTablePersistenceMode);
@@ -299,6 +339,10 @@ export const hydrateAppPreferences = async (options?: {
       DEFAULT_PREFERENCES.refreshBackgroundClustersEnabled,
     metricsRefreshIntervalMs: normalizeMetricsIntervalMs(backendSettings?.metricsRefreshIntervalMs),
     logBufferMaxSize: normalizeLogBufferMaxSize(backendSettings?.logBufferMaxSize),
+    logTargetPerScopeLimit: normalizeLogTargetPerScopeLimit(
+      backendSettings?.logTargetPerScopeLimit
+    ),
+    logTargetGlobalLimit: normalizeLogTargetGlobalLimit(backendSettings?.logTargetGlobalLimit),
     gridTablePersistenceMode: normalizeGridTableMode(backendSettings?.gridTablePersistenceMode),
     defaultObjectPanelPosition: normalizeObjectPanelPosition(
       backendSettings?.defaultObjectPanelPosition
@@ -365,6 +409,14 @@ export const getMetricsRefreshIntervalMs = (): number => {
 
 export const getLogBufferMaxSize = (): number => {
   return preferenceCache.logBufferMaxSize;
+};
+
+export const getLogTargetPerScopeLimit = (): number => {
+  return preferenceCache.logTargetPerScopeLimit;
+};
+
+export const getLogTargetGlobalLimit = (): number => {
+  return preferenceCache.logTargetGlobalLimit;
 };
 
 export const getGridTablePersistenceMode = (): GridTablePersistenceMode => {
@@ -503,12 +555,46 @@ const persistLogBufferMaxSize = async (size: number): Promise<void> => {
   await SetLogBufferMaxSizeBackend(size);
 };
 
+const persistLogTargetPerScopeLimit = async (limit: number): Promise<void> => {
+  const runtimeApp = (window as any)?.go?.backend?.App;
+  if (!runtimeApp) {
+    return;
+  }
+  await SetLogTargetPerScopeLimitBackend(limit);
+};
+
+const persistLogTargetGlobalLimit = async (limit: number): Promise<void> => {
+  const runtimeApp = (window as any)?.go?.backend?.App;
+  if (!runtimeApp) {
+    return;
+  }
+  await SetLogTargetGlobalLimitBackend(limit);
+};
+
 export const setLogBufferMaxSize = (size: number): void => {
   const normalized = normalizeLogBufferMaxSize(size);
   hydrated = true;
   updatePreferenceCache({ logBufferMaxSize: normalized });
   void persistLogBufferMaxSize(normalized).catch((error) => {
     console.error('Failed to persist log buffer max size:', error);
+  });
+};
+
+export const setLogTargetPerScopeLimit = (limit: number): void => {
+  const normalized = normalizeLogTargetPerScopeLimit(limit);
+  hydrated = true;
+  updatePreferenceCache({ logTargetPerScopeLimit: normalized });
+  void persistLogTargetPerScopeLimit(normalized).catch((error) => {
+    console.error('Failed to persist log target per-scope limit:', error);
+  });
+};
+
+export const setLogTargetGlobalLimit = (limit: number): void => {
+  const normalized = normalizeLogTargetGlobalLimit(limit);
+  hydrated = true;
+  updatePreferenceCache({ logTargetGlobalLimit: normalized });
+  void persistLogTargetGlobalLimit(normalized).catch((error) => {
+    console.error('Failed to persist log target global limit:', error);
   });
 };
 

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.css
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.css
@@ -355,6 +355,16 @@
   position: relative;
 }
 
+.pod-logs-warning-bar {
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  background-color: var(--color-error-bg);
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+  font-weight: 500;
+}
+
 .pod-logs-text {
   color: var(--log-text-primary);
   font-size: var(--font-size-mono);

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.test.tsx
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.test.tsx
@@ -611,7 +611,7 @@ describe('LogViewer active pod synchronisation', () => {
     expect(mockModules.orchestrator.restartStreamingDomain).not.toHaveBeenCalled();
   });
 
-  it('does not render backend warning banners from fallback/manual log responses', async () => {
+  it('surfaces target-cap warnings from fallback/manual log responses', async () => {
     seedLogSnapshot(
       [
         {
@@ -651,8 +651,49 @@ describe('LogViewer active pod synchronisation', () => {
     });
     await flushAsync();
 
-    expect(container.textContent).not.toContain(
+    expect(container.textContent).toContain(
       'Showing logs for 24 of 25 pod/container targets. Refine filters to view more.'
+    );
+  });
+
+  it('surfaces target-cap warnings from the scoped log snapshot', async () => {
+    const generatedAt = Date.now();
+    setScopedDomainState('object-logs', defaultScope, () => ({
+      status: 'ready',
+      data: {
+        entries: [
+          {
+            pod: 'web-1',
+            container: 'app',
+            line: 'line 1',
+            timestamp: '2024-05-01T10:00:00Z',
+            isInit: false,
+          },
+        ],
+        sequence: 2,
+        generatedAt,
+        resetCount: 0,
+        error: null,
+      },
+      stats: {
+        itemCount: 1,
+        buildDurationMs: 0,
+        warnings: ['Showing logs for 24 of 52 pod/container targets. Refine filters to view more.'],
+      },
+      error: null,
+      droppedAutoRefreshes: 0,
+      scope: defaultScope,
+      lastUpdated: generatedAt,
+      lastAutoRefresh: generatedAt,
+      lastManualRefresh: undefined,
+      isManual: false,
+    }));
+
+    await renderViewer({ activePodNames: ['web-1'], isActive: false });
+    await flushAsync();
+
+    expect(container.textContent).toContain(
+      'Showing logs for 24 of 52 pod/container targets. Refine filters to view more.'
     );
   });
 

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.test.tsx
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.test.tsx
@@ -1271,7 +1271,7 @@ describe('LogViewer active pod synchronisation', () => {
     expect(filteredLines[0]).not.toContain('[sidecar:init]');
     expect(filteredLines[0]).toContain('init complete');
     expect(getLogStreamScopeParams(buildLogScope('team-a:pod:api'))).toEqual({
-      container: 'sidecar',
+      selectedFilters: ['init:sidecar'],
     });
     expect(mockModules.orchestrator.restartStreamingDomain).toHaveBeenCalledWith(
       'object-logs',
@@ -1329,8 +1329,7 @@ describe('LogViewer active pod synchronisation', () => {
           isInit: true,
         },
       ],
-      defaultScope,
-      { status: 'error', error: 'stream disconnected' }
+      defaultScope
     );
     await renderViewer({ activePodNames: ['web-1', 'web-2'] });
     await flushAsync();
@@ -1351,7 +1350,9 @@ describe('LogViewer active pod synchronisation', () => {
     );
     expect(filteredLines).toHaveLength(1);
     expect(filteredLines[0]).toContain('[web-1/app] matched log');
-    expect(getLogStreamScopeParams(defaultScope)).toBeUndefined();
+    expect(getLogStreamScopeParams(defaultScope)).toEqual({
+      selectedFilters: ['pod:web-1', 'container:app'],
+    });
     expect(getLogViewerPrefs('obj:test:deployment:team-a:api')?.selectedFilters).toEqual([
       'pod:web-1',
       'container:app',
@@ -1955,7 +1956,9 @@ describe('LogViewer active pod synchronisation', () => {
     );
     expect(highlightButton?.getAttribute('aria-pressed')).toBe('true');
     expect(getLogViewerPrefs(panelId)?.selectedFilters).toEqual(['pod:web-1']);
-    expect(getLogStreamScopeParams(defaultScope)).toBeUndefined();
+    expect(getLogStreamScopeParams(defaultScope)).toEqual({
+      selectedFilters: ['pod:web-1'],
+    });
   });
 
   it('writes prefs back to the cache as the user toggles them', async () => {

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.test.tsx
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.test.tsx
@@ -15,7 +15,7 @@ import {
 } from '@/core/refresh/store';
 import { buildClusterScope } from '@/core/refresh/clusterScope';
 import type { ObjectLogEntry } from '@/core/refresh/types';
-import { GetPodContainers, LogFetcher } from '@wailsjs/go/backend/App';
+import { GetLogScopeContainers, LogFetcher } from '@wailsjs/go/backend/App';
 import {
   getLogViewerPrefs,
   resetLogViewerPrefsCacheForTesting,
@@ -91,7 +91,7 @@ const mockModules = vi.hoisted(() => {
 
 vi.mock('@wailsjs/go/backend/App', () => ({
   LogFetcher: vi.fn(),
-  GetPodContainers: vi.fn(),
+  GetLogScopeContainers: vi.fn(),
 }));
 
 vi.mock('@/core/refresh/orchestrator', () => ({
@@ -232,6 +232,8 @@ describe('LogViewer active pod synchronisation', () => {
     vi.clearAllMocks();
     shortcutMocks.useShortcut.mockClear();
     (LogFetcher as unknown as ViMock).mockReset?.();
+    (GetLogScopeContainers as unknown as ViMock).mockReset?.();
+    (GetLogScopeContainers as unknown as ViMock).mockResolvedValue(['app']);
     resetLogViewerPrefsCacheForTesting();
     resetLogStreamScopeParamsCacheForTesting();
     container = document.createElement('div');
@@ -887,7 +889,7 @@ describe('LogViewer active pod synchronisation', () => {
   });
 
   it('colors API timestamps and container metadata only when showing all containers', async () => {
-    (GetPodContainers as unknown as ViMock).mockResolvedValue(['app', 'sidecar']);
+    (GetLogScopeContainers as unknown as ViMock).mockResolvedValue(['app', 'sidecar']);
     seedLogSnapshot(
       [
         {
@@ -902,7 +904,7 @@ describe('LogViewer active pod synchronisation', () => {
     );
 
     await renderViewer({ resourceKind: 'pod', resourceName: 'api-pod-0' });
-    await waitForMockCalls(GetPodContainers as unknown as ViMock, 1);
+    await waitForMockCalls(GetLogScopeContainers as unknown as ViMock, 1);
 
     const allMetadataSpans = Array.from(
       container.querySelectorAll('.pod-log-line .pod-log-metadata')
@@ -1130,7 +1132,7 @@ describe('LogViewer active pod synchronisation', () => {
   });
 
   it('renders ANSI-colored segments by default and strips them when disabled', async () => {
-    (GetPodContainers as unknown as ViMock).mockResolvedValue(['app']);
+    (GetLogScopeContainers as unknown as ViMock).mockResolvedValue(['app']);
     seedLogSnapshot(
       [
         {
@@ -1150,7 +1152,7 @@ describe('LogViewer active pod synchronisation', () => {
       activePodNames: ['api'],
       panelId: 'obj:test:pod:team-a:api',
     });
-    await waitForMockCalls(GetPodContainers as unknown as ViMock, 1);
+    await waitForMockCalls(GetLogScopeContainers as unknown as ViMock, 1);
     await flushAsync();
 
     const ansiButton = container.querySelector<HTMLButtonElement>(
@@ -1173,7 +1175,7 @@ describe('LogViewer active pod synchronisation', () => {
   });
 
   it('auto-selects the only container for single pod logs', async () => {
-    (GetPodContainers as unknown as ViMock).mockResolvedValue(['app']);
+    (GetLogScopeContainers as unknown as ViMock).mockResolvedValue(['app']);
     seedLogSnapshot(
       [
         {
@@ -1193,7 +1195,7 @@ describe('LogViewer active pod synchronisation', () => {
       activePodNames: ['api'],
     });
 
-    await waitForMockCalls(GetPodContainers as unknown as ViMock, 1);
+    await waitForMockCalls(GetLogScopeContainers as unknown as ViMock, 1);
     await flushAsync();
 
     const lines = Array.from(container.querySelectorAll('.pod-log-line')).map((el) =>
@@ -1203,7 +1205,7 @@ describe('LogViewer active pod synchronisation', () => {
   });
 
   it('filters single pod logs by selected container', async () => {
-    (GetPodContainers as unknown as ViMock).mockResolvedValue(['app', 'sidecar (init)']);
+    (GetLogScopeContainers as unknown as ViMock).mockResolvedValue(['app', 'sidecar (init)']);
     seedLogSnapshot(
       [
         {
@@ -1230,15 +1232,14 @@ describe('LogViewer active pod synchronisation', () => {
       activePodNames: ['api'],
     });
 
-    await waitForMockCalls(GetPodContainers as unknown as ViMock, 1);
+    await waitForMockCalls(GetLogScopeContainers as unknown as ViMock, 1);
     await flushAsync();
     expect(getLogStreamScopeParams(buildLogScope('team-a:pod:api'))).toBeUndefined();
     expect(mockModules.orchestrator.restartStreamingDomain).not.toHaveBeenCalled();
 
-    expect((GetPodContainers as unknown as ViMock).mock.calls[0]).toEqual([
+    expect((GetLogScopeContainers as unknown as ViMock).mock.calls[0]).toEqual([
       'alpha:ctx',
-      'team-a',
-      'api',
+      buildLogScope('team-a:pod:api'),
     ]);
 
     const containerSelect = container.querySelector<HTMLSelectElement>(
@@ -1279,6 +1280,7 @@ describe('LogViewer active pod synchronisation', () => {
   });
 
   it('filters workload logs locally from the multi-select pod/container dropdown', async () => {
+    (GetLogScopeContainers as unknown as ViMock).mockResolvedValue(['app', 'init-db (init)', 'sidecar']);
     setLogViewerPrefs('obj:test:deployment:team-a:api', {
       selectedContainer: '',
       selectedFilters: [],
@@ -1422,7 +1424,7 @@ describe('LogViewer active pod synchronisation', () => {
 
   it('filters single-pod logs when container metadata is clicked', async () => {
     const panelId = 'obj:test:pod:team-a:api';
-    (GetPodContainers as unknown as ViMock).mockResolvedValue(['app', 'sidecar']);
+    (GetLogScopeContainers as unknown as ViMock).mockResolvedValue(['app', 'sidecar']);
 
     seedLogSnapshot(
       [
@@ -1450,7 +1452,7 @@ describe('LogViewer active pod synchronisation', () => {
       activePodNames: ['api'],
       panelId,
     });
-    await waitForMockCalls(GetPodContainers as unknown as ViMock, 1);
+    await waitForMockCalls(GetLogScopeContainers as unknown as ViMock, 1);
 
     const containerButton = await waitForElement(() =>
       container.querySelector<HTMLButtonElement>(
@@ -1469,7 +1471,7 @@ describe('LogViewer active pod synchronisation', () => {
   });
 
   it('labels all-containers mode to indicate debug containers are included', async () => {
-    (GetPodContainers as unknown as ViMock).mockResolvedValue(['app', 'debug-abc (debug)']);
+    (GetLogScopeContainers as unknown as ViMock).mockResolvedValue(['app', 'debug-abc (debug)']);
     seedLogSnapshot(
       [
         {
@@ -1496,7 +1498,7 @@ describe('LogViewer active pod synchronisation', () => {
       activePodNames: ['api'],
     });
 
-    await waitForMockCalls(GetPodContainers as unknown as ViMock, 1);
+    await waitForMockCalls(GetLogScopeContainers as unknown as ViMock, 1);
     await flushAsync();
 
     const containerSelect = container.querySelector<HTMLSelectElement>(
@@ -1507,6 +1509,48 @@ describe('LogViewer active pod synchronisation', () => {
     expect(optionLabels).not.toContain('Init Containers');
     expect(optionLabels).toContain('Containers');
     expect(optionLabels).toContain('debug-abc (debug)');
+  });
+
+  it('shows workload containers even when they have not produced log lines yet', async () => {
+    (GetLogScopeContainers as unknown as ViMock).mockResolvedValue([
+      'aws-node',
+      'aws-eks-nodeagent',
+      'aws-vpc-cni-init (init)',
+    ]);
+    seedLogSnapshot(
+      [
+        {
+          pod: 'aws-node-a',
+          container: 'aws-node',
+          line: 'visible workload log',
+          timestamp: '2024-05-01T12:00:00Z',
+          isInit: false,
+        },
+      ],
+      buildLogScope('kube-system:daemonset:aws-node')
+    );
+
+    await renderViewer({
+      namespace: 'kube-system',
+      resourceName: 'aws-node',
+      resourceKind: 'daemonset',
+      activePodNames: ['aws-node-a', 'aws-node-b'],
+      logScope: buildLogScope('kube-system:daemonset:aws-node'),
+    });
+
+    await waitForMockCalls(GetLogScopeContainers as unknown as ViMock, 1);
+    await flushAsync();
+
+    const containerSelect = container.querySelector<HTMLSelectElement>(
+      '[data-testid="pod-container-dropdown"]'
+    );
+    expect(containerSelect).toBeTruthy();
+    const optionLabels = Array.from(containerSelect?.options ?? []).map((option) => option.text);
+    expect(optionLabels).toContain('Init Containers');
+    expect(optionLabels).toContain('aws-vpc-cni-init');
+    expect(optionLabels).toContain('Containers');
+    expect(optionLabels).toContain('aws-node');
+    expect(optionLabels).toContain('aws-eks-nodeagent');
   });
 
   it('highlights matching substrings in visible log text without changing backend params', async () => {
@@ -2052,6 +2096,7 @@ describe('LogViewer active pod synchronisation', () => {
 
   it('shows active filter chips for the current filter state', async () => {
     const panelId = 'obj:cluster-a:pod:team-a:api';
+    (GetLogScopeContainers as unknown as ViMock).mockResolvedValue(['app']);
     setLogViewerPrefs(panelId, {
       selectedContainer: '',
       selectedFilters: ['pod:web-1', 'container:app'],
@@ -2071,6 +2116,8 @@ describe('LogViewer active pod synchronisation', () => {
     });
 
     await renderViewer({ panelId });
+    await waitForMockCalls(GetLogScopeContainers as unknown as ViMock, 1);
+    await flushAsync();
 
     const chipStrip = container.querySelector('[aria-label="Active log filters"]');
     expect(chipStrip).toBeTruthy();

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.test.tsx
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.test.tsx
@@ -637,7 +637,9 @@ describe('LogViewer active pod synchronisation', () => {
           isInit: false,
         },
       ],
-      warnings: ['Showing logs for 24 of 25 pod/container targets. Refine filters to view more.'],
+      warnings: [
+        'Logs are hidden for 1 containers because the per-tab limit of 24 was reached. Using filters to reduce the number of containers may clear this message.',
+      ],
     });
 
     await renderViewer({ activePodNames: ['web-1'] });
@@ -653,8 +655,8 @@ describe('LogViewer active pod synchronisation', () => {
     });
     await flushAsync();
 
-    expect(container.textContent).toContain(
-      'Showing logs for 24 of 25 pod/container targets. Refine filters to view more.'
+    expect(container.querySelector('[aria-label="Log warnings"]')?.textContent).toContain(
+      'Logs are hidden for 1 containers because the per-tab limit of 24 was reached. Using filters to reduce the number of containers may clear this message.'
     );
   });
 
@@ -680,7 +682,9 @@ describe('LogViewer active pod synchronisation', () => {
       stats: {
         itemCount: 1,
         buildDurationMs: 0,
-        warnings: ['Showing logs for 24 of 52 pod/container targets. Refine filters to view more.'],
+        warnings: [
+          'Logs are hidden for 28 containers because the per-tab limit of 24 was reached. Using filters to reduce the number of containers may clear this message.',
+        ],
       },
       error: null,
       droppedAutoRefreshes: 0,
@@ -694,8 +698,52 @@ describe('LogViewer active pod synchronisation', () => {
     await renderViewer({ activePodNames: ['web-1'], isActive: false });
     await flushAsync();
 
-    expect(container.textContent).toContain(
-      'Showing logs for 24 of 52 pod/container targets. Refine filters to view more.'
+    expect(container.querySelector('[aria-label="Log warnings"]')?.textContent).toContain(
+      'Logs are hidden for 28 containers because the per-tab limit of 24 was reached. Using filters to reduce the number of containers may clear this message.'
+    );
+  });
+
+  it('merges per-tab and global target-cap warnings into a single message', async () => {
+    const generatedAt = Date.now();
+    setScopedDomainState('object-logs', defaultScope, () => ({
+      status: 'ready',
+      data: {
+        entries: [
+          {
+            pod: 'web-1',
+            container: 'app',
+            line: 'line 1',
+            timestamp: '2024-05-01T10:00:00Z',
+            isInit: false,
+          },
+        ],
+        sequence: 2,
+        generatedAt,
+        resetCount: 0,
+        error: null,
+      },
+      stats: {
+        itemCount: 1,
+        buildDurationMs: 0,
+        warnings: [
+          'Logs are hidden for 2 containers because the per-tab limit of 10 was reached. Using filters to reduce the number of containers may clear this message.',
+          'Logs are hidden for 1 containers because the global limit of 15 was reached. Using filters to reduce the number of containers may clear this message.',
+        ],
+      },
+      error: null,
+      droppedAutoRefreshes: 0,
+      scope: defaultScope,
+      lastUpdated: generatedAt,
+      lastAutoRefresh: generatedAt,
+      lastManualRefresh: undefined,
+      isManual: false,
+    }));
+
+    await renderViewer({ activePodNames: ['web-1'], isActive: false });
+    await flushAsync();
+
+    expect(container.querySelector('[aria-label="Log warnings"]')?.textContent).toContain(
+      'Logs are hidden for 3 containers because the per-tab limit of 10 and global limit of 15 were reached. Using filters to reduce the number of containers may clear this message.'
     );
   });
 
@@ -1280,7 +1328,11 @@ describe('LogViewer active pod synchronisation', () => {
   });
 
   it('filters workload logs locally from the multi-select pod/container dropdown', async () => {
-    (GetLogScopeContainers as unknown as ViMock).mockResolvedValue(['app', 'init-db (init)', 'sidecar']);
+    (GetLogScopeContainers as unknown as ViMock).mockResolvedValue([
+      'app',
+      'init-db (init)',
+      'sidecar',
+    ]);
     setLogViewerPrefs('obj:test:deployment:team-a:api', {
       selectedContainer: '',
       selectedFilters: [],

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.tsx
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.tsx
@@ -164,8 +164,26 @@ const formatParsedValue = (value: unknown): string => {
 };
 
 // Build a display label for a container, appending :init for init containers
-const formatContainerLabel = (container: string, isInit: boolean): string =>
-  isInit ? `${container}:init` : container;
+const formatContainerLabel = (container: string, isInit: boolean, isEphemeral: boolean): string =>
+  isInit ? `${container}:init` : isEphemeral ? `${container} (debug)` : container;
+
+const parseContainerLabel = (label: string): { name: string; isInit: boolean; isEphemeral: boolean } => {
+  if (label.endsWith(':init')) {
+    return {
+      name: label.slice(0, -':init'.length),
+      isInit: true,
+      isEphemeral: false,
+    };
+  }
+  if (label.endsWith(' (debug)')) {
+    return {
+      name: label.slice(0, -' (debug)'.length),
+      isInit: false,
+      isEphemeral: true,
+    };
+  }
+  return { name: label, isInit: false, isEphemeral: false };
+};
 
 const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 const escapeCsvCell = (value: string): string =>
@@ -174,16 +192,27 @@ const escapeCsvCell = (value: string): string =>
 const POD_FILTER_PREFIX = 'pod:';
 const INIT_FILTER_PREFIX = 'init:';
 const CONTAINER_FILTER_PREFIX = 'container:';
+const DEBUG_FILTER_PREFIX = 'debug:';
 
 const isInitContainerDisplayName = (container: string): boolean => container.endsWith(' (init)');
+const isDebugContainerDisplayName = (container: string): boolean => container.endsWith(' (debug)');
 
 const toPodFilterValue = (pod: string): string => `${POD_FILTER_PREFIX}${pod}`;
 const toInitContainerFilterValue = (container: string): string =>
   `${INIT_FILTER_PREFIX}${container}`;
 const toContainerFilterValue = (container: string): string =>
   `${CONTAINER_FILTER_PREFIX}${container}`;
-const toContainerFilterValueForKind = (container: string, isInit: boolean): string =>
-  isInit ? toInitContainerFilterValue(container) : toContainerFilterValue(container);
+const toDebugContainerFilterValue = (container: string): string => `${DEBUG_FILTER_PREFIX}${container}`;
+const toContainerFilterValueForKind = (
+  container: string,
+  isInit: boolean,
+  isEphemeral: boolean
+): string =>
+  isInit
+    ? toInitContainerFilterValue(container)
+    : isEphemeral
+      ? toDebugContainerFilterValue(container)
+      : toContainerFilterValue(container);
 
 const summarizeWorkloadSelection = (
   selectedValues: string[],
@@ -201,8 +230,9 @@ const summarizeWorkloadSelection = (
   const initContainerCount = selectedValues.filter((value) =>
     value.startsWith(INIT_FILTER_PREFIX)
   ).length;
-  const containerCount = selectedValues.filter((value) =>
-    value.startsWith(CONTAINER_FILTER_PREFIX)
+  const containerCount = selectedValues.filter(
+    (value) =>
+      value.startsWith(CONTAINER_FILTER_PREFIX) || value.startsWith(DEBUG_FILTER_PREFIX)
   ).length;
   const labels: string[] = [];
 
@@ -235,6 +265,9 @@ const formatSelectedFilterLabel = (
   }
   if (filterValue.startsWith(CONTAINER_FILTER_PREFIX)) {
     return filterValue.substring(CONTAINER_FILTER_PREFIX.length);
+  }
+  if (filterValue.startsWith(DEBUG_FILTER_PREFIX)) {
+    return `${filterValue.substring(DEBUG_FILTER_PREFIX.length)} (debug)`;
   }
   return filterValue;
 };
@@ -409,7 +442,17 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
       ),
     [selectedFilters]
   );
-  const selectedContainerFilterCount = selectedInitContainers.size + selectedRegularContainers.size;
+  const selectedEphemeralContainers = useMemo(
+    () =>
+      new Set(
+        selectedFilters
+          .filter((filterValue) => filterValue.startsWith(DEBUG_FILTER_PREFIX))
+          .map((filterValue) => filterValue.substring(DEBUG_FILTER_PREFIX.length))
+      ),
+    [selectedFilters]
+  );
+  const selectedContainerFilterCount =
+    selectedInitContainers.size + selectedRegularContainers.size + selectedEphemeralContainers.size;
   const handleSelectPodFilter = useCallback(
     (pod: string) => {
       const preservedContainerFilters = selectedFilters.filter(
@@ -423,13 +466,16 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
     [dispatch, selectedFilters]
   );
   const handleSelectContainerFilter = useCallback(
-    (container: string, isInit: boolean) => {
+    (container: string, isInit: boolean, isEphemeral: boolean) => {
       const preservedPodFilters = selectedFilters.filter((filterValue) =>
         filterValue.startsWith(POD_FILTER_PREFIX)
       );
       dispatch({
         type: 'SET_SELECTED_FILTERS',
-        payload: [...preservedPodFilters, toContainerFilterValueForKind(container, isInit)],
+        payload: [
+          ...preservedPodFilters,
+          toContainerFilterValueForKind(container, isInit, isEphemeral),
+        ],
       });
     },
     [dispatch, selectedFilters]
@@ -444,30 +490,13 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
     [caseSensitiveMatches, highlightMatches, inverseMatches, regexMatches, textFilter]
   );
   const backendLogSelection = useMemo(() => {
-    const selectedContainerNames = [
-      ...Array.from(selectedInitContainers),
-      ...Array.from(selectedRegularContainers),
-    ];
-    if (isWorkload) {
-      return {
-        container: '',
-        includeInit: true,
-        includeEphemeral: true,
-      };
-    }
-    if (selectedContainerNames.length === 1) {
-      return {
-        container: selectedContainerNames[0],
-        includeInit: true,
-        includeEphemeral: true,
-      };
-    }
     return {
       container: '',
       includeInit: true,
       includeEphemeral: true,
+      selectedFilters,
     };
-  }, [isWorkload, selectedInitContainers, selectedRegularContainers]);
+  }, [selectedFilters]);
 
   // Reset state when scope changes - do this during render, not in an effect,
   // to avoid causing a re-render that would interrupt streaming startup
@@ -647,6 +676,7 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
           workloadName: isWorkload ? resourceName : '',
           workloadKind: isWorkload ? resourceKindKey : '',
           podName: isWorkload ? '' : podName,
+          selectedFilters: backendLogSelection.selectedFilters,
           container: backendLogSelection.container,
           includeInit: backendLogSelection.includeInit,
           includeEphemeral: backendLogSelection.includeEphemeral,
@@ -964,10 +994,22 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
     options.push(...initContainerOptions);
 
     const regularContainerOptions = containers
-      .filter((container) => !isInitContainerDisplayName(container))
+      .filter(
+        (container) =>
+          !isInitContainerDisplayName(container) && !isDebugContainerDisplayName(container)
+      )
       .map((container) => ({
         value: toContainerFilterValue(getActualContainerName(container)),
         label: container.endsWith(' (debug)') ? container : getActualContainerName(container),
+        group: 'Containers',
+      }))
+      .sort((left, right) => left.label.localeCompare(right.label));
+
+    const debugContainerOptions = containers
+      .filter((container) => isDebugContainerDisplayName(container))
+      .map((container) => ({
+        value: toDebugContainerFilterValue(getActualContainerName(container)),
+        label: container,
         group: 'Containers',
       }))
       .sort((left, right) => left.label.localeCompare(right.label));
@@ -981,6 +1023,7 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
       });
     }
     options.push(...regularContainerOptions);
+    options.push(...debugContainerOptions);
 
     return options;
   }, [containers, isWorkload, workloadPodsForSelector]);
@@ -989,7 +1032,8 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
       selectorOptions.filter(
         (option) =>
           option.value.startsWith(INIT_FILTER_PREFIX) ||
-          option.value.startsWith(CONTAINER_FILTER_PREFIX)
+          option.value.startsWith(CONTAINER_FILTER_PREFIX) ||
+          option.value.startsWith(DEBUG_FILTER_PREFIX)
       ).length,
     [selectorOptions]
   );
@@ -1230,7 +1274,11 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
       const timestampPrefix = timestamp ? `[${timestamp}] ` : '';
 
       if (isWorkload) {
-        const containerLabel = formatContainerLabel(entry.container, entry.isInit);
+        const containerLabel = formatContainerLabel(
+          entry.container,
+          entry.isInit,
+          Boolean(entry.isEphemeral)
+        );
         const formatted = lineContent.trim()
           ? `[${entry.pod}/${containerLabel}] ${lineContent}`
           : lineContent;
@@ -1241,7 +1289,11 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
         selectedContainerFilterCount !== 1 &&
         !(selectedContainerFilterCount === 0 && singlePodSelectableContainerCount === 1)
       ) {
-        const containerLabel = formatContainerLabel(entry.container, entry.isInit);
+        const containerLabel = formatContainerLabel(
+          entry.container,
+          entry.isInit,
+          Boolean(entry.isEphemeral)
+        );
         const formatted = lineContent.trim() ? `[${containerLabel}] ${lineContent}` : lineContent;
         return timestampPrefix + formatted;
       }
@@ -1444,10 +1496,14 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
                   className="pod-log-metadata-button pod-color-text"
                   style={{ '--pod-color': podColor } as React.CSSProperties}
                   onClick={() =>
-                    handleSelectContainerFilter(
-                      container.endsWith(':init') ? container.slice(0, -':init'.length) : container,
-                      container.endsWith(':init')
-                    )
+                    (() => {
+                      const parsedContainerLabel = parseContainerLabel(container);
+                      handleSelectContainerFilter(
+                        parsedContainerLabel.name,
+                        parsedContainerLabel.isInit,
+                        parsedContainerLabel.isEphemeral
+                      );
+                    })()
                   }
                   title={`Show only logs from container ${container}`}
                   aria-label={`Show only logs from container ${container}`}
@@ -1491,12 +1547,14 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
                     type="button"
                     className="pod-log-metadata-button"
                     onClick={() =>
-                      handleSelectContainerFilter(
-                        containerLabel.endsWith(':init')
-                          ? containerLabel.slice(0, -':init'.length)
-                          : containerLabel,
-                        containerLabel.endsWith(':init')
-                      )
+                      (() => {
+                        const parsedContainerLabel = parseContainerLabel(containerLabel);
+                        handleSelectContainerFilter(
+                          parsedContainerLabel.name,
+                          parsedContainerLabel.isInit,
+                          parsedContainerLabel.isEphemeral
+                        );
+                      })()
                     }
                     title={`Show only logs from container ${containerLabel}`}
                     aria-label={`Show only logs from container ${containerLabel}`}
@@ -1850,10 +1908,14 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
             }
             onClick={(event) => {
               event.stopPropagation();
-              handleSelectContainerFilter(item.container!, Boolean(item.isInit));
+              handleSelectContainerFilter(
+                item.container!,
+                Boolean(item.isInit),
+                Boolean(item.isEphemeral)
+              );
             }}
-            title={`Show only logs from container ${formatContainerLabel(item.container, Boolean(item.isInit))}`}
-            aria-label={`Show only logs from container ${formatContainerLabel(item.container, Boolean(item.isInit))}`}
+            title={`Show only logs from container ${formatContainerLabel(item.container, Boolean(item.isInit), Boolean(item.isEphemeral))}`}
+            aria-label={`Show only logs from container ${formatContainerLabel(item.container, Boolean(item.isInit), Boolean(item.isEphemeral))}`}
           >
             {item.container}
           </button>

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.tsx
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.tsx
@@ -504,6 +504,14 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
   const logWarnings = (logSnapshot.stats?.warnings ?? []).filter(
     (warning) => typeof warning === 'string' && warning.trim().length > 0
   );
+  const visibleLogWarnings = useMemo(
+    () =>
+      logWarnings.filter((warning) =>
+        warning.includes('pod/container targets') ||
+        warning.includes('global log stream cap')
+      ),
+    [logWarnings]
+  );
 
   const displayError = snapshotError && !isLogDataUnavailable(snapshotError) ? snapshotError : null;
   const transientStreamError = displayError
@@ -2051,7 +2059,7 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
     <div className="object-panel-tab-content">
       <div className="pod-logs-display">
         <div
-          className={`pod-logs-controls${activeFilterChips.length > 0 ? ' pod-logs-controls--with-active-filters' : ''}`}
+          className={`pod-logs-controls${activeFilterChips.length > 0 || visibleLogWarnings.length > 0 ? ' pod-logs-controls--with-active-filters' : ''}`}
         >
           <div className="pod-logs-controls-left">
             {/* Pod / container selector */}
@@ -2269,17 +2277,19 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
           </div>
         </div>
 
-        {activeFilterChips.length > 0 && (
+        {(activeFilterChips.length > 0 || visibleLogWarnings.length > 0) && (
           <div className="pod-logs-active-filters" aria-label="Active log filters">
-            <button
-              type="button"
-              className="pod-logs-filter-chip pod-logs-filter-chip--clear-all"
-              onClick={handleClearAllFilters}
-              aria-label="Clear all filters"
-              title="Clear all filters"
-            >
-              Clear all
-            </button>
+            {activeFilterChips.length > 0 && (
+              <button
+                type="button"
+                className="pod-logs-filter-chip pod-logs-filter-chip--clear-all"
+                onClick={handleClearAllFilters}
+                aria-label="Clear all filters"
+                title="Clear all filters"
+              >
+                Clear all
+              </button>
+            )}
             {activeFilterChips.map((chip) => (
               <span key={chip.key} className="pod-logs-filter-chip">
                 <span className="pod-logs-filter-chip-label">{chip.label}</span>
@@ -2292,6 +2302,16 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
                 >
                   ×
                 </button>
+              </span>
+            ))}
+            {visibleLogWarnings.map((warning) => (
+              <span
+                key={warning}
+                className="pod-logs-filter-chip"
+                title={warning}
+                aria-label={warning}
+              >
+                <span className="pod-logs-filter-chip-label">{warning}</span>
               </span>
             ))}
           </div>

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.tsx
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.tsx
@@ -6,7 +6,7 @@
  * Uses a reducer for state management.
  */
 import React, { useReducer, useEffect, useRef, useMemo, useCallback } from 'react';
-import { GetPodContainers, LogFetcher } from '@wailsjs/go/backend/App';
+import { GetLogScopeContainers, LogFetcher } from '@wailsjs/go/backend/App';
 import GridTable, {
   type GridColumnDefinition,
   GRIDTABLE_VIRTUALIZATION_DEFAULT,
@@ -923,10 +923,6 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
         .slice()
         .sort();
       dispatch({ type: 'SET_AVAILABLE_PODS', payload: pods });
-      const containersList = Array.from(
-        new Set(logEntries.map((entry) => entry.container).filter(Boolean))
-      ).sort();
-      dispatch({ type: 'SET_AVAILABLE_CONTAINERS', payload: containersList });
     }
   }, [isWorkload, logEntries, normalizedActivePods]);
 
@@ -948,29 +944,14 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
       );
     }
 
-    const initContainerOptions = isWorkload
-      ? Array.from(
-          new Set(
-            logEntries
-              .filter((entry) => entry.isInit && entry.container)
-              .map((entry) => entry.container)
-              .filter(Boolean)
-          )
-        )
-          .sort()
-          .map((container) => ({
-            value: toInitContainerFilterValue(container),
-            label: container,
-            group: 'Init Containers',
-          }))
-      : containers
-          .filter((container) => isInitContainerDisplayName(container))
-          .map((container) => ({
-            value: toInitContainerFilterValue(getActualContainerName(container)),
-            label: getActualContainerName(container),
-            group: 'Init Containers',
-          }))
-          .sort((left, right) => left.label.localeCompare(right.label));
+    const initContainerOptions = containers
+      .filter((container) => isInitContainerDisplayName(container))
+      .map((container) => ({
+        value: toInitContainerFilterValue(getActualContainerName(container)),
+        label: getActualContainerName(container),
+        group: 'Init Containers',
+      }))
+      .sort((left, right) => left.label.localeCompare(right.label));
 
     if (initContainerOptions.length > 0) {
       options.push({
@@ -982,29 +963,14 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
     }
     options.push(...initContainerOptions);
 
-    const regularContainerOptions = isWorkload
-      ? Array.from(
-          new Set(
-            logEntries
-              .filter((entry) => !entry.isInit && entry.container)
-              .map((entry) => entry.container)
-              .filter(Boolean)
-          )
-        )
-          .sort()
-          .map((container) => ({
-            value: toContainerFilterValue(container),
-            label: container,
-            group: 'Containers',
-          }))
-      : containers
-          .filter((container) => !isInitContainerDisplayName(container))
-          .map((container) => ({
-            value: toContainerFilterValue(getActualContainerName(container)),
-            label: container.endsWith(' (debug)') ? container : getActualContainerName(container),
-            group: 'Containers',
-          }))
-          .sort((left, right) => left.label.localeCompare(right.label));
+    const regularContainerOptions = containers
+      .filter((container) => !isInitContainerDisplayName(container))
+      .map((container) => ({
+        value: toContainerFilterValue(getActualContainerName(container)),
+        label: container.endsWith(' (debug)') ? container : getActualContainerName(container),
+        group: 'Containers',
+      }))
+      .sort((left, right) => left.label.localeCompare(right.label));
 
     if (isWorkload || containers.length > 0) {
       options.push({
@@ -1017,7 +983,7 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
     options.push(...regularContainerOptions);
 
     return options;
-  }, [containers, isWorkload, logEntries, workloadPodsForSelector]);
+  }, [containers, isWorkload, workloadPodsForSelector]);
   const singlePodSelectableContainerCount = useMemo(
     () =>
       selectorOptions.filter(
@@ -1170,6 +1136,14 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
     if (selectedFilters.length === 0) {
       return;
     }
+    const hasSelectedContainerFilters = selectedFilters.some(
+      (filterValue) =>
+        filterValue.startsWith(INIT_FILTER_PREFIX) ||
+        filterValue.startsWith(CONTAINER_FILTER_PREFIX)
+    );
+    if (hasSelectedContainerFilters && containers.length === 0) {
+      return;
+    }
     const validFilterValues = new Set(
       selectorOptions.filter((option) => option.group !== 'header').map((option) => option.value)
     );
@@ -1182,7 +1156,7 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
     if (nextSelectedFilters.length !== selectedFilters.length) {
       dispatch({ type: 'SET_SELECTED_FILTERS', payload: nextSelectedFilters });
     }
-  }, [selectedFilters, selectorOptions]);
+  }, [containers.length, selectedFilters, selectorOptions]);
 
   // Helper functions
   const unavailableLogMessage =
@@ -1568,25 +1542,29 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
     };
   }, []);
 
-  // Fetch containers for single pod
+  // Fetch container inventory for the current log scope.
   useEffect(() => {
-    if (isWorkload || !namespace || !podName) return;
+    if (!logScope) {
+      dispatch({ type: 'SET_CONTAINERS', payload: [] });
+      dispatch({ type: 'SET_SELECTED_CONTAINER', payload: '' });
+      return;
+    }
 
     let isCancelled = false;
     const fetchContainers = async () => {
       try {
-        const containerList = await GetPodContainers(resolvedClusterId, namespace, podName);
+        const containerList = await GetLogScopeContainers(resolvedClusterId, logScope);
 
         if (isCancelled) return;
 
         if (!containerList || containerList.length === 0) {
           dispatch({ type: 'SET_CONTAINERS', payload: [] });
-          dispatch({ type: 'SET_SELECTED_CONTAINER', payload: '' });
+          dispatch({ type: 'SET_SELECTED_CONTAINER', payload: isWorkload ? '' : ALL_CONTAINERS });
           return;
         }
 
         dispatch({ type: 'SET_CONTAINERS', payload: containerList });
-        dispatch({ type: 'SET_SELECTED_CONTAINER', payload: ALL_CONTAINERS });
+        dispatch({ type: 'SET_SELECTED_CONTAINER', payload: isWorkload ? '' : ALL_CONTAINERS });
       } catch (err) {
         if (isCancelled) return;
         console.warn('Failed to fetch containers:', err);
@@ -1602,7 +1580,7 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
     return () => {
       isCancelled = true;
     };
-  }, [namespace, podName, isWorkload, resolvedClusterId]);
+  }, [isWorkload, logScope, resolvedClusterId]);
 
   // --- Scroll position and tail-follow ---
   //

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.tsx
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.tsx
@@ -167,7 +167,9 @@ const formatParsedValue = (value: unknown): string => {
 const formatContainerLabel = (container: string, isInit: boolean, isEphemeral: boolean): string =>
   isInit ? `${container}:init` : isEphemeral ? `${container} (debug)` : container;
 
-const parseContainerLabel = (label: string): { name: string; isInit: boolean; isEphemeral: boolean } => {
+const parseContainerLabel = (
+  label: string
+): { name: string; isInit: boolean; isEphemeral: boolean } => {
   if (label.endsWith(':init')) {
     return {
       name: label.slice(0, -':init'.length),
@@ -193,6 +195,52 @@ const POD_FILTER_PREFIX = 'pod:';
 const INIT_FILTER_PREFIX = 'init:';
 const CONTAINER_FILTER_PREFIX = 'container:';
 const DEBUG_FILTER_PREFIX = 'debug:';
+const TARGET_LIMIT_WARNING_PATTERN =
+  /^Logs are hidden for (\d+) containers because the (per-tab|global) limit of (\d+) was reached\. Using filters to reduce the number of containers may clear this message\.$/;
+
+const mergeTargetLimitWarnings = (warnings: string[]): string[] => {
+  if (warnings.length < 2) {
+    return warnings;
+  }
+
+  const merged: string[] = [];
+  let perTabMatch: RegExpMatchArray | null = null;
+  let globalMatch: RegExpMatchArray | null = null;
+
+  for (const warning of warnings) {
+    const match = warning.match(TARGET_LIMIT_WARNING_PATTERN);
+    if (!match) {
+      merged.push(warning);
+      continue;
+    }
+    if (match[2] === 'per-tab') {
+      perTabMatch = match;
+      continue;
+    }
+    if (match[2] === 'global') {
+      globalMatch = match;
+      continue;
+    }
+    merged.push(warning);
+  }
+
+  if (perTabMatch && globalMatch) {
+    const hiddenCount = Number.parseInt(perTabMatch[1], 10) + Number.parseInt(globalMatch[1], 10);
+    merged.unshift(
+      `Logs are hidden for ${hiddenCount} containers because the per-tab limit of ${perTabMatch[3]} and global limit of ${globalMatch[3]} were reached. Using filters to reduce the number of containers may clear this message.`
+    );
+    return merged;
+  }
+
+  if (perTabMatch) {
+    merged.unshift(perTabMatch[0]);
+  }
+  if (globalMatch) {
+    merged.unshift(globalMatch[0]);
+  }
+
+  return merged;
+};
 
 const isInitContainerDisplayName = (container: string): boolean => container.endsWith(' (init)');
 const isDebugContainerDisplayName = (container: string): boolean => container.endsWith(' (debug)');
@@ -202,7 +250,8 @@ const toInitContainerFilterValue = (container: string): string =>
   `${INIT_FILTER_PREFIX}${container}`;
 const toContainerFilterValue = (container: string): string =>
   `${CONTAINER_FILTER_PREFIX}${container}`;
-const toDebugContainerFilterValue = (container: string): string => `${DEBUG_FILTER_PREFIX}${container}`;
+const toDebugContainerFilterValue = (container: string): string =>
+  `${DEBUG_FILTER_PREFIX}${container}`;
 const toContainerFilterValueForKind = (
   container: string,
   isInit: boolean,
@@ -231,8 +280,7 @@ const summarizeWorkloadSelection = (
     value.startsWith(INIT_FILTER_PREFIX)
   ).length;
   const containerCount = selectedValues.filter(
-    (value) =>
-      value.startsWith(CONTAINER_FILTER_PREFIX) || value.startsWith(DEBUG_FILTER_PREFIX)
+    (value) => value.startsWith(CONTAINER_FILTER_PREFIX) || value.startsWith(DEBUG_FILTER_PREFIX)
   ).length;
   const labels: string[] = [];
 
@@ -535,9 +583,10 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
   );
   const visibleLogWarnings = useMemo(
     () =>
-      logWarnings.filter((warning) =>
-        warning.includes('pod/container targets') ||
-        warning.includes('global log stream cap')
+      mergeTargetLimitWarnings(
+        logWarnings.filter(
+          (warning) => warning.includes('per-tab limit') || warning.includes('global limit')
+        )
       ),
     [logWarnings]
   );
@@ -737,6 +786,7 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
       backendLogSelection.container,
       backendLogSelection.includeEphemeral,
       backendLogSelection.includeInit,
+      backendLogSelection.selectedFilters,
       resolvedClusterId,
     ]
   );
@@ -2099,7 +2149,7 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
     <div className="object-panel-tab-content">
       <div className="pod-logs-display">
         <div
-          className={`pod-logs-controls${activeFilterChips.length > 0 || visibleLogWarnings.length > 0 ? ' pod-logs-controls--with-active-filters' : ''}`}
+          className={`pod-logs-controls${activeFilterChips.length > 0 ? ' pod-logs-controls--with-active-filters' : ''}`}
         >
           <div className="pod-logs-controls-left">
             {/* Pod / container selector */}
@@ -2317,7 +2367,7 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
           </div>
         </div>
 
-        {(activeFilterChips.length > 0 || visibleLogWarnings.length > 0) && (
+        {activeFilterChips.length > 0 && (
           <div className="pod-logs-active-filters" aria-label="Active log filters">
             {activeFilterChips.length > 0 && (
               <button
@@ -2344,16 +2394,12 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
                 </button>
               </span>
             ))}
-            {visibleLogWarnings.map((warning) => (
-              <span
-                key={warning}
-                className="pod-logs-filter-chip"
-                title={warning}
-                aria-label={warning}
-              >
-                <span className="pod-logs-filter-chip-label">{warning}</span>
-              </span>
-            ))}
+          </div>
+        )}
+
+        {visibleLogWarnings.length > 0 && (
+          <div className="pod-logs-warning-bar" aria-label="Log warnings">
+            {visibleLogWarnings.join(' ')}
           </div>
         )}
 

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.tsx
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.tsx
@@ -989,6 +989,14 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
       styles.getPropertyValue('--log-pod-color-10').trim(),
       styles.getPropertyValue('--log-pod-color-11').trim(),
       styles.getPropertyValue('--log-pod-color-12').trim(),
+      styles.getPropertyValue('--log-pod-color-13').trim(),
+      styles.getPropertyValue('--log-pod-color-14').trim(),
+      styles.getPropertyValue('--log-pod-color-15').trim(),
+      styles.getPropertyValue('--log-pod-color-16').trim(),
+      styles.getPropertyValue('--log-pod-color-17').trim(),
+      styles.getPropertyValue('--log-pod-color-18').trim(),
+      styles.getPropertyValue('--log-pod-color-19').trim(),
+      styles.getPropertyValue('--log-pod-color-20').trim(),
     ];
     const fallbackColor = styles.getPropertyValue('--log-pod-color-fallback').trim();
     return buildStablePodColorMap(availablePods, palette, fallbackColor);

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/hooks/useLogFiltering.ts
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/hooks/useLogFiltering.ts
@@ -109,15 +109,26 @@ export function useLogFiltering({
           .filter((filterValue) => filterValue.startsWith('container:'))
           .map((filterValue) => filterValue.substring(10))
       );
+      const selectedDebugContainers = new Set(
+        selectedFilters
+          .filter((filterValue) => filterValue.startsWith('debug:'))
+          .map((filterValue) => filterValue.substring(6))
+      );
 
       if (isWorkload && selectedPods.size > 0) {
         entries = entries.filter((entry) => selectedPods.has(entry.pod));
       }
-      if (selectedInitContainers.size > 0 || selectedContainers.size > 0) {
+      if (
+        selectedInitContainers.size > 0 ||
+        selectedContainers.size > 0 ||
+        selectedDebugContainers.size > 0
+      ) {
         entries = entries.filter((entry) =>
           entry.isInit
             ? selectedInitContainers.has(entry.container)
-            : selectedContainers.has(entry.container)
+            : entry.isEphemeral
+              ? selectedDebugContainers.has(entry.container)
+              : selectedContainers.has(entry.container)
         );
       }
     }
@@ -185,6 +196,7 @@ export function useLogFiltering({
           pod: isWorkload ? entry.pod : undefined,
           container: entry.container,
           isInit: entry.isInit,
+          isEphemeral: entry.isEphemeral,
           seq: entry._seq,
         });
       } catch {

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/logStreamScopeParamsCache.ts
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/logStreamScopeParamsCache.ts
@@ -10,21 +10,33 @@
 
 export interface LogStreamScopeParams {
   container?: string;
+  selectedFilters?: string[];
 }
 
 const cache = new Map<string, LogStreamScopeParams>();
 
 const normalize = (params: LogStreamScopeParams): LogStreamScopeParams => {
   const container = params.container?.trim() ?? '';
+  const selectedFilters = Array.from(
+    new Set(
+      (params.selectedFilters ?? [])
+        .map((value) => value.trim())
+        .filter((value) => value.length > 0)
+    )
+  );
   const next: LogStreamScopeParams = {};
   if (container) {
     next.container = container;
+  }
+  if (selectedFilters.length > 0) {
+    next.selectedFilters = selectedFilters;
   }
   return next;
 };
 
 const areEqual = (left: LogStreamScopeParams, right: LogStreamScopeParams): boolean =>
-  (left.container ?? '') === (right.container ?? '');
+  (left.container ?? '') === (right.container ?? '') &&
+  JSON.stringify(left.selectedFilters ?? []) === JSON.stringify(right.selectedFilters ?? []);
 
 export const getLogStreamScopeParams = (scope: string): LogStreamScopeParams | undefined =>
   cache.get(scope);

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/logViewerReducer.ts
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/logViewerReducer.ts
@@ -15,6 +15,7 @@ export interface ParsedLogEntry {
   pod?: string;
   container?: string;
   isInit?: boolean;
+  isEphemeral?: boolean;
   timestamp?: string;
   rawLine: string;
   lineNumber: number;

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/podColors.test.ts
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/podColors.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { buildStablePodColorMap, hashPodColorIndex } from './podColors';
 
 describe('podColors', () => {
-  const palette = Array.from({ length: 12 }, (_, index) => `color-${index + 1}`);
+  const palette = Array.from({ length: 20 }, (_, index) => `color-${index + 1}`);
 
   it('keeps a pod on the same color when the visible pod set changes', () => {
     const first = buildStablePodColorMap(['api-7', 'api-1'], palette, 'fallback');
@@ -17,7 +17,7 @@ describe('podColors', () => {
     expect(first['api-1']).toBe(second['api-1']);
   });
 
-  it('wraps onto the existing 12-color palette deterministically', () => {
+  it('wraps onto the existing 20-color palette deterministically', () => {
     const podNames = Array.from({ length: 20 }, (_, index) => `pod-${index + 1}`);
     const colorMap = buildStablePodColorMap(podNames, palette, 'fallback');
 

--- a/frontend/src/ui/settings/Settings.tsx
+++ b/frontend/src/ui/settings/Settings.tsx
@@ -60,9 +60,19 @@ import {
   setObjectPanelLayoutDefaults,
   getLogBufferMaxSize,
   setLogBufferMaxSize,
+  getLogTargetGlobalLimit,
+  getLogTargetPerScopeLimit,
+  setLogTargetGlobalLimit,
+  setLogTargetPerScopeLimit,
   LOG_BUFFER_MIN_SIZE,
   LOG_BUFFER_MAX_SIZE,
   LOG_BUFFER_DEFAULT_SIZE,
+  LOG_TARGET_GLOBAL_DEFAULT,
+  LOG_TARGET_GLOBAL_MAX,
+  LOG_TARGET_GLOBAL_MIN,
+  LOG_TARGET_PER_SCOPE_DEFAULT,
+  LOG_TARGET_PER_SCOPE_MAX,
+  LOG_TARGET_PER_SCOPE_MIN,
   type ObjectPanelPosition,
   type ObjectPanelLayoutDefaults,
 } from '@core/settings/appPreferences';
@@ -107,6 +117,12 @@ function Settings({ onClose }: SettingsProps) {
   // cache on blur/commit, where the normalizer clamps the final value.
   const [logBufferMaxSizeInput, setLogBufferMaxSizeInput] = useState<string>(() =>
     String(getLogBufferMaxSize())
+  );
+  const [logTargetPerScopeLimitInput, setLogTargetPerScopeLimitInput] = useState<string>(() =>
+    String(getLogTargetPerScopeLimit())
+  );
+  const [logTargetGlobalLimitInput, setLogTargetGlobalLimitInput] = useState<string>(() =>
+    String(getLogTargetGlobalLimit())
   );
   // Track kubeconfig search paths for the settings panel.
   const [kubeconfigPaths, setKubeconfigPaths] = useState<string[]>([]);
@@ -251,6 +267,9 @@ function Settings({ onClose }: SettingsProps) {
       setObjectPanelPositionState(getDefaultObjectPanelPosition());
       const freshLayout = getObjectPanelLayoutDefaults();
       setPanelLayout(freshLayout);
+      setLogBufferMaxSizeInput(String(getLogBufferMaxSize()));
+      setLogTargetPerScopeLimitInput(String(getLogTargetPerScopeLimit()));
+      setLogTargetGlobalLimitInput(String(getLogTargetGlobalLimit()));
       setPanelLayoutInputs({
         dockedRightWidth: String(freshLayout.dockedRightWidth),
         dockedBottomHeight: String(freshLayout.dockedBottomHeight),
@@ -323,6 +342,28 @@ function Settings({ onClose }: SettingsProps) {
     const clamped = Math.max(LOG_BUFFER_MIN_SIZE, Math.min(LOG_BUFFER_MAX_SIZE, parsed));
     setLogBufferMaxSize(clamped);
     setLogBufferMaxSizeInput(String(clamped));
+  };
+
+  const commitLogTargetPerScopeLimit = (raw: string) => {
+    const parsed = Number.parseInt(raw, 10);
+    if (!Number.isFinite(parsed)) {
+      setLogTargetPerScopeLimitInput(String(getLogTargetPerScopeLimit()));
+      return;
+    }
+    const clamped = Math.max(LOG_TARGET_PER_SCOPE_MIN, Math.min(LOG_TARGET_PER_SCOPE_MAX, parsed));
+    setLogTargetPerScopeLimit(clamped);
+    setLogTargetPerScopeLimitInput(String(clamped));
+  };
+
+  const commitLogTargetGlobalLimit = (raw: string) => {
+    const parsed = Number.parseInt(raw, 10);
+    if (!Number.isFinite(parsed)) {
+      setLogTargetGlobalLimitInput(String(getLogTargetGlobalLimit()));
+      return;
+    }
+    const clamped = Math.max(LOG_TARGET_GLOBAL_MIN, Math.min(LOG_TARGET_GLOBAL_MAX, parsed));
+    setLogTargetGlobalLimit(clamped);
+    setLogTargetGlobalLimitInput(String(clamped));
   };
 
   const handleObjectPanelPositionChange = (position: ObjectPanelPosition) => {
@@ -1698,6 +1739,71 @@ function Settings({ onClose }: SettingsProps) {
                     <p style={{ marginTop: '1em' }}>
                       Range {LOG_BUFFER_MIN_SIZE}-{LOG_BUFFER_MAX_SIZE}, default{' '}
                       {LOG_BUFFER_DEFAULT_SIZE}
+                    </p>
+                  </>
+                }
+                variant="dark"
+              />
+            </div>
+            <div className="setting-item setting-item-inline">
+              <label htmlFor="log-target-per-scope-limit">Max log targets per tab </label>
+              <input
+                type="number"
+                id="log-target-per-scope-limit"
+                min={LOG_TARGET_PER_SCOPE_MIN}
+                max={LOG_TARGET_PER_SCOPE_MAX}
+                step={1}
+                value={logTargetPerScopeLimitInput}
+                onChange={(e) => setLogTargetPerScopeLimitInput(e.target.value)}
+                onBlur={(e) => commitLogTargetPerScopeLimit(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    commitLogTargetPerScopeLimit((e.target as HTMLInputElement).value);
+                  }
+                }}
+              />
+              <Tooltip
+                content={
+                  <>
+                    <p>
+                      Max pod/container log targets a single Logs tab can stream or fetch at once.
+                    </p>
+                    <p style={{ marginTop: '1em' }}>
+                      Range {LOG_TARGET_PER_SCOPE_MIN}-{LOG_TARGET_PER_SCOPE_MAX}, default{' '}
+                      {LOG_TARGET_PER_SCOPE_DEFAULT}
+                    </p>
+                  </>
+                }
+                variant="dark"
+              />
+            </div>
+            <div className="setting-item setting-item-inline">
+              <label htmlFor="log-target-global-limit">Max log targets across tabs </label>
+              <input
+                type="number"
+                id="log-target-global-limit"
+                min={LOG_TARGET_GLOBAL_MIN}
+                max={LOG_TARGET_GLOBAL_MAX}
+                step={1}
+                value={logTargetGlobalLimitInput}
+                onChange={(e) => setLogTargetGlobalLimitInput(e.target.value)}
+                onBlur={(e) => commitLogTargetGlobalLimit(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    commitLogTargetGlobalLimit((e.target as HTMLInputElement).value);
+                  }
+                }}
+              />
+              <Tooltip
+                content={
+                  <>
+                    <p>
+                      Max pod/container log targets shared across all open Logs tabs. Lower values
+                      reduce overall load but can cap large workloads sooner.
+                    </p>
+                    <p style={{ marginTop: '1em' }}>
+                      Range {LOG_TARGET_GLOBAL_MIN}-{LOG_TARGET_GLOBAL_MAX}, default{' '}
+                      {LOG_TARGET_GLOBAL_DEFAULT}
                     </p>
                   </>
                 }

--- a/frontend/styles/themes/dark.css
+++ b/frontend/styles/themes/dark.css
@@ -203,12 +203,20 @@
   --log-pod-color-4: #c084fc;
   --log-pod-color-5: #22d3ee;
   --log-pod-color-6: #a3e635;
-  --log-pod-color-7: #fbbf24;
-  --log-pod-color-8: #f472b6;
+  --log-pod-color-7: #f472b6;
+  --log-pod-color-8: #818cf8;
   --log-pod-color-9: #2dd4bf;
-  --log-pod-color-10: #a8a29e;
-  --log-pod-color-11: #94a3b8;
-  --log-pod-color-12: #fb7185;
+  --log-pod-color-10: #f87171;
+  --log-pod-color-11: #facc15;
+  --log-pod-color-12: #e879f9;
+  --log-pod-color-13: #a78bfa;
+  --log-pod-color-14: #5eead4;
+  --log-pod-color-15: #fdba74;
+  --log-pod-color-16: #fb7185;
+  --log-pod-color-17: #818cf8;
+  --log-pod-color-18: #4ade80;
+  --log-pod-color-19: #38bdf8;
+  --log-pod-color-20: #d946ef;
   --log-pod-color-fallback: var(--color-base-400);
 
   /* Dropdown */

--- a/frontend/styles/themes/light.css
+++ b/frontend/styles/themes/light.css
@@ -201,12 +201,20 @@
   --log-pod-color-4: #9333ea;
   --log-pod-color-5: #0891b2;
   --log-pod-color-6: #65a30d;
-  --log-pod-color-7: #d97706;
-  --log-pod-color-8: #db2777;
-  --log-pod-color-9: #0d9488;
-  --log-pod-color-10: #78716c;
-  --log-pod-color-11: #475569;
-  --log-pod-color-12: #e11d48;
+  --log-pod-color-7: #db2777;
+  --log-pod-color-8: #4f46e5;
+  --log-pod-color-9: #0f766e;
+  --log-pod-color-10: #dc2626;
+  --log-pod-color-11: #ca8a04;
+  --log-pod-color-12: #c026d3;
+  --log-pod-color-13: #7c3aed;
+  --log-pod-color-14: #0f766e;
+  --log-pod-color-15: #b45309;
+  --log-pod-color-16: #be123c;
+  --log-pod-color-17: #4338ca;
+  --log-pod-color-18: #15803d;
+  --log-pod-color-19: #0ea5e9;
+  --log-pod-color-20: #a21caf;
   --log-pod-color-fallback: var(--color-base-500);
 
   /* Dropdown */

--- a/frontend/wailsjs/go/backend/App.d.ts
+++ b/frontend/wailsjs/go/backend/App.d.ts
@@ -112,6 +112,8 @@ export function GetKubeconfigs():Promise<Array<types.KubeconfigInfo>>;
 
 export function GetLimitRange(arg1:string,arg2:string,arg3:string):Promise<types.LimitRangeDetails>;
 
+export function GetLogScopeContainers(arg1:string,arg2:string):Promise<Array<string>>;
+
 export function GetLogs():Promise<Array<backend.LogEntry>>;
 
 export function GetMutatingWebhookConfiguration(arg1:string,arg2:string):Promise<types.MutatingWebhookConfigurationDetails>;
@@ -241,6 +243,10 @@ export function SetKubeconfigSearchPaths(arg1:Array<string>):Promise<void>;
 export function SetLinkColor(arg1:string,arg2:string):Promise<void>;
 
 export function SetLogBufferMaxSize(arg1:number):Promise<void>;
+
+export function SetLogTargetGlobalLimit(arg1:number):Promise<void>;
+
+export function SetLogTargetPerScopeLimit(arg1:number):Promise<void>;
 
 export function SetLogsPanelVisible(arg1:boolean):Promise<void>;
 

--- a/frontend/wailsjs/go/backend/App.js
+++ b/frontend/wailsjs/go/backend/App.js
@@ -214,6 +214,10 @@ export function GetLimitRange(arg1, arg2, arg3) {
   return window['go']['backend']['App']['GetLimitRange'](arg1, arg2, arg3);
 }
 
+export function GetLogScopeContainers(arg1, arg2) {
+  return window['go']['backend']['App']['GetLogScopeContainers'](arg1, arg2);
+}
+
 export function GetLogs() {
   return window['go']['backend']['App']['GetLogs']();
 }
@@ -472,6 +476,14 @@ export function SetLinkColor(arg1, arg2) {
 
 export function SetLogBufferMaxSize(arg1) {
   return window['go']['backend']['App']['SetLogBufferMaxSize'](arg1);
+}
+
+export function SetLogTargetGlobalLimit(arg1) {
+  return window['go']['backend']['App']['SetLogTargetGlobalLimit'](arg1);
+}
+
+export function SetLogTargetPerScopeLimit(arg1) {
+  return window['go']['backend']['App']['SetLogTargetPerScopeLimit'](arg1);
 }
 
 export function SetLogsPanelVisible(arg1) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -2542,6 +2542,7 @@ export namespace types {
 	    podFilter?: string;
 	    podInclude?: string;
 	    podExclude?: string;
+	    selectedFilters?: string[];
 	    container?: string;
 	    includeInit?: boolean;
 	    includeEphemeral?: boolean;
@@ -2566,6 +2567,7 @@ export namespace types {
 	        this.podFilter = source["podFilter"];
 	        this.podInclude = source["podInclude"];
 	        this.podExclude = source["podExclude"];
+	        this.selectedFilters = source["selectedFilters"];
 	        this.container = source["container"];
 	        this.includeInit = source["includeInit"];
 	        this.includeEphemeral = source["includeEphemeral"];
@@ -2583,6 +2585,7 @@ export namespace types {
 	    container: string;
 	    line: string;
 	    isInit: boolean;
+	    isEphemeral?: boolean;
 	
 	    static createFrom(source: any = {}) {
 	        return new PodLogEntry(source);
@@ -2595,6 +2598,7 @@ export namespace types {
 	        this.container = source["container"];
 	        this.line = source["line"];
 	        this.isInit = source["isInit"];
+	        this.isEphemeral = source["isEphemeral"];
 	    }
 	}
 	export class LogFetchResponse {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -745,6 +745,8 @@ export namespace types {
 	    refreshBackgroundClustersEnabled: boolean;
 	    metricsRefreshIntervalMs: number;
 	    logBufferMaxSize: number;
+	    logTargetPerScopeLimit: number;
+	    logTargetGlobalLimit: number;
 	    gridTablePersistenceMode: string;
 	    defaultObjectPanelPosition: string;
 	    objectPanelDockedRightWidth: number;
@@ -778,6 +780,8 @@ export namespace types {
 	        this.refreshBackgroundClustersEnabled = source["refreshBackgroundClustersEnabled"];
 	        this.metricsRefreshIntervalMs = source["metricsRefreshIntervalMs"];
 	        this.logBufferMaxSize = source["logBufferMaxSize"];
+	        this.logTargetPerScopeLimit = source["logTargetPerScopeLimit"];
+	        this.logTargetGlobalLimit = source["logTargetGlobalLimit"];
 	        this.gridTablePersistenceMode = source["gridTablePersistenceMode"];
 	        this.defaultObjectPanelPosition = source["defaultObjectPanelPosition"];
 	        this.objectPanelDockedRightWidth = source["objectPanelDockedRightWidth"];


### PR DESCRIPTION
- Added configurable log target limits in Settings
- Frontend pod/container selections participate in backend target resolution before limits are applied
- Fixed log streams so active tabs react when global target-limit rebalancing changes their allowed targets
- Improved target-limit warnings with a dedicated warning bar
