### PR TITLE
Overview status cards

### DIFF
--- a/backend/refresh/snapshot/cluster_overview.go
+++ b/backend/refresh/snapshot/cluster_overview.go
@@ -573,7 +573,7 @@ func buildClusterOverviewSnapshot(
 
 		model := resourcemodel.BuildPodResourceModel("", pod)
 		countPodStatusPresentation(&overview, model.Status.Presentation)
-		if podFacts := model.Facts.Pod; podFacts != nil && podFacts.TotalContainers > 0 && podFacts.ReadyContainers < podFacts.TotalContainers {
+		if podCountsAsNotReadySignal(pod, model.Facts.Pod) {
 			overview.NotReadyPods++
 		}
 		hasRestarts := podHasRestarts(pod)
@@ -879,6 +879,13 @@ func countPodStatusPresentation(overview *ClusterOverviewPayload, presentation s
 	case "terminating":
 		overview.TerminatingPods++
 	}
+}
+
+func podCountsAsNotReadySignal(pod *corev1.Pod, facts *resourcemodel.PodFacts) bool {
+	if pod == nil || facts == nil || pod.Status.Phase == corev1.PodSucceeded {
+		return false
+	}
+	return facts.TotalContainers > 0 && facts.ReadyContainers < facts.TotalContainers
 }
 
 func podHasRestarts(pod *corev1.Pod) bool {

--- a/backend/refresh/snapshot/cluster_overview.go
+++ b/backend/refresh/snapshot/cluster_overview.go
@@ -116,7 +116,12 @@ type ClusterOverviewPayload struct {
 	SucceededPods       int `json:"succeededPods"`
 	PendingPods         int `json:"pendingPods"`
 	FailedPods          int `json:"failedPods"`
+	ReadyPods           int `json:"readyPods"`
+	StartingPods        int `json:"startingPods"`
+	FailingPods         int `json:"failingPods"`
+	TerminatingPods     int `json:"terminatingPods"`
 	RestartedPods       int `json:"restartedPods"`
+	NotReadyPods        int `json:"notReadyPods"`
 
 	TotalNamespaces int `json:"totalNamespaces"`
 
@@ -566,21 +571,12 @@ func buildClusterOverviewSnapshot(
 		overview.TotalContainers += len(pod.Spec.Containers)
 		overview.TotalInitContainers += len(pod.Spec.InitContainers)
 
-		hasRestarts := false
-		for _, status := range pod.Status.ContainerStatuses {
-			if status.RestartCount > 0 {
-				hasRestarts = true
-				break
-			}
+		model := resourcemodel.BuildPodResourceModel("", pod)
+		countPodStatusPresentation(&overview, model.Status.Presentation)
+		if podFacts := model.Facts.Pod; podFacts != nil && podFacts.TotalContainers > 0 && podFacts.ReadyContainers < podFacts.TotalContainers {
+			overview.NotReadyPods++
 		}
-		if !hasRestarts {
-			for _, status := range pod.Status.InitContainerStatuses {
-				if status.RestartCount > 0 {
-					hasRestarts = true
-					break
-				}
-			}
-		}
+		hasRestarts := podHasRestarts(pod)
 
 		for _, container := range pod.Spec.Containers {
 			if cpu := container.Resources.Requests.Cpu(); cpu != nil {
@@ -867,6 +863,41 @@ func buildClusterOverviewReplicaSetDeploymentMap(replicaSets []*appsv1.ReplicaSe
 		}
 	}
 	return out
+}
+
+func countPodStatusPresentation(overview *ClusterOverviewPayload, presentation string) {
+	if overview == nil {
+		return
+	}
+	switch strings.ToLower(strings.TrimSpace(presentation)) {
+	case "ready":
+		overview.ReadyPods++
+	case "warning":
+		overview.StartingPods++
+	case "error", "not-ready":
+		overview.FailingPods++
+	case "terminating":
+		overview.TerminatingPods++
+	}
+}
+
+func podHasRestarts(pod *corev1.Pod) bool {
+	for _, status := range pod.Status.ContainerStatuses {
+		if status.RestartCount > 0 {
+			return true
+		}
+	}
+	for _, status := range pod.Status.InitContainerStatuses {
+		if status.RestartCount > 0 {
+			return true
+		}
+	}
+	for _, status := range pod.Status.EphemeralContainerStatuses {
+		if status.RestartCount > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func clusterOverviewWorkloadKind(pod *corev1.Pod, replicaSetDeployments map[string]string) string {

--- a/backend/refresh/snapshot/cluster_overview_test.go
+++ b/backend/refresh/snapshot/cluster_overview_test.go
@@ -134,6 +134,27 @@ func TestClusterOverviewBuilder(t *testing.T) {
 		Status: corev1.PodStatus{Phase: corev1.PodPending},
 	}
 
+	podCompleted := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "completed-c",
+			Namespace:       "default",
+			ResourceVersion: "23",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "done"}},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodSucceeded,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:  "done",
+				Ready: false,
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{Reason: "Completed"},
+				},
+			}},
+		},
+	}
+
 	nsA := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "default",
@@ -149,7 +170,7 @@ func TestClusterOverviewBuilder(t *testing.T) {
 	builder := &ClusterOverviewBuilder{
 		client:          nil,
 		nodeLister:      testsupport.NewNodeLister(t, nodeFargate, nodeEC2),
-		podLister:       testsupport.NewPodLister(t, podRunning, podPending),
+		podLister:       testsupport.NewPodLister(t, podRunning, podPending, podCompleted),
 		namespaceLister: testsupport.NewNamespaceLister(t, nsA, nsB),
 		metrics: fakeClusterMetrics{
 			pods: map[string]metrics.PodUsage{
@@ -186,11 +207,12 @@ func TestClusterOverviewBuilder(t *testing.T) {
 	require.Equal(t, 0, overview.RegularNodes)
 	require.Equal(t, 0, overview.VirtualNodes)
 	require.Equal(t, 0, overview.VMNodes)
-	require.Equal(t, 2, overview.TotalPods)
+	require.Equal(t, 3, overview.TotalPods)
 	require.Equal(t, 1, overview.RunningPods)
+	require.Equal(t, 1, overview.SucceededPods)
 	require.Equal(t, 1, overview.PendingPods)
 	require.Equal(t, 0, overview.FailedPods)
-	require.Equal(t, 1, overview.ReadyPods)
+	require.Equal(t, 2, overview.ReadyPods)
 	require.Equal(t, 1, overview.StartingPods)
 	require.Equal(t, 0, overview.FailingPods)
 	require.Equal(t, 0, overview.TerminatingPods)

--- a/backend/refresh/snapshot/cluster_overview_test.go
+++ b/backend/refresh/snapshot/cluster_overview_test.go
@@ -103,7 +103,14 @@ func TestClusterOverviewBuilder(t *testing.T) {
 				},
 			}},
 		},
-		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:         "c1",
+				Ready:        true,
+				RestartCount: 1,
+			}},
+		},
 	}
 
 	podPending := &corev1.Pod{
@@ -113,6 +120,7 @@ func TestClusterOverviewBuilder(t *testing.T) {
 			ResourceVersion: "22",
 		},
 		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "app"}},
 			InitContainers: []corev1.Container{{
 				Name: "init",
 				Resources: corev1.ResourceRequirements{
@@ -182,6 +190,12 @@ func TestClusterOverviewBuilder(t *testing.T) {
 	require.Equal(t, 1, overview.RunningPods)
 	require.Equal(t, 1, overview.PendingPods)
 	require.Equal(t, 0, overview.FailedPods)
+	require.Equal(t, 1, overview.ReadyPods)
+	require.Equal(t, 1, overview.StartingPods)
+	require.Equal(t, 0, overview.FailingPods)
+	require.Equal(t, 0, overview.TerminatingPods)
+	require.Equal(t, 1, overview.RestartedPods)
+	require.Equal(t, 1, overview.NotReadyPods)
 	require.Equal(t, 2, overview.TotalNamespaces)
 	require.Equal(t, "150m", overview.CPUUsage)
 	require.Equal(t, "350m", overview.CPURequests)

--- a/backend/refresh/snapshot/merge.go
+++ b/backend/refresh/snapshot/merge.go
@@ -703,7 +703,12 @@ func mergeClusterOverviewPayload(payloads []ClusterOverviewSnapshot) ClusterOver
 		out.SucceededPods += overview.SucceededPods
 		out.PendingPods += overview.PendingPods
 		out.FailedPods += overview.FailedPods
+		out.ReadyPods += overview.ReadyPods
+		out.StartingPods += overview.StartingPods
+		out.FailingPods += overview.FailingPods
+		out.TerminatingPods += overview.TerminatingPods
 		out.RestartedPods += overview.RestartedPods
+		out.NotReadyPods += overview.NotReadyPods
 		out.TotalNamespaces += overview.TotalNamespaces
 		out.TotalDeployments += overview.TotalDeployments
 		out.TotalStatefulSets += overview.TotalStatefulSets

--- a/backend/refresh/snapshot/merge_test.go
+++ b/backend/refresh/snapshot/merge_test.go
@@ -17,7 +17,10 @@ func TestMergeClusterOverviewPreservesSnapshotWarningsAndTruncation(t *testing.T
 			Payload: ClusterOverviewSnapshot{
 				ClusterMeta: ClusterMeta{ClusterID: "cluster-a", ClusterName: "alpha"},
 				Overview: ClusterOverviewPayload{
-					TotalNodes: 3,
+					TotalNodes:   3,
+					ReadyPods:    1,
+					StartingPods: 2,
+					NotReadyPods: 2,
 					WorkloadResourceUsage: WorkloadResourceUsage{
 						Deployments: WorkloadTypeResourceUsage{CPUUsage: "250m", MemoryUsage: "300.0 Mi"},
 						Jobs:        WorkloadTypeResourceUsage{CPUUsage: "1", MemoryUsage: "1.0 Gi"},
@@ -43,7 +46,11 @@ func TestMergeClusterOverviewPreservesSnapshotWarningsAndTruncation(t *testing.T
 			Payload: ClusterOverviewSnapshot{
 				ClusterMeta: ClusterMeta{ClusterID: "cluster-b", ClusterName: "beta"},
 				Overview: ClusterOverviewPayload{
-					TotalNodes: 4,
+					TotalNodes:      4,
+					ReadyPods:       3,
+					FailingPods:     1,
+					TerminatingPods: 1,
+					NotReadyPods:    5,
 					WorkloadResourceUsage: WorkloadResourceUsage{
 						Deployments: WorkloadTypeResourceUsage{CPUUsage: "750m", MemoryUsage: "724.0 Mi"},
 						Jobs:        WorkloadTypeResourceUsage{CPUUsage: "500m", MemoryUsage: "512.0 Mi"},
@@ -81,6 +88,12 @@ func TestMergeClusterOverviewPreservesSnapshotWarningsAndTruncation(t *testing.T
 	payload, ok := merged.Payload.(ClusterOverviewSnapshot)
 	if !ok {
 		t.Fatalf("expected cluster overview snapshot payload, got %T", merged.Payload)
+	}
+	if payload.Overview.ReadyPods != 4 || payload.Overview.StartingPods != 2 || payload.Overview.FailingPods != 1 || payload.Overview.TerminatingPods != 1 {
+		t.Fatalf("expected status pod counts to be merged, got %+v", payload.Overview)
+	}
+	if payload.Overview.NotReadyPods != 7 {
+		t.Fatalf("expected not-ready pod count to be merged, got %d", payload.Overview.NotReadyPods)
 	}
 	usage := payload.Overview.WorkloadResourceUsage
 	if usage.Deployments.CPUUsage != "1" || usage.Deployments.MemoryUsage != "1.0 Gi" {

--- a/frontend/src/core/events/eventBus.ts
+++ b/frontend/src/core/events/eventBus.ts
@@ -101,7 +101,11 @@ export interface AppEvents {
   'settings:appearance-mode-resolved': 'light' | 'dark';
 
   // Feature events
-  'pods:show-unhealthy': { clusterId: string; scope: string };
+  'pods:show-unhealthy': {
+    clusterId: string;
+    scope: string;
+    filter?: 'unhealthy' | 'restarts' | 'not-ready';
+  };
   'gridtable:persistence-mode': 'namespaced' | 'shared';
 
   // Grid table external focus — emitted to request that a visible GridTable

--- a/frontend/src/core/refresh/types.ts
+++ b/frontend/src/core/refresh/types.ts
@@ -242,7 +242,12 @@ export interface ClusterOverviewPayload {
   succeededPods: number;
   pendingPods: number;
   failedPods: number;
+  readyPods: number;
+  startingPods: number;
+  failingPods: number;
+  terminatingPods: number;
   restartedPods: number;
+  notReadyPods: number;
   totalNamespaces: number;
   totalDeployments: number;
   totalStatefulSets: number;

--- a/frontend/src/modules/cluster/components/ClusterOverview.css
+++ b/frontend/src/modules/cluster/components/ClusterOverview.css
@@ -420,7 +420,7 @@
 }
 
 .pod-status-card--terminating {
-  --pod-status-card-color: var(--pod-phase-pending);
+  --pod-status-card-color: var(--color-info, #60a5fa);
 }
 
 .pod-status-card--failing {

--- a/frontend/src/modules/cluster/components/ClusterOverview.css
+++ b/frontend/src/modules/cluster/components/ClusterOverview.css
@@ -454,9 +454,14 @@
 }
 
 .pod-status-card__label {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
   margin-top: 0.25rem;
   font-size: 0.75rem;
   color: var(--color-text-secondary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .stacked-bar__segment--deployment {

--- a/frontend/src/modules/cluster/components/ClusterOverview.css
+++ b/frontend/src/modules/cluster/components/ClusterOverview.css
@@ -375,6 +375,18 @@
   background: var(--pod-phase-failing);
 }
 
+.pod-status-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.pod-status-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
 .pod-status-cards {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -396,11 +408,18 @@
   color: var(--color-text-secondary);
 }
 
-.pod-status-card--healthy {
+.pod-status-card--healthy,
+.pod-status-card--ready {
   --pod-status-card-color: var(--pod-phase-healthy);
 }
 
-.pod-status-card--pending {
+.pod-status-card--pending,
+.pod-status-card--starting,
+.pod-status-card--not-ready {
+  --pod-status-card-color: var(--pod-phase-pending);
+}
+
+.pod-status-card--terminating {
   --pod-status-card-color: var(--pod-phase-pending);
 }
 
@@ -428,7 +447,7 @@
 
 .pod-status-card__count {
   color: var(--pod-status-card-color);
-  font-size: 0.9rem;
+  font-size: 1.3em;
   font-weight: 600;
   line-height: 1.2;
   font-variant-numeric: tabular-nums;

--- a/frontend/src/modules/cluster/components/ClusterOverview.test.tsx
+++ b/frontend/src/modules/cluster/components/ClusterOverview.test.tsx
@@ -736,10 +736,14 @@ describe('ClusterOverview', () => {
       value: ALL_NAMESPACES_SCOPE,
     });
     expect(navigateToNamespaceMock).toHaveBeenCalled();
-    expect(emitPodsUnhealthySignalMock).toHaveBeenCalledWith('cluster-1', ALL_NAMESPACES_SCOPE);
+    expect(emitPodsUnhealthySignalMock).toHaveBeenCalledWith(
+      'cluster-1',
+      ALL_NAMESPACES_SCOPE,
+      'unhealthy'
+    );
   });
 
-  it('renders signal cards as non-clickable diagnostics', async () => {
+  it('navigates to the filtered pods view from signal cards', async () => {
     mockLifecycleState = 'loading';
     domainStateRef.current = createDomainState('ready', {
       overview: {
@@ -755,8 +759,26 @@ describe('ClusterOverview', () => {
 
     const restartedCard = container.querySelector('[data-testid="cluster-pod-status-restarted"]');
     const notReadyCard = container.querySelector('[data-testid="cluster-pod-status-not-ready"]');
-    expect(restartedCard?.getAttribute('role')).toBeNull();
-    expect(notReadyCard?.getAttribute('role')).toBeNull();
+    expect(restartedCard?.getAttribute('role')).toBe('button');
+    expect(notReadyCard?.getAttribute('role')).toBe('button');
+
+    act(() => {
+      restartedCard?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(emitPodsUnhealthySignalMock).toHaveBeenLastCalledWith(
+      'cluster-1',
+      ALL_NAMESPACES_SCOPE,
+      'restarts'
+    );
+
+    act(() => {
+      notReadyCard?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(emitPodsUnhealthySignalMock).toHaveBeenLastCalledWith(
+      'cluster-1',
+      ALL_NAMESPACES_SCOPE,
+      'not-ready'
+    );
   });
 
   it('navigates to the pods view without unhealthy filter when clicking the ready item', async () => {

--- a/frontend/src/modules/cluster/components/ClusterOverview.test.tsx
+++ b/frontend/src/modules/cluster/components/ClusterOverview.test.tsx
@@ -347,7 +347,12 @@ describe('ClusterOverview', () => {
         succeededPods: 0,
         pendingPods: 1,
         failedPods: 1,
+        readyPods: 40,
+        startingPods: 1,
+        failingPods: 1,
+        terminatingPods: 2,
         restartedPods: 7,
+        notReadyPods: 9,
         totalNamespaces: 6,
         totalDeployments: 8,
         totalStatefulSets: 2,
@@ -369,7 +374,8 @@ describe('ClusterOverview', () => {
     expect(container.textContent).toContain('EKS');
     expect(container.textContent).toContain('1.26.3');
     expect(container.textContent).not.toContain('Loading cluster overview...');
-    expect(container.textContent).toContain('Status');
+    expect(container.textContent).toContain('Pod Status');
+    expect(container.textContent).toContain('Pod Signals');
     expect(container.textContent).toContain('Ready');
     expect(container.textContent).toContain('400m of 2 cores');
     expect(container.textContent).toContain('20.0%');
@@ -385,11 +391,13 @@ describe('ClusterOverview', () => {
       Array.from(container.querySelectorAll('.pod-status-card')).map(
         (element) => element.textContent
       )
-    ).toEqual(['40healthy', '1pending', '1failing', '7restarted']);
-    expect(container.querySelector('.pod-status-card--healthy')).not.toBeNull();
-    expect(container.querySelector('.pod-status-card--pending')).not.toBeNull();
+    ).toEqual(['40ready', '1starting', '1failing', '2terminating', '7restarts', '9not ready']);
+    expect(container.querySelector('.pod-status-card--ready')).not.toBeNull();
+    expect(container.querySelector('.pod-status-card--starting')).not.toBeNull();
     expect(container.querySelector('.pod-status-card--failing')).not.toBeNull();
+    expect(container.querySelector('.pod-status-card--terminating')).not.toBeNull();
     expect(container.querySelector('.pod-status-card--restarted')).not.toBeNull();
+    expect(container.querySelector('.pod-status-card--not-ready')).not.toBeNull();
   });
 
   it('uses warning color classes for resource percentages over 100 percent', async () => {
@@ -701,12 +709,12 @@ describe('ClusterOverview', () => {
     expect(container.textContent).not.toContain('Loading cluster overview...');
   });
 
-  it('navigates to the pods view with unhealthy filter when clicking a pod status card', async () => {
+  it('navigates to the pods view with unhealthy filter when clicking a non-ready status card', async () => {
     mockLifecycleState = 'loading';
     domainStateRef.current = createDomainState('ready', {
       overview: {
         ...EMPTY_OVERVIEW_DATA,
-        pendingPods: 3,
+        startingPods: 3,
       },
     });
 
@@ -714,11 +722,11 @@ describe('ClusterOverview', () => {
     cleanupRoot = cleanup;
     await flushEffects();
 
-    const pendingCard = container.querySelector('[data-testid="cluster-pod-status-pending"]');
-    expect(pendingCard).not.toBeNull();
+    const startingCard = container.querySelector('[data-testid="cluster-pod-status-starting"]');
+    expect(startingCard).not.toBeNull();
 
     act(() => {
-      pendingCard?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      startingCard?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
 
     expect(setSelectedNamespaceMock).toHaveBeenCalledWith(ALL_NAMESPACES_SCOPE);
@@ -731,13 +739,13 @@ describe('ClusterOverview', () => {
     expect(emitPodsUnhealthySignalMock).toHaveBeenCalledWith('cluster-1', ALL_NAMESPACES_SCOPE);
   });
 
-  it('navigates to the pods view without unhealthy filter when clicking the healthy item', async () => {
+  it('renders signal cards as non-clickable diagnostics', async () => {
     mockLifecycleState = 'loading';
     domainStateRef.current = createDomainState('ready', {
       overview: {
         ...EMPTY_OVERVIEW_DATA,
-        runningPods: 4,
-        succeededPods: 1,
+        restartedPods: 4,
+        notReadyPods: 2,
       },
     });
 
@@ -745,12 +753,31 @@ describe('ClusterOverview', () => {
     cleanupRoot = cleanup;
     await flushEffects();
 
-    const healthyItem = container.querySelector('[data-testid="cluster-pod-status-healthy"]');
-    expect(healthyItem).not.toBeNull();
-    expect(healthyItem?.textContent).toContain('5');
+    const restartedCard = container.querySelector('[data-testid="cluster-pod-status-restarted"]');
+    const notReadyCard = container.querySelector('[data-testid="cluster-pod-status-not-ready"]');
+    expect(restartedCard?.getAttribute('role')).toBeNull();
+    expect(notReadyCard?.getAttribute('role')).toBeNull();
+  });
+
+  it('navigates to the pods view without unhealthy filter when clicking the ready item', async () => {
+    mockLifecycleState = 'loading';
+    domainStateRef.current = createDomainState('ready', {
+      overview: {
+        ...EMPTY_OVERVIEW_DATA,
+        readyPods: 5,
+      },
+    });
+
+    const { container, cleanup } = renderClusterOverview();
+    cleanupRoot = cleanup;
+    await flushEffects();
+
+    const readyItem = container.querySelector('[data-testid="cluster-pod-status-ready"]');
+    expect(readyItem).not.toBeNull();
+    expect(readyItem?.textContent).toContain('5');
 
     act(() => {
-      healthyItem?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      readyItem?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
 
     expect(setSelectedNamespaceMock).toHaveBeenCalledWith(ALL_NAMESPACES_SCOPE);
@@ -876,7 +903,12 @@ const EMPTY_OVERVIEW_DATA: ClusterOverviewPayload = {
   succeededPods: 0,
   pendingPods: 0,
   failedPods: 0,
+  readyPods: 0,
+  startingPods: 0,
+  failingPods: 0,
+  terminatingPods: 0,
   restartedPods: 0,
+  notReadyPods: 0,
   totalDeployments: 0,
   totalStatefulSets: 0,
   totalDaemonSets: 0,

--- a/frontend/src/modules/cluster/components/ClusterOverview.tsx
+++ b/frontend/src/modules/cluster/components/ClusterOverview.tsx
@@ -76,7 +76,12 @@ const EMPTY_OVERVIEW: ClusterOverviewPayload = {
   succeededPods: 0,
   pendingPods: 0,
   failedPods: 0,
+  readyPods: 0,
+  startingPods: 0,
+  failingPods: 0,
+  terminatingPods: 0,
   restartedPods: 0,
+  notReadyPods: 0,
   totalNamespaces: 0,
   totalDeployments: 0,
   totalStatefulSets: 0,
@@ -367,7 +372,7 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
   }, [canActivateOverviewRefresh, overviewScope]);
 
   const handlePodStatusNavigate = useCallback(
-    (key: string, count: number) => {
+    (filter: 'none' | 'unhealthy', count: number) => {
       if (count <= 0) {
         return;
       }
@@ -375,7 +380,7 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
       setActiveNamespaceTab('pods');
       setSidebarSelection({ type: 'namespace', value: ALL_NAMESPACES_SCOPE });
       navigateToNamespace();
-      if (key !== 'healthy' && selectedClusterId) {
+      if (filter === 'unhealthy' && selectedClusterId) {
         emitPodsUnhealthySignal(selectedClusterId, ALL_NAMESPACES_SCOPE);
       }
     },
@@ -389,40 +394,75 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
   );
 
   const handlePodStatusKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLDivElement>, key: string, count: number) => {
+    (event: React.KeyboardEvent<HTMLDivElement>, filter: 'none' | 'unhealthy', count: number) => {
       if (count <= 0) {
         return;
       }
       if (event.key === 'Enter' || event.key === ' ') {
         event.preventDefault();
-        handlePodStatusNavigate(key, count);
+        handlePodStatusNavigate(filter, count);
       }
     },
     [handlePodStatusNavigate]
   );
 
-  // "Healthy" groups pods in the Running and Succeeded phases — CronJob-launched
-  // pods end up Succeeded, so counting only Running would understate the count.
-  const healthyPods = displayOverview.runningPods + displayOverview.succeededPods;
-  const podPhaseItems = [
-    { key: 'healthy', label: 'healthy', value: healthyPods, variant: 'healthy' },
-    { key: 'pending', label: 'pending', value: displayOverview.pendingPods, variant: 'pending' },
-    { key: 'failed', label: 'failing', value: displayOverview.failedPods, variant: 'failing' },
+  const podStatusItems = [
+    {
+      key: 'ready',
+      label: 'ready',
+      value: displayOverview.readyPods,
+      variant: 'ready',
+      filter: 'none' as const,
+    },
+    {
+      key: 'starting',
+      label: 'starting',
+      value: displayOverview.startingPods,
+      variant: 'starting',
+      filter: 'unhealthy' as const,
+    },
+    {
+      key: 'failing',
+      label: 'failing',
+      value: displayOverview.failingPods,
+      variant: 'failing',
+      filter: 'unhealthy' as const,
+    },
+    {
+      key: 'terminating',
+      label: 'terminating',
+      value: displayOverview.terminatingPods,
+      variant: 'terminating',
+      filter: 'unhealthy' as const,
+    },
   ];
-  const podRestartedItem = {
-    key: 'restarted',
-    label: 'restarted',
-    value: displayOverview.restartedPods,
-    variant: 'restarted',
-  };
-
+  const podSignalItems = [
+    {
+      key: 'restarted',
+      label: 'restarts',
+      value: displayOverview.restartedPods,
+      variant: 'restarted',
+      filter: 'none' as const,
+      clickable: false,
+    },
+    {
+      key: 'not-ready',
+      label: 'not ready',
+      value: displayOverview.notReadyPods,
+      variant: 'not-ready',
+      filter: 'none' as const,
+      clickable: false,
+    },
+  ];
   const renderPodStatusCard = (item: {
     key: string;
     label: string;
     value: number;
     variant: string;
+    filter: 'none' | 'unhealthy';
+    clickable?: boolean;
   }) => {
-    const clickable = item.value > 0;
+    const clickable = item.clickable !== false && item.value > 0;
     const itemClass = `pod-status-card pod-status-card--${item.variant}${clickable ? ' pod-status-card--clickable' : ''}`;
     return (
       <div
@@ -430,9 +470,9 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
         className={itemClass}
         role={clickable ? 'button' : undefined}
         tabIndex={clickable ? 0 : undefined}
-        onClick={clickable ? () => handlePodStatusNavigate(item.key, item.value) : undefined}
+        onClick={clickable ? () => handlePodStatusNavigate(item.filter, item.value) : undefined}
         onKeyDown={
-          clickable ? (event) => handlePodStatusKeyDown(event, item.key, item.value) : undefined
+          clickable ? (event) => handlePodStatusKeyDown(event, item.filter, item.value) : undefined
         }
         aria-disabled={!clickable}
         data-testid={`cluster-pod-status-${item.key}`}
@@ -1047,18 +1087,29 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
           </div>
 
           <div className="pod-status">
-            <div className="metric-header">
-              <h3>Pod Status</h3>
-              <div className="metric-legend__total">
-                <span className="metric-legend__total-value">
-                  {showSkeleton ? DASH : displayOverview.totalPods}
-                </span>
-                <span className="metric-legend__total-label"> total</span>
+            <div className="pod-status-groups">
+              <div className="pod-status-group">
+                <div className="metric-header">
+                  <h3>Pod Status</h3>
+                  <div className="metric-legend__total">
+                    <span className="metric-legend__total-value">
+                      {showSkeleton ? DASH : displayOverview.totalPods}
+                    </span>
+                    <span className="metric-legend__total-label"> total</span>
+                  </div>
+                </div>
+                <div className="pod-status-cards">
+                  {podStatusItems.map((item) => renderPodStatusCard(item))}
+                </div>
               </div>
-            </div>
-            <div className="pod-status-cards">
-              {podPhaseItems.map((item) => renderPodStatusCard(item))}
-              {renderPodStatusCard(podRestartedItem)}
+              <div className="pod-status-group">
+                <div className="metric-header">
+                  <h3>Pod Signals</h3>
+                </div>
+                <div className="pod-status-cards pod-status-cards--signals">
+                  {podSignalItems.map((item) => renderPodStatusCard(item))}
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/frontend/src/modules/cluster/components/ClusterOverview.tsx
+++ b/frontend/src/modules/cluster/components/ClusterOverview.tsx
@@ -481,7 +481,9 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
         data-testid={`cluster-pod-status-${item.key}`}
       >
         <span className="pod-status-card__count">{showSkeleton ? DASH : item.value}</span>
-        <span className="pod-status-card__label">{item.label}</span>
+        <span className="pod-status-card__label" title={item.label}>
+          {item.label}
+        </span>
       </div>
     );
   };

--- a/frontend/src/modules/cluster/components/ClusterOverview.tsx
+++ b/frontend/src/modules/cluster/components/ClusterOverview.tsx
@@ -30,7 +30,10 @@ import { getMetricsBannerInfo } from '@shared/utils/metricsAvailability';
 import { useNamespace } from '@modules/namespace/contexts/NamespaceContext';
 import { ALL_NAMESPACES_SCOPE } from '@modules/namespace/constants';
 import { useViewState } from '@/core/contexts/ViewStateContext';
-import { emitPodsUnhealthySignal } from '@modules/namespace/components/podsFilterSignals';
+import {
+  emitPodsUnhealthySignal,
+  type PodsFilterMode,
+} from '@modules/namespace/components/podsFilterSignals';
 import { BrowserOpenURL } from '@wailsjs/runtime/runtime';
 import { useClusterLifecycle } from '@core/contexts/ClusterLifecycleContext';
 import { backend } from '@wailsjs/go/models';
@@ -371,8 +374,10 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
     };
   }, [canActivateOverviewRefresh, overviewScope]);
 
+  type PodStatusFilter = 'none' | PodsFilterMode;
+
   const handlePodStatusNavigate = useCallback(
-    (filter: 'none' | 'unhealthy', count: number) => {
+    (filter: PodStatusFilter, count: number) => {
       if (count <= 0) {
         return;
       }
@@ -380,8 +385,8 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
       setActiveNamespaceTab('pods');
       setSidebarSelection({ type: 'namespace', value: ALL_NAMESPACES_SCOPE });
       navigateToNamespace();
-      if (filter === 'unhealthy' && selectedClusterId) {
-        emitPodsUnhealthySignal(selectedClusterId, ALL_NAMESPACES_SCOPE);
+      if (filter !== 'none' && selectedClusterId) {
+        emitPodsUnhealthySignal(selectedClusterId, ALL_NAMESPACES_SCOPE, filter);
       }
     },
     [
@@ -394,7 +399,7 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
   );
 
   const handlePodStatusKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLDivElement>, filter: 'none' | 'unhealthy', count: number) => {
+    (event: React.KeyboardEvent<HTMLDivElement>, filter: PodStatusFilter, count: number) => {
       if (count <= 0) {
         return;
       }
@@ -442,16 +447,14 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
       label: 'restarts',
       value: displayOverview.restartedPods,
       variant: 'restarted',
-      filter: 'none' as const,
-      clickable: false,
+      filter: 'restarts' as const,
     },
     {
       key: 'not-ready',
       label: 'not ready',
       value: displayOverview.notReadyPods,
       variant: 'not-ready',
-      filter: 'none' as const,
-      clickable: false,
+      filter: 'not-ready' as const,
     },
   ];
   const renderPodStatusCard = (item: {
@@ -459,7 +462,7 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
     label: string;
     value: number;
     variant: string;
-    filter: 'none' | 'unhealthy';
+    filter: PodStatusFilter;
     clickable?: boolean;
   }) => {
     const clickable = item.clickable !== false && item.value > 0;

--- a/frontend/src/modules/namespace/components/NsViewPods.test.tsx
+++ b/frontend/src/modules/namespace/components/NsViewPods.test.tsx
@@ -721,6 +721,14 @@ describe('NsViewPods', () => {
       createPod({ name: 'healthy', status: 'Running', ready: '1/1', restarts: 0 }),
       createPod({ name: 'not-ready', status: 'Running', ready: '0/1', restarts: 0 }),
       createPod({
+        name: 'completed',
+        status: 'Completed',
+        statusState: 'Succeeded',
+        statusPresentation: 'ready',
+        ready: '0/1',
+        restarts: 0,
+      }),
+      createPod({
         name: 'pending',
         status: 'Pending',
         statusPresentation: 'warning',
@@ -739,7 +747,7 @@ describe('NsViewPods', () => {
       });
     });
 
-    expect(gridTablePropsRef.current.data).toEqual([pods[1], pods[2]]);
+    expect(gridTablePropsRef.current.data).toEqual([pods[1], pods[3]]);
   });
 
   it('ignores unhealthy filter events for other clusters', async () => {

--- a/frontend/src/modules/namespace/components/NsViewPods.test.tsx
+++ b/frontend/src/modules/namespace/components/NsViewPods.test.tsx
@@ -11,6 +11,7 @@ import { act } from 'react';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { PodSnapshotEntry, PodMetricsInfo } from '@/core/refresh/types';
 import { getPodsUnhealthyStorageKey } from '@modules/namespace/components/podsFilterSignals';
+import { ALL_NAMESPACES_SCOPE } from '@modules/namespace/constants';
 import { eventBus } from '@/core/events';
 
 const {
@@ -661,6 +662,34 @@ describe('NsViewPods', () => {
     expect(gridTablePropsRef.current.data).toEqual([pods[1]]);
   });
 
+  it('enables the unhealthy filter when an event targets all namespaces', async () => {
+    const pods = [
+      createPod({ name: 'healthy', namespace: 'team-a', status: 'Running', ready: '1/1' }),
+      createPod({
+        name: 'pending',
+        namespace: 'team-b',
+        status: 'Pending',
+        statusPresentation: 'warning',
+        ready: '0/1',
+      }),
+    ];
+
+    await renderPods({
+      namespace: ALL_NAMESPACES_SCOPE,
+      data: pods,
+      showNamespaceColumn: true,
+    });
+
+    act(() => {
+      eventBus.emit('pods:show-unhealthy', {
+        clusterId: 'alpha:ctx',
+        scope: ALL_NAMESPACES_SCOPE,
+      });
+    });
+
+    expect(gridTablePropsRef.current.data).toEqual([pods[1]]);
+  });
+
   it('ignores unhealthy filter events for other clusters', async () => {
     const pods = [
       createPod({ name: 'healthy', status: 'Running', ready: '1/1', restarts: 0 }),
@@ -703,6 +732,59 @@ describe('NsViewPods', () => {
 
     expect(gridTablePropsRef.current.data).toEqual([pods[1]]);
     expect(window.sessionStorage.getItem(storageKey)).toBeNull();
+  });
+
+  it('keeps the unhealthy toggle visible while active when no unhealthy pods remain', async () => {
+    const pods = [
+      createPod({ name: 'healthy', status: 'Running', ready: '1/1' }),
+      createPod({
+        name: 'pending',
+        status: 'Pending',
+        statusPresentation: 'warning',
+        ready: '0/1',
+      }),
+    ];
+
+    await renderPods({ data: pods });
+
+    const toggle = container.querySelector<HTMLButtonElement>(
+      'button[title="Show unhealthy pods (1/2)"]'
+    );
+    expect(toggle).not.toBeNull();
+
+    await act(async () => {
+      toggle?.click();
+      await Promise.resolve();
+    });
+    expect(gridTablePropsRef.current.data).toEqual([pods[1]]);
+
+    await renderPods({
+      data: [
+        createPod({ name: 'healthy', status: 'Running', ready: '1/1' }),
+        createPod({
+          name: 'recovered',
+          status: 'Running',
+          statusPresentation: 'ready',
+          ready: '1/1',
+        }),
+      ],
+    });
+
+    expect(gridTablePropsRef.current.data).toEqual([]);
+    const activeToggle = container.querySelector<HTMLButtonElement>(
+      'button[title="Show all pods"]'
+    );
+    expect(activeToggle).not.toBeNull();
+    expect(activeToggle?.getAttribute('aria-pressed')).toBe('true');
+
+    await act(async () => {
+      activeToggle?.click();
+      await Promise.resolve();
+    });
+    expect(gridTablePropsRef.current.data.map((pod: PodSnapshotEntry) => pod.name)).toEqual([
+      'healthy',
+      'recovered',
+    ]);
   });
 
   it('deletes a pod when confirmation succeeds', async () => {

--- a/frontend/src/modules/namespace/components/NsViewPods.test.tsx
+++ b/frontend/src/modules/namespace/components/NsViewPods.test.tsx
@@ -690,6 +690,58 @@ describe('NsViewPods', () => {
     expect(gridTablePropsRef.current.data).toEqual([pods[1]]);
   });
 
+  it('filters restarted pods when a restart signal targets the namespace and cluster', async () => {
+    const pods = [
+      createPod({ name: 'healthy', status: 'Running', ready: '1/1', restarts: 0 }),
+      createPod({ name: 'restarted', status: 'Running', ready: '1/1', restarts: 2 }),
+      createPod({
+        name: 'pending',
+        status: 'Pending',
+        statusPresentation: 'warning',
+        ready: '0/1',
+        restarts: 0,
+      }),
+    ];
+
+    await renderPods({ data: pods });
+
+    act(() => {
+      eventBus.emit('pods:show-unhealthy', {
+        clusterId: 'alpha:ctx',
+        scope: 'team-a',
+        filter: 'restarts',
+      });
+    });
+
+    expect(gridTablePropsRef.current.data).toEqual([pods[1]]);
+  });
+
+  it('filters not-ready pods when a not-ready signal targets the namespace and cluster', async () => {
+    const pods = [
+      createPod({ name: 'healthy', status: 'Running', ready: '1/1', restarts: 0 }),
+      createPod({ name: 'not-ready', status: 'Running', ready: '0/1', restarts: 0 }),
+      createPod({
+        name: 'pending',
+        status: 'Pending',
+        statusPresentation: 'warning',
+        ready: '0/1',
+        restarts: 0,
+      }),
+    ];
+
+    await renderPods({ data: pods });
+
+    act(() => {
+      eventBus.emit('pods:show-unhealthy', {
+        clusterId: 'alpha:ctx',
+        scope: 'team-a',
+        filter: 'not-ready',
+      });
+    });
+
+    expect(gridTablePropsRef.current.data).toEqual([pods[1], pods[2]]);
+  });
+
   it('ignores unhealthy filter events for other clusters', async () => {
     const pods = [
       createPod({ name: 'healthy', status: 'Running', ready: '1/1', restarts: 0 }),

--- a/frontend/src/modules/namespace/components/NsViewPods.tsx
+++ b/frontend/src/modules/namespace/components/NsViewPods.tsx
@@ -18,7 +18,12 @@ import type { ContextMenuItem } from '@shared/components/ContextMenu';
 import { type GridColumnDefinition } from '@shared/components/tables/GridTable';
 import type { PodSnapshotEntry, PodMetricsInfo } from '@/core/refresh/types';
 import { ALL_NAMESPACES_SCOPE } from '@modules/namespace/constants';
-import { getPodsUnhealthyStorageKey } from '@modules/namespace/components/podsFilterSignals';
+import {
+  getPodsUnhealthyStorageKey,
+  parsePodsFilterRequest,
+  type PodsFilterMode,
+  type PodsFilterRequest,
+} from '@modules/namespace/components/podsFilterSignals';
 import { useKubeconfig } from '@modules/kubernetes/config/KubeconfigContext';
 import { useObjectActionController } from '@shared/hooks/useObjectActionController';
 import { useNavigateToView } from '@shared/hooks/useNavigateToView';
@@ -87,6 +92,26 @@ const isPodUnhealthy = (pod: PodSnapshotEntry): boolean => {
   return UNHEALTHY_POD_PRESENTATIONS.has((pod.statusPresentation || '').trim().toLowerCase());
 };
 
+const isPodRestarted = (pod: PodSnapshotEntry): boolean => (pod.restarts ?? 0) > 0;
+
+const isPodNotReady = (pod: PodSnapshotEntry): boolean => {
+  const counts = parseReadyCounts(pod.ready);
+  return counts !== null && counts.total > 0 && counts.ready < counts.total;
+};
+
+const matchesPodsFilter = (filter: PodsFilterMode, pod: PodSnapshotEntry): boolean => {
+  switch (filter) {
+    case 'restarts':
+      return isPodRestarted(pod);
+    case 'not-ready':
+      return isPodNotReady(pod);
+    case 'unhealthy':
+      return isPodUnhealthy(pod);
+    default:
+      return false;
+  }
+};
+
 /**
  * GridTable component for namespace Pods
  */
@@ -107,7 +132,7 @@ const NsViewPods: React.FC<PodsViewProps> = React.memo(
     const effectiveMetrics = metrics ?? clusterMetrics ?? null;
     const { selectedClusterId } = useKubeconfig();
 
-    const [showUnhealthyOnly, setShowUnhealthyOnly] = useState(false);
+    const [activePodFilter, setActivePodFilter] = useState<PodsFilterMode | null>(null);
 
     // Include cluster metadata so object details stay scoped to the active tab.
     const handlePodOpen = useCallback(
@@ -446,15 +471,15 @@ const NsViewPods: React.FC<PodsViewProps> = React.memo(
     const unhealthyCount = useMemo(() => data.filter((pod) => isPodUnhealthy(pod)).length, [data]);
 
     const handleToggleUnhealthy = useCallback(() => {
-      setShowUnhealthyOnly((prev) => !prev);
+      setActivePodFilter((prev) => (prev ? null : 'unhealthy'));
     }, []);
 
     const unhealthyToggle = useMemo<IconBarItem | null>(() => {
-      if (unhealthyCount <= 0 && !showUnhealthyOnly) {
+      if (unhealthyCount <= 0 && !activePodFilter) {
         return null;
       }
 
-      const title = showUnhealthyOnly
+      const title = activePodFilter
         ? 'Show all pods'
         : `Show unhealthy pods (${unhealthyCount}/${data.length})`;
 
@@ -462,17 +487,19 @@ const NsViewPods: React.FC<PodsViewProps> = React.memo(
         type: 'toggle',
         id: 'pods-unhealthy-toggle',
         icon: <UnhealthyPodsIcon />,
-        active: showUnhealthyOnly,
+        active: activePodFilter !== null,
         onClick: handleToggleUnhealthy,
         title,
         ariaLabel: title,
       };
-    }, [data.length, handleToggleUnhealthy, showUnhealthyOnly, unhealthyCount]);
+    }, [activePodFilter, data.length, handleToggleUnhealthy, unhealthyCount]);
 
     const transformSortedPods = useCallback(
       (sortedPods: PodSnapshotEntry[]) =>
-        showUnhealthyOnly ? sortedPods.filter((pod) => isPodUnhealthy(pod)) : sortedPods,
-      [showUnhealthyOnly]
+        activePodFilter
+          ? sortedPods.filter((pod) => matchesPodsFilter(activePodFilter, pod))
+          : sortedPods,
+      [activePodFilter]
     );
 
     const getTrailingFilterActions = useCallback(
@@ -505,14 +532,18 @@ const NsViewPods: React.FC<PodsViewProps> = React.memo(
 
       const storageKey = getPodsUnhealthyStorageKey(selectedClusterId);
 
-      const applyPendingFilter = (scope: string | null | undefined, shouldClearStorage = false) => {
-        if (!scope || scope !== namespace) {
+      const applyPendingFilter = (
+        request: PodsFilterRequest | null,
+        shouldClearStorage = false
+      ) => {
+        if (!request || request.scope !== namespace) {
           return;
         }
-        if (unhealthyCount === 0) {
+        const matchingCount = data.filter((pod) => matchesPodsFilter(request.filter, pod)).length;
+        if (matchingCount === 0) {
           return;
         }
-        setShowUnhealthyOnly(true);
+        setActivePodFilter(request.filter);
         if (shouldClearStorage) {
           try {
             window.sessionStorage.removeItem(storageKey);
@@ -524,7 +555,7 @@ const NsViewPods: React.FC<PodsViewProps> = React.memo(
 
       const pendingScope = (() => {
         try {
-          return window.sessionStorage.getItem(storageKey);
+          return parsePodsFilterRequest(window.sessionStorage.getItem(storageKey));
         } catch {
           return null;
         }
@@ -533,14 +564,14 @@ const NsViewPods: React.FC<PodsViewProps> = React.memo(
         applyPendingFilter(pendingScope, true);
       }
 
-      return eventBus.on('pods:show-unhealthy', ({ clusterId, scope }) => {
+      return eventBus.on('pods:show-unhealthy', ({ clusterId, scope, filter = 'unhealthy' }) => {
         // Only apply the filter if the event is for the current cluster.
         if (clusterId !== selectedClusterId) {
           return;
         }
-        applyPendingFilter(scope, true);
+        applyPendingFilter({ scope, filter }, true);
       });
-    }, [namespace, selectedClusterId, unhealthyCount]);
+    }, [data, namespace, selectedClusterId]);
 
     const getContextMenuItems = useCallback(
       (pod: PodSnapshotEntry): ContextMenuItem[] => {

--- a/frontend/src/modules/namespace/components/NsViewPods.tsx
+++ b/frontend/src/modules/namespace/components/NsViewPods.tsx
@@ -450,7 +450,7 @@ const NsViewPods: React.FC<PodsViewProps> = React.memo(
     }, []);
 
     const unhealthyToggle = useMemo<IconBarItem | null>(() => {
-      if (unhealthyCount <= 0) {
+      if (unhealthyCount <= 0 && !showUnhealthyOnly) {
         return null;
       }
 

--- a/frontend/src/modules/namespace/components/NsViewPods.tsx
+++ b/frontend/src/modules/namespace/components/NsViewPods.tsx
@@ -94,9 +94,15 @@ const isPodUnhealthy = (pod: PodSnapshotEntry): boolean => {
 
 const isPodRestarted = (pod: PodSnapshotEntry): boolean => (pod.restarts ?? 0) > 0;
 
+const isCompletedPod = (pod: PodSnapshotEntry): boolean => {
+  const status = (pod.status || '').trim().toLowerCase();
+  const statusState = (pod.statusState || '').trim().toLowerCase();
+  return status === 'completed' || statusState === 'succeeded';
+};
+
 const isPodNotReady = (pod: PodSnapshotEntry): boolean => {
   const counts = parseReadyCounts(pod.ready);
-  return counts !== null && counts.total > 0 && counts.ready < counts.total;
+  return !isCompletedPod(pod) && counts !== null && counts.total > 0 && counts.ready < counts.total;
 };
 
 const matchesPodsFilter = (filter: PodsFilterMode, pod: PodSnapshotEntry): boolean => {

--- a/frontend/src/modules/namespace/components/podsFilterSignals.test.ts
+++ b/frontend/src/modules/namespace/components/podsFilterSignals.test.ts
@@ -5,7 +5,7 @@
  * Verifies cluster-specific storage key generation for pods unhealthy filter.
  */
 import { describe, expect, it } from 'vitest';
-import { getPodsUnhealthyStorageKey } from './podsFilterSignals';
+import { getPodsUnhealthyStorageKey, parsePodsFilterRequest } from './podsFilterSignals';
 
 describe('podsFilterSignals', () => {
   it('generates cluster-specific storage keys', () => {
@@ -15,5 +15,19 @@ describe('podsFilterSignals', () => {
     expect(keyA).toBe('pods:unhealthy-filter-scope:cluster-a');
     expect(keyB).toBe('pods:unhealthy-filter-scope:cluster-b');
     expect(keyA).not.toBe(keyB);
+  });
+
+  it('parses legacy unhealthy filter requests', () => {
+    expect(parsePodsFilterRequest('team-a')).toEqual({
+      scope: 'team-a',
+      filter: 'unhealthy',
+    });
+  });
+
+  it('parses typed pod filter requests', () => {
+    expect(parsePodsFilterRequest('{"scope":"team-a","filter":"restarts"}')).toEqual({
+      scope: 'team-a',
+      filter: 'restarts',
+    });
   });
 });

--- a/frontend/src/modules/namespace/components/podsFilterSignals.ts
+++ b/frontend/src/modules/namespace/components/podsFilterSignals.ts
@@ -6,6 +6,15 @@
  */
 import { eventBus } from '@/core/events';
 
+export type PodsFilterMode = 'unhealthy' | 'restarts' | 'not-ready';
+
+export interface PodsFilterRequest {
+  scope: string;
+  filter: PodsFilterMode;
+}
+
+const DEFAULT_PODS_FILTER_MODE: PodsFilterMode = 'unhealthy';
+
 /**
  * Generate a cluster-specific storage key for the pods unhealthy filter.
  * This ensures filter state is isolated per cluster and doesn't leak between cluster tabs.
@@ -13,15 +22,41 @@ import { eventBus } from '@/core/events';
 export const getPodsUnhealthyStorageKey = (clusterId: string) =>
   `pods:unhealthy-filter-scope:${clusterId}`;
 
-export const emitPodsUnhealthySignal = (clusterId: string, scope: string) => {
+const isPodsFilterMode = (value: unknown): value is PodsFilterMode =>
+  value === 'unhealthy' || value === 'restarts' || value === 'not-ready';
+
+export const parsePodsFilterRequest = (
+  value: string | null | undefined
+): PodsFilterRequest | null => {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(value) as Partial<PodsFilterRequest>;
+    if (typeof parsed.scope === 'string' && isPodsFilterMode(parsed.filter)) {
+      return { scope: parsed.scope, filter: parsed.filter };
+    }
+  } catch {
+    return { scope: value, filter: DEFAULT_PODS_FILTER_MODE };
+  }
+
+  return null;
+};
+
+export const emitPodsUnhealthySignal = (
+  clusterId: string,
+  scope: string,
+  filter: PodsFilterMode = DEFAULT_PODS_FILTER_MODE
+) => {
   if (typeof window === 'undefined') {
     return;
   }
   const storageKey = getPodsUnhealthyStorageKey(clusterId);
   try {
-    window.sessionStorage.setItem(storageKey, scope);
+    window.sessionStorage.setItem(storageKey, JSON.stringify({ scope, filter }));
   } catch {
     // Ignore sessionStorage failures (for private browsing, etc.)
   }
-  eventBus.emit('pods:show-unhealthy', { clusterId, scope });
+  eventBus.emit('pods:show-unhealthy', { clusterId, scope, filter });
 };

--- a/frontend/src/shared/components/ToggleSwitch.css
+++ b/frontend/src/shared/components/ToggleSwitch.css
@@ -73,7 +73,9 @@
 .toggle-switch:focus,
 .toggle-switch:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 2px var(--color-bg), 0 0 0 4px var(--color-accent);
+  box-shadow:
+    0 0 0 2px var(--color-bg),
+    0 0 0 4px var(--color-accent);
 }
 
 .toggle-switch:disabled {

--- a/frontend/src/ui/settings/Settings.css
+++ b/frontend/src/ui/settings/Settings.css
@@ -26,25 +26,24 @@
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--color-text-tertiary);
-  margin-top: 0.5rem;
+  margin-top: 1.5rem;
 }
 
 .settings-subgroup-label:first-of-type {
-  margin-top: 0;
+  margin-top: 0.5rem;
 }
 
 .settings-subgroup-divider {
   border: 0;
   border-top: 1px solid var(--color-border);
-  margin: 0.4rem 0 1rem 0;
+  margin: 0.4rem 0 0.75rem 0;
 }
 
-/* Row: label/description on left, control on right */
 .settings-row {
   display: grid;
   grid-template-columns: 280px 1fr;
   gap: 1.5rem;
-  padding: 1.1rem 0;
+  padding: 1rem 0;
   align-items: start;
 }
 


### PR DESCRIPTION
- Split Cluster Overview pod metrics into separate Pod Status and Pod Signals rows.
- Added backend snapshot fields for ready, starting, failing, terminating, and not ready pod counts.
- Wired status/signal cards to the all-namespaces Pods view with the correct filters:
    - starting/failing/terminating -> unhealthy
    - restarts -> restarted pods
    - not ready -> not-ready pods
- Fixed not-ready logic so completed/succeeded pods are not counted or shown as not ready.
- Updated card styling, including blue terminating cards and truncation for long labels at narrow widths.