### PR TITLE
css tweaks to prevent clipping text descenders in windows

### DIFF
--- a/frontend/src/modules/cluster/components/ClusterOverview.css
+++ b/frontend/src/modules/cluster/components/ClusterOverview.css
@@ -35,6 +35,7 @@
 .overview-top__title {
   font-size: 1.1rem;
   font-weight: 600;
+  line-height: 1.3rem;
   color: var(--color-text);
   margin-bottom: 0.5rem;
   overflow: hidden;

--- a/frontend/src/shared/components/KubeconfigSelector.css
+++ b/frontend/src/shared/components/KubeconfigSelector.css
@@ -12,8 +12,9 @@
 .kubeconfig-selector .dropdown-trigger {
   width: auto;
   min-width: max-content;
-  padding: 0.3rem 2rem 0.3rem var(--spacing-md);
-  overflow: hidden;
+  line-height: 1.5rem;
+  padding: 0 2rem 0 var(--spacing-md);
+  overflow: visible;
 }
 
 .kubeconfig-selector .dropdown-value {
@@ -69,6 +70,7 @@
 
 .kubeconfig-filename {
   font-size: var(--font-size-normal);
+  line-height: 1.35;
   color: var(--color-text-tertiary);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -86,7 +88,8 @@
   align-items: center;
   gap: 8px;
   min-width: 0;
-  padding: 4px 4px;
+  line-height: 1.35rem;
+  padding: 1px 4px;
   border-radius: var(--border-radius-sm);
   transition:
     background-color var(--transition-fast),
@@ -100,6 +103,7 @@
   align-items: center;
   justify-content: center;
   font-size: 12px;
+  line-height: inherit;
   font-weight: 600;
   color: var(--color-text);
   flex: 0 0 auto;
@@ -108,6 +112,7 @@
 .kubeconfig-context-label {
   flex: 1 1 auto;
   min-width: 0;
+  line-height: inherit;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/frontend/src/ui/layout/Sidebar.css
+++ b/frontend/src/ui/layout/Sidebar.css
@@ -146,8 +146,9 @@
   gap: 0.5rem;
   color: var(--color-text);
   font-size: var(--font-size-normal);
-  padding: 0.2rem 0.5rem;
-  margin-bottom: 0.2rem;
+  line-height: 1.35rem;
+  padding: 0rem 0.5rem;
+  margin: 0.2rem 0;
   border-radius: var(--border-radius-round);
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
@@ -158,7 +159,6 @@
     border-color var(--duration-fast, 150ms) var(--ease-out, ease),
     transform var(--duration-fast, 150ms) var(--ease-out, ease);
   -webkit-app-region: no-drag;
-  overflow: hidden;
   cursor: pointer;
   outline: none;
 }

--- a/frontend/styles/components/badges.css
+++ b/frontend/styles/components/badges.css
@@ -13,6 +13,7 @@
   padding: 0.25rem 0.5rem;
   border-radius: var(--border-radius-round);
   font-size: var(--font-size-badge);
+  line-height: 1.2;
   font-weight: var(--font-weight-badge);
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -291,31 +292,6 @@
   color: var(--status-text-info);
 }
 
-/* ==========================================================================
-   Scope Badges
-   ========================================================================== */
-.scope-badge {
-  display: inline-block;
-  padding: 0.2rem 0.5rem;
-  border-radius: var(--border-radius-round);
-  font-size: var(--font-size-badge);
-  font-weight: var(--font-weight-badge);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  border: 1px solid transparent;
-}
-
-.scope-badge.namespace {
-  background-color: var(--badge-blue-bg);
-  color: var(--badge-blue-text);
-  border-color: rgba(59, 130, 246, 0.2);
-}
-
-.scope-badge.cluster {
-  background-color: var(--badge-purple-bg);
-  color: var(--badge-purple-text);
-  border-color: rgba(168, 85, 247, 0.2);
-}
 
 /* ==========================================================================
    Badge Focus States

--- a/frontend/styles/components/dropdowns.css
+++ b/frontend/styles/components/dropdowns.css
@@ -35,7 +35,7 @@
   border: 1px solid var(--color-border);
   border-radius: var(--border-radius-sm);
   color: var(--color-text);
-  line-height: 1.2;
+  line-height: 1.5rem;
   width: auto;
   min-width: min-content;
   cursor: pointer;
@@ -75,6 +75,7 @@
 /* Trigger content elements */
 .dropdown-value {
   color: var(--color-text);
+  line-height: inherit;
   white-space: nowrap;
 }
 
@@ -178,7 +179,8 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 6px 10px;
+  line-height: 1.35rem;
+  padding: 3px 10px;
   font-size: var(--font-size-normal);
   color: var(--color-text);
   user-select: none;
@@ -218,7 +220,7 @@
 /* Shared multi-select filter styling (Browse filters & Application Logs) */
 .dropdown-menu.dropdown-filter-menu .dropdown-option {
   gap: 0;
-  padding: 6px 12px;
+  padding: 3px 12px;
 }
 
 .dropdown-menu.dropdown-filter-menu .dropdown-option.selected {
@@ -245,6 +247,7 @@
   align-items: center;
   justify-content: center;
   font-size: 12px;
+  line-height: inherit;
   color: var(--color-text);
   font-weight: 600;
 }
@@ -252,6 +255,7 @@
 .dropdown-filter-label {
   flex: 1;
   min-width: 0;
+  line-height: inherit;
   text-align: left;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -260,6 +264,7 @@
 /* Option content elements */
 .option-label {
   flex: 1;
+  line-height: inherit;
   font-weight: 400;
 }
 
@@ -406,7 +411,7 @@
    ============================================ */
 .dropdown .dropdown-trigger {
   /* Default/compact/small all use same styling for consistency */
-  padding: 0.3rem 2rem 0.3rem var(--spacing-md);
+  padding: 0 2rem 0 var(--spacing-md);
   min-height: 12px;
   font-size: var(--font-size-button);
   min-width: 150px;

--- a/frontend/styles/components/gridtables.css
+++ b/frontend/styles/components/gridtables.css
@@ -66,7 +66,9 @@
   --grid-spacing-sm: var(--spacing-sm);
   --grid-spacing-md: var(--spacing-md);
   --grid-spacing-cell-x: 1rem;
-  --grid-spacing-cell-y: var(--spacing-sm);
+  --grid-spacing-cell-y: 0.3rem;
+  --grid-spacing-badge-cell-y: var(--spacing-sm);
+  --grid-cell-line-height: 1.35rem;
 
   /* Note: Table-specific column definitions moved to individual CSS files */
 }
@@ -199,6 +201,7 @@ body.dockable-panel-resizing .content-body .gridtable-header-container {
 .grid-cell-header {
   font-size: var(--grid-font-size-header);
   font-weight: var(--font-weight-bold);
+  line-height: var(--grid-cell-line-height);
   letter-spacing: 0.04em;
   padding: var(--grid-spacing-cell-y) var(--grid-spacing-cell-x);
   text-align: left;
@@ -220,11 +223,13 @@ body.dockable-panel-resizing .content-body .gridtable-header-container {
   display: flex;
   align-items: center;
   flex: 1;
+  line-height: inherit;
   overflow: hidden;
 }
 
 .header-content > span {
   display: inline-block;
+  line-height: inherit;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -401,6 +406,7 @@ body.gridtable-disable-hover .gridtable-hover-overlay {
 
 .grid-cell {
   font-size: var(--grid-font-size-data);
+  line-height: var(--grid-cell-line-height);
   padding: var(--grid-spacing-cell-y) var(--grid-spacing-cell-x);
   text-align: left;
   display: flex;
@@ -420,6 +426,7 @@ body.gridtable-disable-hover .gridtable-hover-overlay {
 /* Content wrapper for proper truncation within flex container */
 .grid-cell-content {
   white-space: nowrap;
+  line-height: inherit;
   overflow: hidden;
   text-overflow: ellipsis;
   min-width: 0;
@@ -428,6 +435,12 @@ body.gridtable-disable-hover .gridtable-hover-overlay {
 }
 
 /* Type column - no ellipsis for badge display */
+.grid-cell[data-column="kind"],
+.grid-cell[data-column="type"] {
+  padding-top: var(--grid-spacing-badge-cell-y);
+  padding-bottom: var(--grid-spacing-badge-cell-y);
+}
+
 .grid-cell[data-column="type"] {
   overflow: visible;
   text-overflow: clip;
@@ -439,7 +452,7 @@ body.gridtable-disable-hover .gridtable-hover-overlay {
   overflow: visible;
   text-overflow: clip;
   white-space: normal; /* Allow event text to wrap */
-  line-height: 1.4;
+  line-height: var(--grid-cell-line-height);
 }
 
 /* --- Table Variants ------------------------------------------------------ */
@@ -613,6 +626,7 @@ body.gridtable-disable-hover .gridtable-hover-overlay {
 
 .event-message {
   display: block;
+  line-height: inherit;
   max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
Fix rendering problem where letters with descenders like `g` could get clipped in Windows.