### PR TITLE
fix: honor klog -stderrthreshold even when -logtostderr is true

### DIFF
--- a/backend/internal/errorcapture/error_capture.go
+++ b/backend/internal/errorcapture/error_capture.go
@@ -68,6 +68,11 @@ func Init() {
 
 	klogFlags := flag.NewFlagSet("klog", flag.ContinueOnError)
 	klog.InitFlags(klogFlags)
+	// Opt into the new klog behavior so that -stderrthreshold is honored even
+	// when -logtostderr=true (the default).
+	// Ref: kubernetes/klog#212, kubernetes/klog#432
+	klogFlags.Set("legacy_stderr_threshold_behavior", "false")
+	klogFlags.Set("stderrthreshold", "INFO")
 	klogFlags.Set("logtostderr", "true")
 	klogFlags.Set("stderrthreshold", "0")
 	klogFlags.Set("v", "2")

--- a/backend/internal/errorcapture/error_capture.go
+++ b/backend/internal/errorcapture/error_capture.go
@@ -74,7 +74,6 @@ func Init() {
 	klogFlags.Set("legacy_stderr_threshold_behavior", "false")
 	klogFlags.Set("stderrthreshold", "INFO")
 	klogFlags.Set("logtostderr", "true")
-	klogFlags.Set("stderrthreshold", "0")
 	klogFlags.Set("v", "2")
 
 	global.start()


### PR DESCRIPTION
## What changed

klog v2 defaults `-logtostderr` to `true`, which silently ignores `-stderrthreshold` — all log levels go to stderr unconditionally. This has been an [open issue since 2020](https://github.com/kubernetes/klog/issues/212).

klog **v2.140.0** (already in use by this project) introduced a fix behind an opt-in flag (`legacy_stderr_threshold_behavior`). This PR enables the fix in `backend/internal/errorcapture/error_capture.go` so that the `stderrthreshold` setting is actually honored when `-logtostderr=true`.

### What the fix does

```go
klog.InitFlags(klogFlags)
klogFlags.Set("legacy_stderr_threshold_behavior", "false") // enable the klog fix
klogFlags.Set("stderrthreshold", "INFO")                   // preserve current default
```

The fix is backward-compatible and preserves the current stderr capture behavior.

### References

- Upstream issue: https://github.com/kubernetes/klog/issues/212
- Upstream fix: https://github.com/kubernetes/klog/pull/432