### PR TITLE
per-domain informer readiness

### DIFF
--- a/backend/refresh/informer/factory.go
+++ b/backend/refresh/informer/factory.go
@@ -37,6 +37,7 @@ type Factory struct {
 	syncedMu sync.RWMutex
 
 	syncStates   []*informerSyncState
+	shutdown     bool
 	syncStatesMu sync.Mutex
 
 	pendingClusterInformers []clusterInformerRegistration
@@ -50,8 +51,11 @@ type Factory struct {
 
 // informerSyncState tracks one informer's progress toward its initial sync.
 // terminal flips when the watch fails with an error that can never succeed,
-// so the informer stops blocking the factory-wide sync gate.
+// so the informer stops blocking the sync gates. key is the canonical
+// resource identity (permissions.ResourceKey format) used for per-resource
+// readiness checks.
 type informerSyncState struct {
+	key       string
 	hasSynced cache.InformerSynced
 	terminal  atomic.Bool
 }
@@ -126,20 +130,20 @@ func New(client kubernetes.Interface, apiextClient apiextensionsclientset.Interf
 	if err := podInformer.AddIndexers(cache.Indexers{podNodeIndexName: podNodeIndexFunc}); err != nil {
 		klog.V(2).Infof("pods informer: failed to add node index: %v", err)
 	}
-	result.registerInformer(podInformer)
-	result.registerInformer(kubeFactory.Core().V1().ConfigMaps().Informer())
-	result.registerInformer(kubeFactory.Core().V1().Secrets().Informer())
-	result.registerInformer(kubeFactory.Core().V1().Services().Informer())
-	result.registerInformer(kubeFactory.Discovery().V1().EndpointSlices().Informer())
+	result.registerInformer("", "pods", podInformer)
+	result.registerInformer("", "configmaps", kubeFactory.Core().V1().ConfigMaps().Informer())
+	result.registerInformer("", "secrets", kubeFactory.Core().V1().Secrets().Informer())
+	result.registerInformer("", "services", kubeFactory.Core().V1().Services().Informer())
+	result.registerInformer("discovery.k8s.io", "endpointslices", kubeFactory.Discovery().V1().EndpointSlices().Informer())
 	result.registerClusterInformer("", "namespaces", func() cache.SharedIndexInformer {
 		return kubeFactory.Core().V1().Namespaces().Informer()
 	})
-	result.registerInformer(kubeFactory.Apps().V1().ReplicaSets().Informer())
-	result.registerInformer(kubeFactory.Apps().V1().Deployments().Informer())
-	result.registerInformer(kubeFactory.Apps().V1().StatefulSets().Informer())
-	result.registerInformer(kubeFactory.Apps().V1().DaemonSets().Informer())
-	result.registerInformer(kubeFactory.Batch().V1().Jobs().Informer())
-	result.registerInformer(kubeFactory.Batch().V1().CronJobs().Informer())
+	result.registerInformer("apps", "replicasets", kubeFactory.Apps().V1().ReplicaSets().Informer())
+	result.registerInformer("apps", "deployments", kubeFactory.Apps().V1().Deployments().Informer())
+	result.registerInformer("apps", "statefulsets", kubeFactory.Apps().V1().StatefulSets().Informer())
+	result.registerInformer("apps", "daemonsets", kubeFactory.Apps().V1().DaemonSets().Informer())
+	result.registerInformer("batch", "jobs", kubeFactory.Batch().V1().Jobs().Informer())
+	result.registerInformer("batch", "cronjobs", kubeFactory.Batch().V1().CronJobs().Informer())
 	result.registerClusterInformer("rbac.authorization.k8s.io", "clusterroles", func() cache.SharedIndexInformer {
 		return kubeFactory.Rbac().V1().ClusterRoles().Informer()
 	})
@@ -152,31 +156,31 @@ func New(client kubernetes.Interface, apiextClient apiextensionsclientset.Interf
 	result.registerClusterInformer("rbac.authorization.k8s.io", "rolebindings", func() cache.SharedIndexInformer {
 		return kubeFactory.Rbac().V1().RoleBindings().Informer()
 	})
-	result.registerInformer(kubeFactory.Core().V1().ServiceAccounts().Informer())
+	result.registerInformer("", "serviceaccounts", kubeFactory.Core().V1().ServiceAccounts().Informer())
 	result.registerClusterInformer("", "persistentvolumes", func() cache.SharedIndexInformer {
 		return kubeFactory.Core().V1().PersistentVolumes().Informer()
 	})
-	result.registerInformer(kubeFactory.Core().V1().PersistentVolumeClaims().Informer())
-	result.registerInformer(kubeFactory.Core().V1().ResourceQuotas().Informer())
-	result.registerInformer(kubeFactory.Core().V1().LimitRanges().Informer())
+	result.registerInformer("", "persistentvolumeclaims", kubeFactory.Core().V1().PersistentVolumeClaims().Informer())
+	result.registerInformer("", "resourcequotas", kubeFactory.Core().V1().ResourceQuotas().Informer())
+	result.registerInformer("", "limitranges", kubeFactory.Core().V1().LimitRanges().Informer())
 	result.registerClusterInformer("storage.k8s.io", "storageclasses", func() cache.SharedIndexInformer {
 		return kubeFactory.Storage().V1().StorageClasses().Informer()
 	})
 	result.registerClusterInformer("networking.k8s.io", "ingressclasses", func() cache.SharedIndexInformer {
 		return kubeFactory.Networking().V1().IngressClasses().Informer()
 	})
-	result.registerInformer(kubeFactory.Networking().V1().Ingresses().Informer())
-	result.registerInformer(kubeFactory.Networking().V1().NetworkPolicies().Informer())
-	result.registerInformer(kubeFactory.Autoscaling().V1().HorizontalPodAutoscalers().Informer())
+	result.registerInformer("networking.k8s.io", "ingresses", kubeFactory.Networking().V1().Ingresses().Informer())
+	result.registerInformer("networking.k8s.io", "networkpolicies", kubeFactory.Networking().V1().NetworkPolicies().Informer())
+	result.registerInformer("autoscaling", "horizontalpodautoscalers", kubeFactory.Autoscaling().V1().HorizontalPodAutoscalers().Informer())
 	// Keep PDBs in sync for the namespace quotas refresh domain.
-	result.registerInformer(kubeFactory.Policy().V1().PodDisruptionBudgets().Informer())
+	result.registerInformer("policy", "poddisruptionbudgets", kubeFactory.Policy().V1().PodDisruptionBudgets().Informer())
 	result.registerClusterInformer("admissionregistration.k8s.io", "validatingwebhookconfigurations", func() cache.SharedIndexInformer {
 		return kubeFactory.Admissionregistration().V1().ValidatingWebhookConfigurations().Informer()
 	})
 	result.registerClusterInformer("admissionregistration.k8s.io", "mutatingwebhookconfigurations", func() cache.SharedIndexInformer {
 		return kubeFactory.Admissionregistration().V1().MutatingWebhookConfigurations().Informer()
 	})
-	result.registerInformer(kubeFactory.Core().V1().Events().Informer())
+	result.registerInformer("", "events", kubeFactory.Core().V1().Events().Informer())
 
 	if apiextClient != nil {
 		result.apiextFactory = apiextinformers.NewSharedInformerFactory(apiextClient, resync)
@@ -190,6 +194,8 @@ func New(client kubernetes.Interface, apiextClient apiextensionsclientset.Interf
 	return result
 }
 
+const gatewayGroup = "gateway.networking.k8s.io"
+
 // WithGatewayFactory registers Gateway API informers that are available on the cluster.
 // It must be called before Start so the Gateway caches participate in initial sync.
 func (f *Factory) WithGatewayFactory(factory gatewayinformers.SharedInformerFactory, presence common.GatewayAPIPresence) *Factory {
@@ -199,28 +205,28 @@ func (f *Factory) WithGatewayFactory(factory gatewayinformers.SharedInformerFact
 	f.gatewayFactory = factory
 	gateway := factory.Gateway().V1()
 	if presence.Has("GatewayClass") {
-		f.registerInformer(gateway.GatewayClasses().Informer())
+		f.registerInformer(gatewayGroup, "gatewayclasses", gateway.GatewayClasses().Informer())
 	}
 	if presence.Has("Gateway") {
-		f.registerInformer(gateway.Gateways().Informer())
+		f.registerInformer(gatewayGroup, "gateways", gateway.Gateways().Informer())
 	}
 	if presence.Has("HTTPRoute") {
-		f.registerInformer(gateway.HTTPRoutes().Informer())
+		f.registerInformer(gatewayGroup, "httproutes", gateway.HTTPRoutes().Informer())
 	}
 	if presence.Has("GRPCRoute") {
-		f.registerInformer(gateway.GRPCRoutes().Informer())
+		f.registerInformer(gatewayGroup, "grpcroutes", gateway.GRPCRoutes().Informer())
 	}
 	if presence.Has("TLSRoute") {
-		f.registerInformer(gateway.TLSRoutes().Informer())
+		f.registerInformer(gatewayGroup, "tlsroutes", gateway.TLSRoutes().Informer())
 	}
 	if presence.Has("ListenerSet") {
-		f.registerInformer(gateway.ListenerSets().Informer())
+		f.registerInformer(gatewayGroup, "listenersets", gateway.ListenerSets().Informer())
 	}
 	if presence.Has("ReferenceGrant") {
-		f.registerInformer(gateway.ReferenceGrants().Informer())
+		f.registerInformer(gatewayGroup, "referencegrants", gateway.ReferenceGrants().Informer())
 	}
 	if presence.Has("BackendTLSPolicy") {
-		f.registerInformer(gateway.BackendTLSPolicies().Informer())
+		f.registerInformer(gatewayGroup, "backendtlspolicies", gateway.BackendTLSPolicies().Informer())
 	}
 	return f
 }
@@ -317,6 +323,45 @@ func (f *Factory) HasSynced(ctx context.Context) bool {
 	return f.synced
 }
 
+// ResourcesSettled reports whether every informer backing the supplied
+// canonical resource keys (permissions.ResourceKey format, e.g. "core/pods")
+// has either synced or terminally failed. A key with no registered informer
+// is settled — the informer was skipped (insufficient permissions, API not
+// present) so there is nothing to wait for. A shut-down factory reports
+// false, mirroring HasSynced.
+func (f *Factory) ResourcesSettled(keys []string) bool {
+	if f == nil {
+		return false
+	}
+	f.syncStatesMu.Lock()
+	shutdown := f.shutdown
+	states := make([]*informerSyncState, len(f.syncStates))
+	copy(states, f.syncStates)
+	f.syncStatesMu.Unlock()
+	if shutdown {
+		return false
+	}
+	if len(keys) == 0 {
+		return true
+	}
+	wanted := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		wanted[key] = struct{}{}
+	}
+	for _, state := range states {
+		if _, ok := wanted[state.key]; !ok {
+			continue
+		}
+		if state.terminal.Load() {
+			continue
+		}
+		if !state.hasSynced() {
+			return false
+		}
+	}
+	return true
+}
+
 // Shutdown clears factory references to allow garbage collection.
 // The informers themselves stop via context cancellation, but clearing
 // references ensures memory is reclaimed during transport rebuilds.
@@ -332,6 +377,7 @@ func (f *Factory) Shutdown() error {
 
 	f.syncStatesMu.Lock()
 	f.syncStates = nil
+	f.shutdown = true
 	f.syncStatesMu.Unlock()
 
 	f.permissionMu.Lock()
@@ -347,11 +393,11 @@ func (f *Factory) Shutdown() error {
 	return nil
 }
 
-func (f *Factory) registerInformer(inf cache.SharedIndexInformer) {
+func (f *Factory) registerInformer(group, resource string, inf cache.SharedIndexInformer) {
 	if inf == nil {
 		return
 	}
-	state := &informerSyncState{hasSynced: inf.HasSynced}
+	state := &informerSyncState{key: permissions.ResourceKey(group, resource), hasSynced: inf.HasSynced}
 	err := inf.SetWatchErrorHandlerWithContext(func(ctx context.Context, r *cache.Reflector, watchErr error) {
 		cache.DefaultWatchErrorHandler(ctx, r, watchErr)
 		if isTerminalWatchError(watchErr) && state.terminal.CompareAndSwap(false, true) {
@@ -430,7 +476,7 @@ func (f *Factory) processPendingClusterInformers() {
 			klog.V(2).Infof("Skipping informer for %s/%s due to insufficient permissions", pending.group, pending.resource)
 			continue
 		}
-		f.registerInformer(pending.factory())
+		f.registerInformer(pending.group, pending.resource, pending.factory())
 	}
 
 	f.pendingClusterInformers = nil

--- a/backend/refresh/informer/factory_test.go
+++ b/backend/refresh/informer/factory_test.go
@@ -47,7 +47,7 @@ func TestStartSettlesWhenInformerCanNeverSync(t *testing.T) {
 
 	notFound := apierrors.NewNotFound(schema.GroupResource{Group: "gateway.networking.k8s.io", Resource: "tlsroutes"}, "")
 	broken := brokenInformer(notFound)
-	factory.registerInformer(broken)
+	factory.registerInformer("gateway.networking.k8s.io", "tlsroutes", broken)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -68,7 +68,7 @@ func TestStartKeepsBlockingOnTransientFailures(t *testing.T) {
 	factory := newStartedFactory(t)
 
 	broken := brokenInformer(errors.New("connection refused"))
-	factory.registerInformer(broken)
+	factory.registerInformer("gateway.networking.k8s.io", "tlsroutes", broken)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
@@ -79,6 +79,75 @@ func TestStartKeepsBlockingOnTransientFailures(t *testing.T) {
 	}
 	if factory.HasSynced(context.Background()) {
 		t.Fatalf("expected factory to stay unsynced when failures are transient")
+	}
+}
+
+func TestResourcesSettledIsolatesPendingKeys(t *testing.T) {
+	factory := newStartedFactory(t)
+
+	transient := brokenInformer(errors.New("connection refused"))
+	factory.registerInformer("gateway.networking.k8s.io", "tlsroutes", transient)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	go transient.Run(ctx.Done())
+	go func() { _ = factory.Start(ctx) }()
+
+	// The fake-client informers settle while the transient one stays pending —
+	// the per-domain win in miniature.
+	deadline := time.Now().Add(5 * time.Second)
+	for !factory.ResourcesSettled([]string{"core/pods"}) {
+		if time.Now().After(deadline) {
+			t.Fatalf("expected core/pods to settle while an unrelated informer is pending")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if factory.ResourcesSettled([]string{"gateway.networking.k8s.io/tlsroutes"}) {
+		t.Fatalf("expected the pending informer to block its own key")
+	}
+	if factory.ResourcesSettled([]string{"core/pods", "gateway.networking.k8s.io/tlsroutes"}) {
+		t.Fatalf("expected one pending key to block the combined set")
+	}
+}
+
+func TestResourcesSettledTreatsTerminalAsSettled(t *testing.T) {
+	factory := newStartedFactory(t)
+
+	notFound := apierrors.NewNotFound(schema.GroupResource{Group: "gateway.networking.k8s.io", Resource: "tlsroutes"}, "")
+	broken := brokenInformer(notFound)
+	factory.registerInformer("gateway.networking.k8s.io", "tlsroutes", broken)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	go broken.Run(ctx.Done())
+
+	deadline := time.Now().Add(10 * time.Second)
+	for !factory.ResourcesSettled([]string{"gateway.networking.k8s.io/tlsroutes"}) {
+		if time.Now().After(deadline) {
+			t.Fatalf("expected a terminally failed informer to settle its key")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestResourcesSettledUnknownKeyIsSettled(t *testing.T) {
+	factory := newStartedFactory(t)
+	// A resource with no registered informer (skipped for permissions or never
+	// present) has nothing to wait for.
+	if !factory.ResourcesSettled([]string{"gateway.networking.k8s.io/grpcroutes"}) {
+		t.Fatalf("expected a key with no registered informer to be settled")
+	}
+}
+
+func TestResourcesSettledFalseAfterShutdown(t *testing.T) {
+	factory := newStartedFactory(t)
+	if err := factory.Shutdown(); err != nil {
+		t.Fatalf("Shutdown returned error: %v", err)
+	}
+	// Mirror HasSynced: a shut-down factory must block, not default open.
+	if factory.ResourcesSettled([]string{"core/pods"}) {
+		t.Fatalf("expected a shut-down factory to report unsettled")
 	}
 }
 

--- a/backend/refresh/snapshot/service.go
+++ b/backend/refresh/snapshot/service.go
@@ -34,6 +34,7 @@ type Service struct {
 	sequence            uint64
 	cluster             ClusterMeta
 	informerHub         refresh.InformerHub
+	domainReadiness     map[string][]string
 	informerSyncTimeout time.Duration
 	cacheMu             sync.RWMutex
 	cache               map[string]cacheEntry
@@ -108,6 +109,19 @@ func (s *Service) WithInformerHub(hub refresh.InformerHub) *Service {
 	return s
 }
 
+// WithDomainReadiness narrows the informer sync gate per domain: a declared
+// domain waits only on its own resources' informers (canonical
+// permissions.ResourceKey format), so one slow watch no longer delays every
+// other domain's first snapshot. Domains absent from the map keep the
+// conservative factory-wide gate.
+func (s *Service) WithDomainReadiness(readiness map[string][]string) *Service {
+	if s == nil {
+		return s
+	}
+	s.domainReadiness = readiness
+	return s
+}
+
 // Build returns a snapshot for the requested domain/scope.
 func (s *Service) Build(ctx context.Context, domainName, scope string) (*refresh.Snapshot, error) {
 	return s.BuildRequest(BuildRequest{
@@ -131,7 +145,7 @@ func (s *Service) BuildRequest(req BuildRequest) (*refresh.Snapshot, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := s.waitForInformerSync(ctx); err != nil {
+	if err := s.waitForInformerSync(ctx, domainName); err != nil {
 		if errors.Is(err, errInformerSyncTimeout) {
 			s.recordTelemetry(domainName, scope, 0, err, false, 0, nil, 0, 0, 0, true, 0)
 		}
@@ -215,8 +229,20 @@ func (s *Service) BuildRequest(req BuildRequest) (*refresh.Snapshot, error) {
 	return value.(*refresh.Snapshot), nil
 }
 
-func (s *Service) waitForInformerSync(ctx context.Context) error {
-	if s == nil || s.informerHub == nil || s.informerHub.HasSynced(ctx) {
+func (s *Service) waitForInformerSync(ctx context.Context, domainName string) error {
+	if s == nil || s.informerHub == nil {
+		return nil
+	}
+	// A domain with declared readiness resources waits only on those informers;
+	// undeclared domains keep the conservative factory-wide gate.
+	keys, scoped := s.domainReadiness[domainName]
+	settled := func() bool {
+		if scoped {
+			return s.informerHub.ResourcesSettled(keys)
+		}
+		return s.informerHub.HasSynced(ctx)
+	}
+	if settled() {
 		return nil
 	}
 	timeout := s.informerSyncTimeout
@@ -224,8 +250,8 @@ func (s *Service) waitForInformerSync(ctx context.Context) error {
 		timeout = config.RefreshInformerSyncTimeout
 	}
 	// Bound the wait: a single informer whose watch can never complete (for
-	// example an RBAC-forbidden resource) keeps the factory-wide sync flag
-	// false forever, and the caller's context may carry no deadline.
+	// example an RBAC-forbidden resource) keeps the sync gate closed forever,
+	// and the caller's context may carry no deadline.
 	deadline := time.NewTimer(timeout)
 	defer deadline.Stop()
 	ticker := time.NewTicker(config.RefreshInformerSyncPollInterval)
@@ -237,7 +263,7 @@ func (s *Service) waitForInformerSync(ctx context.Context) error {
 		case <-deadline.C:
 			return fmt.Errorf("%w after %s; the cluster API may be unreachable or a watch may be unauthorized", errInformerSyncTimeout, timeout)
 		case <-ticker.C:
-			if s.informerHub.HasSynced(ctx) {
+			if settled() {
 				return nil
 			}
 		}

--- a/backend/refresh/snapshot/service_test.go
+++ b/backend/refresh/snapshot/service_test.go
@@ -27,8 +27,9 @@ func testClusterMeta() ClusterMeta {
 }
 
 type fakeInformerHub struct {
-	mu     sync.RWMutex
-	synced bool
+	mu      sync.RWMutex
+	synced  bool
+	pending map[string]bool
 }
 
 func (h *fakeInformerHub) Start(context.Context) error { return nil }
@@ -39,12 +40,34 @@ func (h *fakeInformerHub) HasSynced(context.Context) bool {
 	return h.synced
 }
 
+// ResourcesSettled mirrors the factory semantics: a key blocks only while
+// explicitly marked pending; unknown keys are settled.
+func (h *fakeInformerHub) ResourcesSettled(keys []string) bool {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	for _, key := range keys {
+		if h.pending[key] {
+			return false
+		}
+	}
+	return true
+}
+
 func (h *fakeInformerHub) Shutdown() error { return nil }
 
 func (h *fakeInformerHub) setSynced(synced bool) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.synced = synced
+}
+
+func (h *fakeInformerHub) setPending(key string, pending bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.pending == nil {
+		h.pending = make(map[string]bool)
+	}
+	h.pending[key] = pending
 }
 
 func TestServiceBuildEmitsSequenceAndChecksum(t *testing.T) {
@@ -179,6 +202,82 @@ func TestServiceBuildFailsWhenInformerSyncTimesOut(t *testing.T) {
 	}
 	if summary.Snapshots[0].LastStatus != "error" || summary.Snapshots[0].LastError == "" {
 		t.Fatalf("expected error telemetry for the sync timeout, got %+v", summary.Snapshots[0])
+	}
+}
+
+func registerEchoDomain(t *testing.T, reg *domain.Registry, name string) {
+	t.Helper()
+	if err := reg.Register(refresh.DomainConfig{
+		Name: name,
+		BuildSnapshot: func(ctx context.Context, scope string) (*refresh.Snapshot, error) {
+			return &refresh.Snapshot{Domain: name, Scope: scope, Payload: map[string]string{"domain": name}}, nil
+		},
+	}); err != nil {
+		t.Fatalf("register %s failed: %v", name, err)
+	}
+}
+
+func TestServiceBuildGatesOnDeclaredDomainResources(t *testing.T) {
+	reg := domain.New()
+	registerEchoDomain(t, reg, "nodes")
+	registerEchoDomain(t, reg, "pods")
+	registerEchoDomain(t, reg, "catalog")
+
+	hub := &fakeInformerHub{}
+	hub.setPending("core/pods", true)
+	// Factory-wide flag stays false the whole test: mapped domains must not
+	// consult it.
+	service := NewService(reg, nil, testClusterMeta()).
+		WithInformerHub(hub).
+		WithDomainReadiness(map[string][]string{
+			"nodes":   {"core/nodes"},
+			"pods":    {"core/pods"},
+			"catalog": {},
+		})
+	service.informerSyncTimeout = 50 * time.Millisecond
+
+	// A domain whose declared resources are settled builds immediately even
+	// while an unrelated informer is pending and the factory-wide flag is false.
+	if _, err := service.Build(context.Background(), "nodes", ""); err != nil {
+		t.Fatalf("nodes build should not wait on unrelated informers: %v", err)
+	}
+
+	// A mapped domain with no informer dependencies never waits.
+	if _, err := service.Build(context.Background(), "catalog", ""); err != nil {
+		t.Fatalf("catalog build with no declared resources should not wait: %v", err)
+	}
+
+	// A domain whose own resource is pending still times out.
+	if _, err := service.Build(context.Background(), "pods", ""); !errors.Is(err, errInformerSyncTimeout) {
+		t.Fatalf("expected pods build to fail with informer sync timeout, got %v", err)
+	}
+
+	// Once its own resource settles, the domain builds.
+	hub.setPending("core/pods", false)
+	if _, err := service.Build(context.Background(), "pods", ""); err != nil {
+		t.Fatalf("pods build should succeed once its resource settles: %v", err)
+	}
+}
+
+func TestServiceBuildUnmappedDomainKeepsFactoryWideGate(t *testing.T) {
+	reg := domain.New()
+	registerEchoDomain(t, reg, "object-yaml")
+
+	hub := &fakeInformerHub{}
+	service := NewService(reg, nil, testClusterMeta()).
+		WithInformerHub(hub).
+		WithDomainReadiness(map[string][]string{"nodes": {"core/nodes"}})
+	service.informerSyncTimeout = 50 * time.Millisecond
+
+	// Domains without a readiness declaration keep today's conservative
+	// factory-wide gate.
+	if _, err := service.Build(context.Background(), "object-yaml", ""); !errors.Is(err, errInformerSyncTimeout) {
+		t.Fatalf("expected unmapped domain to keep the factory-wide gate, got %v", err)
+	}
+
+	hub.setSynced(true)
+	if _, err := service.Build(context.Background(), "object-yaml", ""); err != nil {
+		t.Fatalf("unmapped domain should build once the factory reports synced: %v", err)
 	}
 }
 

--- a/backend/refresh/system/manager.go
+++ b/backend/refresh/system/manager.go
@@ -219,7 +219,8 @@ func NewSubsystemWithServices(cfg Config) (*Subsystem, error) {
 		telemetryRecorder,
 		clusterMeta,
 		runtimePerms,
-	).WithInformerHub(informerFactory)
+	).WithInformerHub(informerFactory).
+		WithDomainReadiness(domainReadinessResources(registrations))
 	queue := refresh.NewInMemoryQueue()
 
 	manager := refresh.NewManager(registry, informerFactory, snapshotService, metricsPoller, queue)

--- a/backend/refresh/system/manager_test.go
+++ b/backend/refresh/system/manager_test.go
@@ -121,4 +121,6 @@ func (h fakeInformerHub) Start(context.Context) error { return nil }
 
 func (h fakeInformerHub) HasSynced(context.Context) bool { return h.synced }
 
+func (h fakeInformerHub) ResourcesSettled([]string) bool { return h.synced }
+
 func (fakeInformerHub) Shutdown() error { return nil }

--- a/backend/refresh/system/registrations.go
+++ b/backend/refresh/system/registrations.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/luxury-yacht/app/backend/refresh/domain"
@@ -169,6 +170,58 @@ func preflightRequests(registrations []domainRegistration, extra []informer.Perm
 	}
 
 	return requests
+}
+
+// domainReadinessResources returns, per registered domain, the canonical
+// resource keys (permissions.ResourceKey format) whose informers must settle
+// before the domain's snapshots build. The set is the union of the shared
+// permission composition (runtime + stream) and the registration's own
+// gate/preflight checks — every place a domain already declares the resources
+// it reads. Domains with no declaration anywhere are omitted and keep the
+// conservative factory-wide sync gate.
+func domainReadinessResources(registrations []domainRegistration) map[string][]string {
+	compositions := domainpermissions.CompositionByDomain()
+	result := make(map[string][]string, len(registrations))
+	for _, registration := range registrations {
+		seen := make(map[string]struct{})
+		add := func(group, resource string) {
+			seen[permissions.ResourceKey(group, resource)] = struct{}{}
+		}
+		if composition, ok := compositions[registration.name]; ok {
+			for _, resource := range composition.Runtime {
+				add(resource.Group, resource.Resource)
+			}
+			for _, resource := range composition.Stream {
+				add(resource.Group, resource.Resource)
+			}
+		}
+		if registration.list != nil {
+			for _, check := range registration.list.checks {
+				add(check.group, check.resource)
+			}
+		}
+		if registration.listWatch != nil {
+			for _, check := range registration.listWatch.checks {
+				add(check.group, check.resource)
+			}
+		}
+		for _, check := range registration.preflightList {
+			add(check.group, check.resource)
+		}
+		for _, check := range registration.preflightListWatch {
+			add(check.group, check.resource)
+		}
+		if len(seen) == 0 {
+			continue
+		}
+		keys := make([]string, 0, len(seen))
+		for key := range seen {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		result[registration.name] = keys
+	}
+	return result
 }
 
 // domainRegistrations returns the ordered domain registration table.

--- a/backend/refresh/system/registrations_test.go
+++ b/backend/refresh/system/registrations_test.go
@@ -779,3 +779,38 @@ func registrationKind(registration domainRegistration) string {
 		return ""
 	}
 }
+
+func TestDomainReadinessResourcesUnionsDeclaredContracts(t *testing.T) {
+	registrations := domainRegistrations(registrationDeps{cfg: Config{}})
+	readiness := domainReadinessResources(registrations)
+
+	// Registration gate checks beyond the permission policy are included:
+	// cluster-overview checks nodes+pods+namespaces while its policy declares
+	// only nodes.
+	require.ElementsMatch(t,
+		[]string{"core/namespaces", "core/nodes", "core/pods"},
+		readiness["cluster-overview"])
+
+	// Composition runtime AND stream resources are included: namespace-workloads
+	// streams replicasets and HPAs beyond its runtime workload kinds.
+	require.Contains(t, readiness["namespace-workloads"], "apps/replicasets")
+	require.Contains(t, readiness["namespace-workloads"], "autoscaling/horizontalpodautoscalers")
+
+	// Direct registrations with a policy entry still get their resources.
+	require.Equal(t, []string{"core/namespaces"}, readiness["namespaces"])
+	require.Equal(t, []string{"core/pods"}, readiness["pods"])
+
+	// Domains with no declaration anywhere stay absent and keep the
+	// conservative factory-wide gate.
+	require.NotContains(t, readiness, "object-yaml")
+	require.NotContains(t, readiness, "object-details")
+	require.NotContains(t, readiness, "catalog")
+
+	// Every mapped domain has a non-empty, canonical (group/resource) key set.
+	for domainName, keys := range readiness {
+		require.NotEmptyf(t, keys, "domain %q mapped with an empty readiness set", domainName)
+		for _, key := range keys {
+			require.Containsf(t, key, "/", "domain %q key %q is not canonical", domainName, key)
+		}
+	}
+}

--- a/backend/refresh/types.go
+++ b/backend/refresh/types.go
@@ -44,6 +44,10 @@ type DomainConfig struct {
 type InformerHub interface {
 	Start(ctx context.Context) error
 	HasSynced(ctx context.Context) bool
+	// ResourcesSettled reports whether the informers backing the supplied
+	// canonical resource keys (permissions.ResourceKey format) have synced or
+	// terminally failed. Keys with no informer are settled.
+	ResourcesSettled(keys []string) bool
 	Shutdown() error
 }
 

--- a/docs/release/pending.md
+++ b/docs/release/pending.md
@@ -5,3 +5,4 @@
 ### Fixed
 
 - Cluster initialization should no longer hang on unknown API versions of CRDs. Unknown CRDs will be flagged in the Application Logs, but cluster init should proceed normally.
+- Tables now load as soon as their own data is ready during cluster connection: one slow or failing watch (for example a misbehaving CRD or restricted resource) no longer delays every other view's first load.


### PR DESCRIPTION
When the app connects to a cluster, it starts dozens of background watchers — one per resource type (pods, nodes, config, and so on). Until now, no view was allowed to show data until every watcher had finished its first load. One slow or broken watcher could make every screen sit in a loading state for up to 30 seconds, even when the data they needed was already there.

With this change, each view waits only for the watchers it actually depends on. The pods table waits for the pod watcher; it no longer cares that some unrelated resource is slow. A misbehaving resource type now affects only the views that use it.

- Each background watcher is now labeled with the resource it watches, instead of being anonymous.
- Each view's data builder knows which resources it reads — taken from lists the codebase already maintained for permission checks, so nothing new to keep in sync.
- Before building a view's data, the app now checks only that view's watchers. 23 of the 29 view types get this precise check; the handful with no declared resource list (mostly object-detail panels) keep the old all-watchers behavior, so they can't be accidentally under-protected.
- The cluster health check and the "is this cluster ready" signal work exactly as before.