### PR TITLE
Auth bin decoupling

### DIFF
--- a/backend/app_heartbeat.go
+++ b/backend/app_heartbeat.go
@@ -2,12 +2,11 @@ package backend
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/luxury-yacht/app/backend/internal/config"
+	"github.com/luxury-yacht/app/backend/internal/credentialerrors"
 	"github.com/luxury-yacht/app/backend/internal/logsources"
-	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // healthStatus distinguishes the outcome of a cluster health check.
@@ -119,31 +118,15 @@ func (a *App) checkClusterHealth(cc *clusterClients) healthStatus {
 		return healthOK
 	}
 
-	// Distinguish auth errors from connectivity errors.
-	// HTTP 401/403 are clear auth failures.
-	if k8sErrors.IsUnauthorized(err) || k8sErrors.IsForbidden(err) {
-		return healthAuthFailure
-	}
-	// Exec credential plugin failures (e.g. expired SSO token causing `aws` to exit non-zero)
-	// never produce an HTTP response — the request fails before it's sent.
-	// Detect these by inspecting the error string for exec-plugin patterns.
-	if isExecCredentialError(err) {
+	// Distinguish auth errors from connectivity errors. A rejected credential
+	// (HTTP 401/403) or a failed/missing exec credential plugin is an auth
+	// failure; everything else (network error, timeout, DNS) is connectivity.
+	// Exec-plugin failures never produce an HTTP response — the request fails
+	// before it is sent — so they are detected by the shared classifier too.
+	if credentialerrors.Classify(err, credentialerrors.Context{}).IsAuth() {
 		return healthAuthFailure
 	}
 	return healthConnectivityFailure
-}
-
-// isExecCredentialError returns true when the error looks like an exec-based
-// credential plugin failure (e.g. expired SSO token, missing CLI tool).
-// These fail before the HTTP request is sent so they never produce a status code.
-func isExecCredentialError(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "getting credentials: exec:") ||
-		strings.Contains(msg, "exec plugin") ||
-		strings.Contains(msg, "executable") && strings.Contains(msg, "failed")
 }
 
 // startHeartbeatLoop runs runHeartbeatIteration on a periodic schedule.

--- a/backend/app_heartbeat_test.go
+++ b/backend/app_heartbeat_test.go
@@ -503,6 +503,32 @@ func TestCheckClusterHealth(t *testing.T) {
 		}
 	})
 
+	t.Run("expired credential transport error returns healthAuthFailure", func(t *testing.T) {
+		// An expired token surfaces as a transport error (no HTTP response). After
+		// centralizing classification, heartbeat treats this as an auth failure;
+		// previously the narrow heartbeat classifier let it fall through to
+		// connectivity. Pins the deliberate broadening.
+		expiredDisco := &heartbeatDiscovery{
+			FakeDiscovery: &fakediscovery.FakeDiscovery{Fake: &cgotesting.Fake{}},
+			restClient: &restfake.RESTClient{
+				NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+				Client: restfake.CreateHTTPClient(func(*http.Request) (*http.Response, error) {
+					return nil, errors.New("token has expired")
+				}),
+			},
+		}
+		expiredClient := &heartbeatClientSet{Clientset: cgofake.NewClientset(), disco: expiredDisco}
+
+		cc := &clusterClients{
+			meta:   ClusterMeta{ID: "expired", Name: "Expired"},
+			client: expiredClient,
+		}
+
+		if got := app.checkClusterHealth(cc); got != healthAuthFailure {
+			t.Errorf("expected healthAuthFailure for expired credential, got %v", got)
+		}
+	})
+
 	t.Run("nil client returns healthConnectivityFailure", func(t *testing.T) {
 		cc := &clusterClients{
 			meta:   ClusterMeta{ID: "nil-client", Name: "Nil Client"},
@@ -515,29 +541,8 @@ func TestCheckClusterHealth(t *testing.T) {
 	})
 }
 
-// TestIsExecCredentialError verifies pattern matching for exec credential plugin failures.
-func TestIsExecCredentialError(t *testing.T) {
-	tests := []struct {
-		name string
-		err  error
-		want bool
-	}{
-		{"aws exec failure", errors.New(`getting credentials: exec: executable aws failed with exit code 255`), true},
-		{"gcloud exec failure", errors.New(`getting credentials: exec: executable gcloud failed with exit code 1`), true},
-		{"exec plugin error", errors.New(`exec plugin: some error occurred`), true},
-		{"connection refused", errors.New("connection refused"), false},
-		{"timeout", errors.New("context deadline exceeded"), false},
-		{"nil error", nil, false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := isExecCredentialError(tt.err); got != tt.want {
-				t.Errorf("isExecCredentialError(%v) = %v, want %v", tt.err, got, tt.want)
-			}
-		})
-	}
-}
+// Exec-credential pattern matching moved to backend/internal/credentialerrors
+// (see TestClassify). Heartbeat call-site behavior is pinned by TestCheckClusterHealth.
 
 // TestCheckClusterHealthUsesReadyz verifies that checkClusterHealth calls /readyz (not /healthz).
 func TestCheckClusterHealthUsesReadyz(t *testing.T) {

--- a/backend/app_refresh_update_test.go
+++ b/backend/app_refresh_update_test.go
@@ -101,7 +101,7 @@ func TestAuthFailedClusterDoesNotBlockNewClusterSelection(t *testing.T) {
 	// stays in StateInvalid after ReportFailure is called.
 	authMgrA := authstate.New(authstate.Config{
 		MaxAttempts:   0, // Disable auto-recovery so state stays Invalid
-		OnStateChange: func(authstate.State, string) {},
+		OnStateChange: func(authstate.State, authstate.FailureDiagnostic) {},
 	})
 	// Force auth manager into invalid state by reporting a failure.
 	// With MaxAttempts=0, this immediately transitions to StateInvalid.

--- a/backend/auth_providers.go
+++ b/backend/auth_providers.go
@@ -50,15 +50,13 @@ func (a *App) setupEnvironment() {
 		}
 
 		merged := mergePathLists(loginPath, current)
-		for _, candidate := range authHelperDirectories() {
+		for _, candidate := range defaultExecutableSearchDirectories() {
 			merged = ensurePathContains(merged, candidate)
 		}
 
 		if merged != "" && merged != current {
 			os.Setenv("PATH", merged)
 		}
-
-		_, _ = exec.LookPath("gke-gcloud-auth-plugin")
 	})
 }
 
@@ -143,30 +141,18 @@ func execCommandContext(ctx context.Context, name string, arg ...string) *exec.C
 	return cmd
 }
 
-func authHelperDirectories() []string {
+// defaultExecutableSearchDirectories returns generic desktop locations where
+// user-installed executables commonly live, including any credential helper a
+// kubeconfig's exec plugin names. It is intentionally provider-neutral: the app
+// does not hard-code cloud-provider install paths or probe for provider-specific
+// commands. Only directories that exist are returned, de-duplicated.
+func defaultExecutableSearchDirectories() []string {
 	home := resolveHomeDir()
 	candidates := []string{
 		"/usr/local/bin",
 		"/opt/homebrew/bin",
 		"/usr/bin",
 		filepath.Join(home, ".local", "bin"),
-		filepath.Join(home, "google-cloud-sdk", "bin"),
-		"/usr/local/share/google-cloud-sdk/bin",
-		"/opt/homebrew/share/google-cloud-sdk/bin",
-		"/usr/local/google-cloud-sdk/bin",
-		"/opt/homebrew/google-cloud-sdk/bin",
-	}
-
-	globs := []string{
-		"/opt/homebrew/Caskroom/google-cloud-sdk/*/google-cloud-sdk/bin",
-		"/usr/local/Caskroom/google-cloud-sdk/*/google-cloud-sdk/bin",
-	}
-
-	for _, pattern := range globs {
-		matches, err := filepath.Glob(pattern)
-		if err == nil {
-			candidates = append(candidates, matches...)
-		}
 	}
 
 	seen := make(map[string]struct{})

--- a/backend/auth_providers_paths_test.go
+++ b/backend/auth_providers_paths_test.go
@@ -2,8 +2,34 @@ package backend
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
+
+// TestDefaultExecutableSearchDirectoriesExcludesProviderPaths pins the Phase 2
+// contract: the app injects only generic desktop executable directories into
+// PATH and never cloud-provider install locations (Google Cloud SDK / Caskroom),
+// even when those directories exist under HOME.
+func TestDefaultExecutableSearchDirectoriesExcludesProviderPaths(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	localBin := filepath.Join(home, ".local", "bin")
+	gcloudBin := filepath.Join(home, "google-cloud-sdk", "bin")
+	require.NoError(t, os.MkdirAll(localBin, 0o755))
+	require.NoError(t, os.MkdirAll(gcloudBin, 0o755))
+
+	dirs := defaultExecutableSearchDirectories()
+
+	require.Contains(t, dirs, localBin, "generic $HOME/.local/bin must still be offered")
+	require.NotContains(t, dirs, gcloudBin, "provider google-cloud-sdk/bin must not be injected")
+	for _, dir := range dirs {
+		require.NotContains(t, dir, "google-cloud-sdk", "no provider path may be injected: %s", dir)
+		require.NotContains(t, dir, "Caskroom", "no provider path may be injected: %s", dir)
+	}
+}
 
 func TestEnsurePathContainsHandlesDuplicates(t *testing.T) {
 	original := "/usr/bin:/opt/bin"

--- a/backend/cluster_auth.go
+++ b/backend/cluster_auth.go
@@ -26,7 +26,7 @@ import (
 //
 // NOTE: This is called from the auth manager with the mutex held, so heavy
 // operations must be run asynchronously to avoid blocking other auth operations.
-func (a *App) handleClusterAuthStateChange(clusterID string, state authstate.State, reason string) {
+func (a *App) handleClusterAuthStateChange(clusterID string, state authstate.State, diag authstate.FailureDiagnostic) {
 	if a == nil || clusterID == "" {
 		return
 	}
@@ -57,13 +57,9 @@ func (a *App) handleClusterAuthStateChange(clusterID string, state authstate.Sta
 		})
 
 	case authstate.StateRecovering:
-		a.logger.Warn(fmt.Sprintf("Cluster %s: auth recovering - %s", clusterName, reason), logsources.Auth, clusterID, clusterName)
+		a.logger.Warn(fmt.Sprintf("Cluster %s: auth recovering - %s", clusterName, diag.Reason), logsources.Auth, clusterID, clusterName)
 		// Emit per-cluster recovering event for the frontend
-		a.emitEvent("cluster:auth:recovering", map[string]any{
-			"clusterId":   clusterID,
-			"clusterName": clusterName,
-			"reason":      reason,
-		})
+		a.emitEvent("cluster:auth:recovering", authEventPayload(clusterID, clusterName, diag))
 		// Teardown only this cluster's subsystem through the coordinated mutation path.
 		a.runSelectionMutationAsync(fmt.Sprintf("cluster-auth-teardown:%s", clusterID), func(_ *selectionMutation) error {
 			return a.runClusterOperation(context.Background(), clusterID, func(opCtx context.Context) error {
@@ -76,18 +72,29 @@ func (a *App) handleClusterAuthStateChange(clusterID string, state authstate.Sta
 		})
 
 	case authstate.StateInvalid:
-		a.logger.Error(fmt.Sprintf("Cluster %s: auth failed - %s", clusterName, reason), logsources.Auth, clusterID, clusterName)
+		a.logger.Error(fmt.Sprintf("Cluster %s: auth failed - %s", clusterName, diag.Reason), logsources.Auth, clusterID, clusterName)
 		// Capture the auth failure with cluster context for error enhancement
-		errorcapture.CaptureWithCluster(clusterID, fmt.Sprintf("auth failed: %s", reason))
+		errorcapture.CaptureWithCluster(clusterID, fmt.Sprintf("auth failed: %s", diag.Reason))
 		// Emit per-cluster failure event for the frontend
-		a.emitEvent("cluster:auth:failed", map[string]any{
-			"clusterId":   clusterID,
-			"clusterName": clusterName,
-			"reason":      reason,
-		})
+		a.emitEvent("cluster:auth:failed", authEventPayload(clusterID, clusterName, diag))
 		if a.clusterLifecycle != nil {
 			a.clusterLifecycle.SetState(clusterID, ClusterStateAuthFailed)
 		}
+	}
+}
+
+// authEventPayload builds an auth event payload carrying the per-cluster identity
+// plus the typed credential diagnostic. Every diagnostic field is always present
+// (empty string when unknown) so the frontend can rely on the payload shape.
+func authEventPayload(clusterID, clusterName string, diag authstate.FailureDiagnostic) map[string]any {
+	return map[string]any{
+		"clusterId":   clusterID,
+		"clusterName": clusterName,
+		"reason":      diag.Reason,
+		"class":       diag.Class,
+		"kind":        diag.Kind,
+		"summary":     diag.Summary,
+		"execCommand": diag.ExecCommand,
 	}
 }
 
@@ -356,14 +363,19 @@ func (a *App) GetAllClusterAuthStates() map[string]map[string]any {
 			states[id] = map[string]any{"state": "unknown", "reason": ""}
 			continue
 		}
-		state, reason := clients.authManager.State()
+		state, _ := clients.authManager.State()
+		diag := clients.authManager.FailureDiagnostic()
 		info := clients.authManager.RecoveryInfo()
 		states[id] = map[string]any{
 			"state":             state.String(),
-			"reason":            reason,
+			"reason":            diag.Reason,
 			"clusterName":       clients.meta.Name,
 			"secondsUntilRetry": info.SecondsUntilRetry,
 			"errorClass":        string(info.ErrorClass),
+			"class":             diag.Class,
+			"kind":              diag.Kind,
+			"summary":           diag.Summary,
+			"execCommand":       diag.ExecCommand,
 		}
 	}
 	return states
@@ -376,19 +388,25 @@ func (a *App) handleClusterAuthRecoveryProgress(clusterID string, progress auths
 		return
 	}
 
-	// Get cluster name for better logging/events
+	// Get cluster name and the stored failure diagnostic. FailureDiagnostic is
+	// read outside the manager's lock (OnRecoveryProgress fires after emitProgress
+	// releases it), so this cannot deadlock.
 	clusterName := clusterID
+	var diag authstate.FailureDiagnostic
 	if clients := a.clusterClientsForID(clusterID); clients != nil {
 		clusterName = clients.meta.Name
+		if clients.authManager != nil {
+			diag = clients.authManager.FailureDiagnostic()
+		}
 	}
 
 	// Emit per-cluster progress event for the frontend. errorClass carries the
 	// latest probe verdict ("auth", "connectivity", or "" before any verdict)
 	// so the UI can distinguish an unreachable cluster from rejected credentials.
-	a.emitEvent("cluster:auth:progress", map[string]any{
-		"clusterId":         clusterID,
-		"clusterName":       clusterName,
-		"secondsUntilRetry": progress.SecondsUntilRetry,
-		"errorClass":        string(progress.ErrorClass),
-	})
+	// The typed diagnostic fields let a late-subscribing UI render exec-helper
+	// copy without having seen the failed/recovering event.
+	payload := authEventPayload(clusterID, clusterName, diag)
+	payload["secondsUntilRetry"] = progress.SecondsUntilRetry
+	payload["errorClass"] = string(progress.ErrorClass)
+	a.emitEvent("cluster:auth:progress", payload)
 }

--- a/backend/cluster_auth_event_test.go
+++ b/backend/cluster_auth_event_test.go
@@ -51,8 +51,13 @@ func TestHandleClusterAuthStateChange_InvalidEmitsAuthFailed(t *testing.T) {
 	}
 	app.clusterClientsMu.Unlock()
 
-	// Trigger the StateInvalid handler.
-	app.handleClusterAuthStateChange("test-cluster", authstate.StateInvalid, "token expired")
+	// Trigger the StateInvalid handler with a typed diagnostic (missing exec helper).
+	app.handleClusterAuthStateChange("test-cluster", authstate.StateInvalid, authstate.FailureDiagnostic{
+		Reason:      "token expired",
+		Kind:        "missing-helper",
+		Summary:     "The kubeconfig's credential helper could not be found.",
+		ExecCommand: "gke-gcloud-auth-plugin",
+	})
 
 	// Verify the event was emitted.
 	mu.Lock()
@@ -69,6 +74,9 @@ func TestHandleClusterAuthStateChange_InvalidEmitsAuthFailed(t *testing.T) {
 	require.Equal(t, "test-cluster", authFailedEvents[0]["clusterId"])
 	require.Equal(t, "Test Cluster", authFailedEvents[0]["clusterName"])
 	require.Equal(t, "token expired", authFailedEvents[0]["reason"])
+	require.Equal(t, "missing-helper", authFailedEvents[0]["kind"])
+	require.Equal(t, "gke-gcloud-auth-plugin", authFailedEvents[0]["execCommand"])
+	require.Equal(t, "The kubeconfig's credential helper could not be found.", authFailedEvents[0]["summary"])
 }
 
 // TestHandleClusterAuthStateChange_RecoveringEmitsEvent verifies that
@@ -108,7 +116,10 @@ func TestHandleClusterAuthStateChange_RecoveringEmitsEvent(t *testing.T) {
 	}
 	app.clusterClientsMu.Unlock()
 
-	app.handleClusterAuthStateChange("cluster-r", authstate.StateRecovering, "401 unauthorized")
+	app.handleClusterAuthStateChange("cluster-r", authstate.StateRecovering, authstate.FailureDiagnostic{
+		Reason:      "401 unauthorized",
+		ExecCommand: "aws",
+	})
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -124,6 +135,7 @@ func TestHandleClusterAuthStateChange_RecoveringEmitsEvent(t *testing.T) {
 	require.Equal(t, "cluster-r", recoveringEvents[0]["clusterId"])
 	require.Equal(t, "Recovering Cluster", recoveringEvents[0]["clusterName"])
 	require.Equal(t, "401 unauthorized", recoveringEvents[0]["reason"])
+	require.Equal(t, "aws", recoveringEvents[0]["execCommand"])
 }
 
 // TestHandleClusterAuthStateChange_ValidEmitsRecoveredEvent verifies that
@@ -164,7 +176,7 @@ func TestHandleClusterAuthStateChange_ValidEmitsRecoveredEvent(t *testing.T) {
 	}
 	app.clusterClientsMu.Unlock()
 
-	app.handleClusterAuthStateChange("cluster-v", authstate.StateValid, "")
+	app.handleClusterAuthStateChange("cluster-v", authstate.StateValid, authstate.FailureDiagnostic{})
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -185,7 +197,7 @@ func TestHandleClusterAuthStateChange_ValidEmitsRecoveredEvent(t *testing.T) {
 func TestHandleClusterAuthStateChange_NilAppNoOp(t *testing.T) {
 	var app *App
 	// Should not panic.
-	app.handleClusterAuthStateChange("any-cluster", authstate.StateInvalid, "reason")
+	app.handleClusterAuthStateChange("any-cluster", authstate.StateInvalid, authstate.FailureDiagnostic{Reason: "reason"})
 }
 
 // TestHandleClusterAuthStateChange_EmptyClusterIDNoOp verifies the empty clusterID guard.
@@ -200,7 +212,7 @@ func TestHandleClusterAuthStateChange_EmptyClusterIDNoOp(t *testing.T) {
 		eventCalled = true
 	}
 
-	app.handleClusterAuthStateChange("", authstate.StateInvalid, "reason")
+	app.handleClusterAuthStateChange("", authstate.StateInvalid, authstate.FailureDiagnostic{Reason: "reason"})
 	require.False(t, eventCalled, "no event should be emitted for empty clusterID")
 }
 
@@ -238,6 +250,81 @@ func TestHandleClusterAuthRecoveryProgress_CarriesErrorClass(t *testing.T) {
 	defer mu.Unlock()
 	require.Len(t, progressEvents, 1)
 	require.Equal(t, "connectivity", progressEvents[0]["errorClass"])
+}
+
+// TestHandleClusterAuthRecoveryProgress_CarriesExecCommand verifies that the
+// progress event surfaces the stored credential diagnostic (read from the
+// manager) so a late-subscribing UI can render exec-helper copy.
+func TestHandleClusterAuthRecoveryProgress_CarriesExecCommand(t *testing.T) {
+	app := newTestAppWithDefaults(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	app.Ctx = ctx
+
+	mgr := authstate.New(authstate.Config{MaxAttempts: 0})
+	defer mgr.Shutdown()
+	mgr.ReportFailureDiagnostic(authstate.FailureDiagnostic{
+		Reason:      "exec: executable gke-gcloud-auth-plugin not found",
+		Kind:        "missing-helper",
+		ExecCommand: "gke-gcloud-auth-plugin",
+	})
+
+	app.clusterClientsMu.Lock()
+	app.clusterClients = map[string]*clusterClients{
+		"cluster-p": {meta: ClusterMeta{ID: "cluster-p", Name: "P"}, authManager: mgr},
+	}
+	app.clusterClientsMu.Unlock()
+
+	var progressEvents []map[string]any
+	var mu sync.Mutex
+	app.eventEmitter = func(_ context.Context, name string, args ...interface{}) {
+		if name != "cluster:auth:progress" || len(args) == 0 {
+			return
+		}
+		if data, ok := args[0].(map[string]any); ok {
+			mu.Lock()
+			progressEvents = append(progressEvents, data)
+			mu.Unlock()
+		}
+	}
+
+	app.handleClusterAuthRecoveryProgress("cluster-p", authstate.RecoveryProgress{
+		SecondsUntilRetry: 5,
+		ErrorClass:        authstate.ErrorClassAuth,
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, progressEvents, 1)
+	require.Equal(t, "gke-gcloud-auth-plugin", progressEvents[0]["execCommand"])
+	require.Equal(t, "missing-helper", progressEvents[0]["kind"])
+	require.Equal(t, 5, progressEvents[0]["secondsUntilRetry"])
+}
+
+// TestGetAllClusterAuthStates_IncludesExecCommand verifies the initial-state RPC
+// surfaces the stored exec command so a freshly mounted frontend can restore the
+// kubeconfig-centered overlay copy.
+func TestGetAllClusterAuthStates_IncludesExecCommand(t *testing.T) {
+	app := newTestAppWithDefaults(t)
+
+	mgr := authstate.New(authstate.Config{MaxAttempts: 0})
+	defer mgr.Shutdown()
+	mgr.ReportFailureDiagnostic(authstate.FailureDiagnostic{
+		Reason:      "exec: executable aws not found",
+		Kind:        "missing-helper",
+		ExecCommand: "aws",
+	})
+
+	app.clusterClientsMu.Lock()
+	app.clusterClients = map[string]*clusterClients{
+		"cluster-x": {meta: ClusterMeta{ID: "cluster-x", Name: "X"}, authManager: mgr},
+	}
+	app.clusterClientsMu.Unlock()
+
+	states := app.GetAllClusterAuthStates()
+	require.Equal(t, "invalid", states["cluster-x"]["state"])
+	require.Equal(t, "aws", states["cluster-x"]["execCommand"])
+	require.Equal(t, "missing-helper", states["cluster-x"]["kind"])
 }
 
 // TestGetAllClusterAuthStates_IncludesErrorClass verifies the state RPC

--- a/backend/cluster_clients.go
+++ b/backend/cluster_clients.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"runtime"
-	"strings"
 	"sync"
 
 	appconfig "github.com/luxury-yacht/app/backend/internal/config"
@@ -15,7 +14,6 @@ import (
 	"github.com/luxury-yacht/app/backend/resources/common"
 	"github.com/luxury-yacht/app/backend/resources/gatewayapi"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -25,6 +23,7 @@ import (
 	gatewayinformers "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions"
 
 	"github.com/luxury-yacht/app/backend/internal/authstate"
+	"github.com/luxury-yacht/app/backend/internal/credentialerrors"
 )
 
 // clusterClients stores Kubernetes clients scoped to a specific cluster selection.
@@ -396,9 +395,12 @@ func (a *App) buildClusterClientsWithManager(
 	var authFailedOnInit bool
 	if err := a.preflightClusterClientWithContext(ctx, clientset); err != nil {
 		a.logger.Warn(fmt.Sprintf("Pre-flight check failed for cluster %s: %v", meta.Name, err), logsources.Auth, meta.ID, meta.Name)
-		if isCredentialError(err) {
+		// Capture the kubeconfig exec command (if any) from the rest config so the
+		// diagnostic can name the credential helper. This is the reliable source —
+		// it is never scraped from the error string.
+		if d := credentialerrors.Classify(err, credentialerrors.Context{ExecCommand: execDisplayCommand(config)}); d.IsAuth() {
 			a.logger.Warn(fmt.Sprintf("Detected credential error for cluster %s, reporting auth failure", meta.Name), logsources.Auth, meta.ID, meta.Name)
-			clusterAuthMgr.ReportFailure(err.Error())
+			clusterAuthMgr.ReportFailureDiagnostic(authstate.NewFailureDiagnostic(err.Error(), d))
 			authFailedOnInit = true
 		}
 		// Don't return error - the cluster clients are valid, auth just needs recovery.
@@ -456,8 +458,8 @@ func (a *App) createClusterAuthManager(meta ClusterMeta) *authstate.Manager {
 		ClassifyError:             classifyRecoveryError,
 		ConnectivityRetryInterval: appconfig.ClusterAuthConnectivityRetryInterval,
 		SteadyRetryInterval:       appconfig.ClusterAuthSteadyRetryInterval,
-		OnStateChange: func(state authstate.State, reason string) {
-			a.handleClusterAuthStateChange(meta.ID, state, reason)
+		OnStateChange: func(state authstate.State, diag authstate.FailureDiagnostic) {
+			a.handleClusterAuthStateChange(meta.ID, state, diag)
 		},
 		OnRecoveryProgress: func(progress authstate.RecoveryProgress) {
 			a.handleClusterAuthRecoveryProgress(meta.ID, progress)
@@ -473,16 +475,14 @@ func (a *App) createClusterAuthManager(meta ClusterMeta) *authstate.Manager {
 // refused, timeouts, DNS, TLS) means the cluster could not be reached, which
 // says nothing about credential validity, so the recovery loop keeps probing.
 func classifyRecoveryError(err error) authstate.ErrorClass {
-	if err == nil {
+	switch credentialerrors.Classify(err, credentialerrors.Context{}).Class {
+	case credentialerrors.ClassAuth:
+		return authstate.ErrorClassAuth
+	case credentialerrors.ClassConnectivity:
+		return authstate.ErrorClassConnectivity
+	default:
 		return authstate.ErrorClassUnknown
 	}
-	if k8sErrors.IsUnauthorized(err) || k8sErrors.IsForbidden(err) {
-		return authstate.ErrorClassAuth
-	}
-	if isCredentialError(err) {
-		return authstate.ErrorClassAuth
-	}
-	return authstate.ErrorClassConnectivity
 }
 
 // buildRestConfigForSelection loads a REST config for the provided kubeconfig path/context.
@@ -527,34 +527,4 @@ func (a *App) buildRestConfigForSelection(selection kubeconfigSelection, meta Cl
 	}
 
 	return config, nil
-}
-
-// isCredentialError checks if an error indicates a credential/auth failure.
-// This catches exec credential provider failures (like AWS SSO) that happen
-// before an HTTP request is made.
-func isCredentialError(err error) bool {
-	if err == nil {
-		return false
-	}
-	errStr := strings.ToLower(err.Error())
-	// Patterns that indicate credential/auth failures from exec providers
-	credentialPatterns := []string{
-		"getting credentials",
-		"exec: executable",
-		"failed with exit code",
-		"token has expired",
-		"token is expired",
-		"sso session",
-		"refresh token",
-		"authentication required",
-		"unauthorized",
-		"access denied",
-		"permission denied",
-	}
-	for _, pattern := range credentialPatterns {
-		if strings.Contains(errStr, pattern) {
-			return true
-		}
-	}
-	return false
 }

--- a/backend/exec_wrapper.go
+++ b/backend/exec_wrapper.go
@@ -57,6 +57,22 @@ func runExecWrapper(command string, args []string) int {
 	return 0
 }
 
+// execDisplayCommand returns the kubeconfig exec credential command suitable for
+// display, or "" when the config declares no exec provider. On Windows the exec
+// provider is rewritten to run through this binary (see wrapExecProviderForWindows);
+// in that case the original helper command is recovered from the wrapper args so
+// diagnostics show the real credential helper, not the app executable.
+func execDisplayCommand(config *rest.Config) string {
+	if config == nil || config.ExecProvider == nil {
+		return ""
+	}
+	args := config.ExecProvider.Args
+	if isExecWrapperConfigured(args) && len(args) >= 2 {
+		return strings.TrimSpace(args[1])
+	}
+	return strings.TrimSpace(config.ExecProvider.Command)
+}
+
 // wrapExecProviderForWindows routes exec helpers through this binary on Windows.
 func wrapExecProviderForWindows(config *rest.Config) {
 	if runtime.GOOS != "windows" || config == nil || config.ExecProvider == nil {

--- a/backend/exec_wrapper_test.go
+++ b/backend/exec_wrapper_test.go
@@ -82,6 +82,42 @@ func TestSameExecutablePath(t *testing.T) {
 	}
 }
 
+func TestExecDisplayCommand(t *testing.T) {
+	t.Run("nil config", func(t *testing.T) {
+		if got := execDisplayCommand(nil); got != "" {
+			t.Fatalf("expected empty for nil config, got %q", got)
+		}
+	})
+
+	t.Run("no exec provider", func(t *testing.T) {
+		if got := execDisplayCommand(&rest.Config{}); got != "" {
+			t.Fatalf("expected empty when no exec provider, got %q", got)
+		}
+	})
+
+	t.Run("unwrapped command", func(t *testing.T) {
+		cfg := &rest.Config{ExecProvider: &api.ExecConfig{
+			Command: "gke-gcloud-auth-plugin",
+			Args:    []string{"--version"},
+		}}
+		if got := execDisplayCommand(cfg); got != "gke-gcloud-auth-plugin" {
+			t.Fatalf("expected gke-gcloud-auth-plugin, got %q", got)
+		}
+	})
+
+	t.Run("windows-wrapped command returns the original, not the app exe", func(t *testing.T) {
+		// Wrapped form (see wrapExecProviderForWindows): Command is the app
+		// executable, the original helper is the first wrapper arg.
+		cfg := &rest.Config{ExecProvider: &api.ExecConfig{
+			Command: filepath.Join("C:\\", "Program Files", "LuxuryYacht", "app.exe"),
+			Args:    []string{execWrapperFlag, "gke-gcloud-auth-plugin", "--version"},
+		}}
+		if got := execDisplayCommand(cfg); got != "gke-gcloud-auth-plugin" {
+			t.Fatalf("expected original command gke-gcloud-auth-plugin, got %q", got)
+		}
+	})
+}
+
 func TestWrapExecProviderForWindowsNoop(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test covers non-windows no-op behavior")

--- a/backend/exec_wrapper_test.go
+++ b/backend/exec_wrapper_test.go
@@ -1,11 +1,14 @@
 package backend
 
 import (
+	"errors"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
 
+	"github.com/luxury-yacht/app/backend/internal/credentialerrors"
+	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd/api"
 )
@@ -116,6 +119,36 @@ func TestExecDisplayCommand(t *testing.T) {
 			t.Fatalf("expected original command gke-gcloud-auth-plugin, got %q", got)
 		}
 	})
+}
+
+// TestExecDisplayCommandWindowsDiagnosticEndToEnd confirms the two halves of the
+// Windows credential-failure path compose correctly: execDisplayCommand recovers
+// the original helper from a wrapper-rewritten config, and the credential
+// classifier turns a wrapped exec failure into an auth-class diagnostic naming
+// that helper — the exact diagnostic a Windows preflight hands the overlay.
+//
+// This runs on any OS because it constructs the wrapped config directly (the same
+// shape wrapExecProviderForWindows produces); it does not depend on runtime.GOOS.
+func TestExecDisplayCommandWindowsDiagnosticEndToEnd(t *testing.T) {
+	// A config as wrapExecProviderForWindows would leave it: Command is the app
+	// executable; the real helper is the first wrapper arg.
+	cfg := &rest.Config{ExecProvider: &api.ExecConfig{
+		Command: filepath.Join("C:\\", "Program Files", "LuxuryYacht", "app.exe"),
+		Args:    []string{execWrapperFlag, "gke-gcloud-auth-plugin", "--version"},
+	}}
+
+	command := execDisplayCommand(cfg)
+	require.Equal(t, "gke-gcloud-auth-plugin", command, "must recover the real helper, not the app exe")
+
+	// The wrapper exits non-zero when the real helper fails; client-go surfaces
+	// that to the preflight as a credential error.
+	diag := credentialerrors.Classify(
+		errors.New(`getting credentials: exec: executable C:\Program Files\LuxuryYacht\app.exe failed with exit code 1`),
+		credentialerrors.Context{ExecCommand: command},
+	)
+
+	require.True(t, diag.IsAuth(), "a wrapped Windows exec failure must be auth-class")
+	require.Equal(t, "gke-gcloud-auth-plugin", diag.ExecCommand, "the overlay must name the real helper")
 }
 
 func TestWrapExecProviderForWindowsNoop(t *testing.T) {

--- a/backend/internal/authstate/integration_test.go
+++ b/backend/internal/authstate/integration_test.go
@@ -29,7 +29,7 @@ func TestFullRecoveryFlow(t *testing.T) {
 	manager := New(Config{
 		MaxAttempts:     4,
 		BackoffSchedule: []time.Duration{0, 10 * time.Millisecond, 10 * time.Millisecond, 10 * time.Millisecond},
-		OnStateChange: func(state State, reason string) {
+		OnStateChange: func(state State, _ FailureDiagnostic) {
 			stateChangesMu.Lock()
 			stateChanges = append(stateChanges, state)
 			stateChangesMu.Unlock()
@@ -76,9 +76,11 @@ func TestFullRecoveryFlow(t *testing.T) {
 	var authErr *AuthInvalidError
 	require.ErrorAs(t, err, &authErr)
 
-	// State should now be Recovering (recovery was triggered).
-	state, _ = manager.State()
-	require.Equal(t, StateRecovering, state)
+	// The 401 triggered recovery. We do not assert the transient Recovering
+	// state synchronously here: with sub-second backoffs the recovery goroutine
+	// can reach Valid before this point under -race scheduling. The Recovering
+	// transition is verified reliably below via the recorded OnStateChange
+	// transitions, which fire regardless of timing.
 
 	// Wait for recovery to complete (should take ~30ms with backoff schedule).
 	time.Sleep(100 * time.Millisecond)
@@ -156,7 +158,7 @@ func TestRecoverySuccessViaRecoveryTest(t *testing.T) {
 	manager := New(Config{
 		MaxAttempts:     4,
 		BackoffSchedule: []time.Duration{0, 0, 0, 0}, // No delay
-		OnStateChange: func(state State, reason string) {
+		OnStateChange: func(state State, _ FailureDiagnostic) {
 			stateChangesMu.Lock()
 			stateChanges = append(stateChanges, state)
 			stateChangesMu.Unlock()
@@ -198,7 +200,7 @@ func TestManualRetryFromInvalid(t *testing.T) {
 	manager := New(Config{
 		MaxAttempts:     4,
 		BackoffSchedule: []time.Duration{0, 0, 0, 0},
-		OnStateChange: func(state State, reason string) {
+		OnStateChange: func(state State, _ FailureDiagnostic) {
 			stateChangesMu.Lock()
 			stateChanges = append(stateChanges, state)
 			stateChangesMu.Unlock()

--- a/backend/internal/authstate/manager.go
+++ b/backend/internal/authstate/manager.go
@@ -6,7 +6,36 @@ import (
 	"time"
 
 	"github.com/luxury-yacht/app/backend/internal/config"
+	"github.com/luxury-yacht/app/backend/internal/credentialerrors"
 )
+
+// FailureDiagnostic carries the reason for an auth failure together with optional
+// typed fields a UI can use to explain it without echoing raw provider stderr.
+// All fields are strings so the struct stays comparable (setState dedupes by ==).
+type FailureDiagnostic struct {
+	// Reason is the raw/human reason. Kept for existing UI copy and logging.
+	Reason string
+	// Class is the credentialerrors verdict: "auth", "connectivity", or "".
+	Class string
+	// Kind is the finer credentialerrors classification (e.g. "missing-helper").
+	Kind string
+	// Summary is a sanitized, provider-neutral one-line description.
+	Summary string
+	// ExecCommand is the kubeconfig exec credential command, when known.
+	ExecCommand string
+}
+
+// NewFailureDiagnostic builds a FailureDiagnostic from a classified credential
+// error. reason is the raw error text; the typed fields come from the diagnostic.
+func NewFailureDiagnostic(reason string, d credentialerrors.Diagnostic) FailureDiagnostic {
+	return FailureDiagnostic{
+		Reason:      reason,
+		Class:       string(d.Class),
+		Kind:        string(d.Kind),
+		Summary:     d.Summary,
+		ExecCommand: d.ExecCommand,
+	}
+}
 
 // DefaultMaxAttempts is the default number of recovery attempts.
 const DefaultMaxAttempts = config.ClusterAuthRecoveryMaxAttempts
@@ -45,9 +74,10 @@ type Config struct {
 	// settled to invalid. If 0, config.ClusterAuthSteadyRetryInterval is used.
 	SteadyRetryInterval time.Duration
 
-	// OnStateChange is called whenever the auth state changes.
-	// The reason is provided for failure states.
-	OnStateChange func(state State, reason string)
+	// OnStateChange is called whenever the auth state changes. The diagnostic
+	// carries the reason plus typed credential fields for failure states; it is
+	// the zero value for the transition back to StateValid.
+	OnStateChange func(state State, diag FailureDiagnostic)
 
 	// OnRecoveryProgress is called periodically during recovery to report progress.
 	// This allows the UI to show countdown timers and attempt counts.
@@ -78,8 +108,9 @@ type Manager struct {
 	// state is the current authentication state.
 	state State
 
-	// failureReason stores the reason for the current failure.
-	failureReason string
+	// failureDiagnostic stores the diagnostic for the current failure. Its
+	// Reason field is what State() returns; the zero value means no failure.
+	failureDiagnostic FailureDiagnostic
 
 	// secondsUntilRetry tracks seconds until next retry (0 if retry in progress or not recovering).
 	secondsUntilRetry int
@@ -139,7 +170,15 @@ func New(cfg Config) *Manager {
 func (m *Manager) State() (State, string) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	return m.state, m.failureReason
+	return m.state, m.failureDiagnostic.Reason
+}
+
+// FailureDiagnostic returns the diagnostic for the current failure (zero value
+// when valid). Safe for concurrent use.
+func (m *Manager) FailureDiagnostic() FailureDiagnostic {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.failureDiagnostic
 }
 
 // IsValid returns true if the current state is StateValid.
@@ -149,10 +188,17 @@ func (m *Manager) IsValid() bool {
 	return m.state == StateValid
 }
 
-// ReportFailure reports an authentication failure.
-// If already in StateInvalid or StateRecovering, this call is ignored (idempotent).
-// If MaxAttempts > 0, recovery is triggered automatically.
+// ReportFailure reports an authentication failure described only by a reason
+// string. Callers with a classified credential error should use
+// ReportFailureDiagnostic to carry the typed fields.
 func (m *Manager) ReportFailure(reason string) {
+	m.ReportFailureDiagnostic(FailureDiagnostic{Reason: reason})
+}
+
+// ReportFailureDiagnostic reports an authentication failure with a typed
+// diagnostic. If already in StateInvalid or StateRecovering, this call is ignored
+// (idempotent). If MaxAttempts > 0, recovery is triggered automatically.
+func (m *Manager) ReportFailureDiagnostic(diag FailureDiagnostic) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -166,10 +212,10 @@ func (m *Manager) ReportFailure(reason string) {
 
 	// Transition to recovering or invalid based on config
 	if m.config.MaxAttempts > 0 {
-		m.setState(StateRecovering, reason)
+		m.setState(StateRecovering, diag)
 		m.startRecoveryLocked()
 	} else {
-		m.setState(StateInvalid, reason)
+		m.setState(StateInvalid, diag)
 	}
 }
 
@@ -186,7 +232,7 @@ func (m *Manager) ReportSuccess() {
 	}
 
 	if m.state != StateValid {
-		m.setState(StateValid, "")
+		m.setState(StateValid, FailureDiagnostic{})
 	}
 }
 
@@ -229,14 +275,14 @@ func (m *Manager) Shutdown() {
 
 // setState changes the current state and calls the OnStateChange callback.
 // Must be called with m.mu held.
-func (m *Manager) setState(newState State, reason string) {
-	if m.state == newState && m.failureReason == reason {
+func (m *Manager) setState(newState State, diag FailureDiagnostic) {
+	if m.state == newState && m.failureDiagnostic == diag {
 		return
 	}
 	m.state = newState
-	m.failureReason = reason
+	m.failureDiagnostic = diag
 	if m.config.OnStateChange != nil {
-		m.config.OnStateChange(newState, reason)
+		m.config.OnStateChange(newState, diag)
 	}
 }
 
@@ -310,7 +356,7 @@ func (m *Manager) runRecovery(ctx context.Context) {
 			m.mu.Lock()
 			// Only update state if we're still the active recovery.
 			if ctx.Err() == nil && m.state != StateValid {
-				m.setState(StateValid, "")
+				m.setState(StateValid, FailureDiagnostic{})
 			}
 			m.mu.Unlock()
 			return
@@ -331,9 +377,14 @@ func (m *Manager) runRecovery(ctx context.Context) {
 		if authFailures >= m.config.MaxAttempts {
 			// Credentials confirmed bad: settle the verdict (idempotent —
 			// setState dedupes repeats) and keep probing at the steady pace.
+			// Preserve the typed fields (kind/execCommand) from the original
+			// failure so the settled overlay can still name the credential
+			// helper; only the human reason changes.
 			m.mu.Lock()
 			if ctx.Err() == nil && m.state == StateRecovering {
-				m.setState(StateInvalid, "Credentials were rejected by the cluster. Please re-authenticate.")
+				settled := m.failureDiagnostic
+				settled.Reason = "Credentials were rejected by the cluster. Please re-authenticate."
+				m.setState(StateInvalid, settled)
 			}
 			m.mu.Unlock()
 			delay = m.steadyRetryDelay()

--- a/backend/internal/authstate/manager_test.go
+++ b/backend/internal/authstate/manager_test.go
@@ -27,7 +27,7 @@ func TestReportFailureTransitionsToInvalid(t *testing.T) {
 	var stateChanges []State
 	var mu sync.Mutex
 	m := New(Config{
-		OnStateChange: func(s State, reason string) {
+		OnStateChange: func(s State, _ FailureDiagnostic) {
 			mu.Lock()
 			stateChanges = append(stateChanges, s)
 			mu.Unlock()
@@ -52,7 +52,7 @@ func TestReportFailureTransitionsToInvalid(t *testing.T) {
 func TestReportFailureIsIdempotent(t *testing.T) {
 	var calls int32
 	m := New(Config{
-		OnStateChange: func(s State, reason string) {
+		OnStateChange: func(s State, _ FailureDiagnostic) {
 			atomic.AddInt32(&calls, 1)
 		},
 		MaxAttempts: 0,
@@ -153,7 +153,7 @@ func TestAuthFailuresSettleInvalidAndKeepProbing(t *testing.T) {
 		ClassifyError: func(error) ErrorClass {
 			return ErrorClassAuth
 		},
-		OnStateChange: func(s State, reason string) {
+		OnStateChange: func(s State, _ FailureDiagnostic) {
 			mu.Lock()
 			states = append(states, s)
 			mu.Unlock()
@@ -272,7 +272,7 @@ func TestOnStateChangeCallback(t *testing.T) {
 	m := New(Config{
 		MaxAttempts:     1,
 		BackoffSchedule: []time.Duration{0},
-		OnStateChange: func(s State, reason string) {
+		OnStateChange: func(s State, _ FailureDiagnostic) {
 			mu.Lock()
 			stateChanges = append(stateChanges, s)
 			mu.Unlock()
@@ -294,11 +294,55 @@ func TestOnStateChangeCallback(t *testing.T) {
 	mu.Unlock()
 }
 
+func TestReportFailureDiagnosticStoresTypedFields(t *testing.T) {
+	m := New(Config{MaxAttempts: 0})
+	defer m.Shutdown()
+
+	diag := FailureDiagnostic{
+		Reason:      "getting credentials: exec: executable gke-gcloud-auth-plugin not found",
+		Class:       "auth",
+		Kind:        "missing-helper",
+		Summary:     "The kubeconfig's credential helper could not be found.",
+		ExecCommand: "gke-gcloud-auth-plugin",
+	}
+	m.ReportFailureDiagnostic(diag)
+
+	state, reason := m.State()
+	require.Equal(t, StateInvalid, state)
+	require.Equal(t, diag.Reason, reason, "State() reason comes from the diagnostic")
+	require.Equal(t, diag, m.FailureDiagnostic())
+
+	// Recovery clears the stored diagnostic.
+	m.ReportSuccess()
+	require.Equal(t, FailureDiagnostic{}, m.FailureDiagnostic())
+}
+
+func TestOnStateChangeReceivesDiagnostic(t *testing.T) {
+	var got FailureDiagnostic
+	var mu sync.Mutex
+	m := New(Config{
+		MaxAttempts: 0,
+		OnStateChange: func(_ State, diag FailureDiagnostic) {
+			mu.Lock()
+			got = diag
+			mu.Unlock()
+		},
+	})
+	defer m.Shutdown()
+
+	want := FailureDiagnostic{Reason: "boom", Class: "auth", ExecCommand: "aws"}
+	m.ReportFailureDiagnostic(want)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, want, got, "the diagnostic flows through OnStateChange unchanged")
+}
+
 func TestReportSuccessWhileValid(t *testing.T) {
 	var calls int32
 	m := New(Config{
 		MaxAttempts: 0,
-		OnStateChange: func(s State, reason string) {
+		OnStateChange: func(s State, _ FailureDiagnostic) {
 			atomic.AddInt32(&calls, 1)
 		},
 	})
@@ -314,7 +358,7 @@ func TestTriggerRetryWhileValid(t *testing.T) {
 	var calls int32
 	m := New(Config{
 		MaxAttempts: 1,
-		OnStateChange: func(s State, reason string) {
+		OnStateChange: func(s State, _ FailureDiagnostic) {
 			atomic.AddInt32(&calls, 1)
 		},
 	})

--- a/backend/internal/authstate/transport.go
+++ b/backend/internal/authstate/transport.go
@@ -2,7 +2,8 @@ package authstate
 
 import (
 	"net/http"
-	"strings"
+
+	"github.com/luxury-yacht/app/backend/internal/credentialerrors"
 )
 
 // AuthAwareTransport wraps an http.RoundTripper with auth state checks.
@@ -58,8 +59,8 @@ func (t *AuthAwareTransport) RoundTrip(req *http.Request) (*http.Response, error
 		// AWS SSO and other exec credential providers fail during RoundTrip
 		// before an HTTP request is even made, returning an error rather than
 		// an HTTP 401 response.
-		if isCredentialError(err) {
-			t.manager.ReportFailure(err.Error())
+		if d := credentialerrors.Classify(err, credentialerrors.Context{}); d.IsAuth() {
+			t.manager.ReportFailureDiagnostic(NewFailureDiagnostic(err.Error(), d))
 			return nil, &AuthInvalidError{
 				Reason: err.Error(),
 				State:  StateInvalid,
@@ -91,34 +92,4 @@ func (t *AuthAwareTransport) RoundTrip(req *http.Request) (*http.Response, error
 
 	// Step 5: Return the response (including 4xx/5xx errors other than 401)
 	return resp, nil
-}
-
-// isCredentialError checks if an error indicates a credential/auth failure.
-// This catches exec credential provider failures (like AWS SSO) that happen
-// before an HTTP request is made.
-func isCredentialError(err error) bool {
-	if err == nil {
-		return false
-	}
-	errStr := strings.ToLower(err.Error())
-	// Patterns that indicate credential/auth failures from exec providers
-	credentialPatterns := []string{
-		"getting credentials",
-		"exec: executable",
-		"failed with exit code",
-		"token has expired",
-		"token is expired",
-		"sso session",
-		"refresh token",
-		"authentication required",
-		"unauthorized",
-		"access denied",
-		"permission denied",
-	}
-	for _, pattern := range credentialPatterns {
-		if strings.Contains(errStr, pattern) {
-			return true
-		}
-	}
-	return false
 }

--- a/backend/internal/authstate/transport_test.go
+++ b/backend/internal/authstate/transport_test.go
@@ -166,7 +166,7 @@ func TestTransportReportsFailureOn401(t *testing.T) {
 	var stateChanges []State
 	manager := New(Config{
 		MaxAttempts: 0, // Disable recovery so we go directly to Invalid
-		OnStateChange: func(state State, reason string) {
+		OnStateChange: func(state State, _ FailureDiagnostic) {
 			stateChanges = append(stateChanges, state)
 		},
 	})
@@ -228,7 +228,7 @@ func TestTransportSuccessKeepsValidState(t *testing.T) {
 			var stateChanges []State
 			manager := New(Config{
 				MaxAttempts: 0, // Disable recovery for this test
-				OnStateChange: func(state State, reason string) {
+				OnStateChange: func(state State, _ FailureDiagnostic) {
 					stateChanges = append(stateChanges, state)
 				},
 			})
@@ -289,7 +289,7 @@ func TestTransportPassesThrough4xxErrors(t *testing.T) {
 			var stateChanges []State
 			manager := New(Config{
 				MaxAttempts: 0, // Disable recovery for this test
-				OnStateChange: func(state State, reason string) {
+				OnStateChange: func(state State, _ FailureDiagnostic) {
 					stateChanges = append(stateChanges, state)
 				},
 			})
@@ -443,7 +443,7 @@ func TestTransportReportsFailureOnCredentialError(t *testing.T) {
 			var stateChanges []State
 			manager := New(Config{
 				MaxAttempts: 0, // Disable recovery so we go directly to Invalid
-				OnStateChange: func(state State, reason string) {
+				OnStateChange: func(state State, _ FailureDiagnostic) {
 					stateChanges = append(stateChanges, state)
 				},
 			})

--- a/backend/internal/credentialerrors/credentialerrors.go
+++ b/backend/internal/credentialerrors/credentialerrors.go
@@ -1,0 +1,142 @@
+// Package credentialerrors classifies Kubernetes client errors into a typed
+// diagnostic that distinguishes credential/auth failures from connectivity
+// failures. It centralizes logic that was previously duplicated (and divergent)
+// across cluster client setup, the auth transport, and heartbeat health checks.
+package credentialerrors
+
+import (
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// Class is the high-level verdict used to gate auth state. Auth-class failures
+// prove the cluster rejected the credentials (or the credential plugin failed)
+// and should drive auth-failure handling; connectivity-class failures say
+// nothing about credential validity and should keep the recovery loop probing.
+type Class string
+
+const (
+	// ClassUnknown is returned only for a nil error.
+	ClassUnknown Class = ""
+	// ClassAuth means the credentials were rejected or the credential plugin failed.
+	ClassAuth Class = "auth"
+	// ClassConnectivity means the cluster could not be reached.
+	ClassConnectivity Class = "connectivity"
+)
+
+// Kind is a finer classification used for richer, provider-neutral diagnostics.
+type Kind string
+
+const (
+	// KindNone is returned for a nil error.
+	KindNone Kind = ""
+	// KindMissingHelper means a kubeconfig exec credential helper was not found.
+	KindMissingHelper Kind = "missing-helper"
+	// KindHelperFailed means a kubeconfig exec credential helper ran but failed.
+	KindHelperFailed Kind = "helper-failed"
+	// KindExpired means the credentials (token/SSO session) have expired.
+	KindExpired Kind = "expired-credentials"
+	// KindRejected means the cluster rejected the credentials (HTTP 401/403).
+	KindRejected Kind = "rejected"
+	// KindConnectivity means the cluster could not be reached.
+	KindConnectivity Kind = "connectivity"
+)
+
+// Context carries optional, caller-supplied facts that the error string cannot
+// reliably provide. ExecCommand is the kubeconfig exec credential command, read
+// from rest.Config.ExecProvider at config-construction time (never scraped from
+// the error string).
+type Context struct {
+	ExecCommand string
+}
+
+// Diagnostic is the typed result of classifying a credential/connectivity error.
+// Summary is a sanitized, provider-neutral, UI-safe phrase; it never echoes raw
+// provider stderr.
+type Diagnostic struct {
+	Class       Class
+	Kind        Kind
+	Summary     string
+	ExecCommand string
+}
+
+// IsAuth reports whether the diagnostic is an auth-class failure.
+func (d Diagnostic) IsAuth() bool { return d.Class == ClassAuth }
+
+// Provider-neutral, sanitized summaries. These never echo raw provider stderr;
+// any provider-specific detail belongs on a dedicated diagnostics surface.
+const (
+	summaryMissingHelper = "The kubeconfig's credential helper could not be found."
+	summaryHelperFailed  = "The kubeconfig's credential helper failed to run."
+	summaryExpired       = "The cluster credentials have expired."
+	summaryRejected      = "The cluster rejected the credentials."
+	summaryConnectivity  = "The cluster could not be reached."
+)
+
+// Classify maps an error (and optional context) to a typed Diagnostic.
+//
+// The pattern set is the union of the three classifiers it replaces, so every
+// input that any of them previously treated as a credential failure stays
+// auth-class. The order of checks matters: a "not found" exec error is reported
+// as a missing helper before the more general helper-failed bucket.
+func Classify(err error, ctx Context) Diagnostic {
+	d := Diagnostic{ExecCommand: strings.TrimSpace(ctx.ExecCommand)}
+	if err == nil {
+		return d
+	}
+
+	// Structured HTTP 401/403 prove the cluster rejected the credentials. This
+	// runs before string matching so it is robust to message wording.
+	if apierrors.IsUnauthorized(err) || apierrors.IsForbidden(err) {
+		d.Class, d.Kind, d.Summary = ClassAuth, KindRejected, summaryRejected
+		return d
+	}
+
+	msg := strings.ToLower(err.Error())
+	switch {
+	case isMissingHelper(msg):
+		d.Class, d.Kind, d.Summary = ClassAuth, KindMissingHelper, summaryMissingHelper
+	case isHelperFailed(msg):
+		d.Class, d.Kind, d.Summary = ClassAuth, KindHelperFailed, summaryHelperFailed
+	case isExpired(msg):
+		d.Class, d.Kind, d.Summary = ClassAuth, KindExpired, summaryExpired
+	case isRejected(msg):
+		d.Class, d.Kind, d.Summary = ClassAuth, KindRejected, summaryRejected
+	default:
+		d.Class, d.Kind, d.Summary = ClassConnectivity, KindConnectivity, summaryConnectivity
+	}
+	return d
+}
+
+// isMissingHelper reports an exec credential helper that could not be located.
+func isMissingHelper(msg string) bool {
+	missing := strings.Contains(msg, "not found") || strings.Contains(msg, "no such file")
+	return missing && (strings.Contains(msg, "exec") || strings.Contains(msg, "executable"))
+}
+
+// isHelperFailed reports an exec credential helper that ran but did not succeed.
+func isHelperFailed(msg string) bool {
+	return strings.Contains(msg, "getting credentials") ||
+		strings.Contains(msg, "exec: executable") ||
+		strings.Contains(msg, "failed with exit code") ||
+		strings.Contains(msg, "exec plugin") ||
+		(strings.Contains(msg, "executable") && strings.Contains(msg, "failed"))
+}
+
+// isExpired reports credentials (token or SSO session) that have expired.
+func isExpired(msg string) bool {
+	return strings.Contains(msg, "token has expired") ||
+		strings.Contains(msg, "token is expired") ||
+		strings.Contains(msg, "sso session") ||
+		strings.Contains(msg, "refresh token")
+}
+
+// isRejected reports credentials the cluster refused (by string, e.g. an
+// unstructured 401/403 or a provider authorization message).
+func isRejected(msg string) bool {
+	return strings.Contains(msg, "authentication required") ||
+		strings.Contains(msg, "unauthorized") ||
+		strings.Contains(msg, "access denied") ||
+		strings.Contains(msg, "permission denied")
+}

--- a/backend/internal/credentialerrors/credentialerrors_test.go
+++ b/backend/internal/credentialerrors/credentialerrors_test.go
@@ -1,0 +1,86 @@
+package credentialerrors
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestClassify(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		wantClass Class
+		wantKind  Kind
+	}{
+		// Missing exec helper (e.g. binary not on PATH).
+		{"exec helper not found", errors.New("getting credentials: exec: executable gke-gcloud-auth-plugin not found"), ClassAuth, KindMissingHelper},
+		{"go exec lookpath failure", errors.New(`exec: "aws": executable file not found in $PATH`), ClassAuth, KindMissingHelper},
+
+		// Exec helper ran but failed (non-zero exit / plugin error).
+		{"aws exec non-zero exit", errors.New("getting credentials: exec: executable aws failed with exit code 255"), ClassAuth, KindHelperFailed},
+		{"gcloud exec non-zero exit", errors.New("getting credentials: exec: executable gcloud failed with exit code 1"), ClassAuth, KindHelperFailed},
+		{"exec plugin error", errors.New("exec plugin: some error occurred"), ClassAuth, KindHelperFailed},
+		{"executable failed", errors.New("executable some-helper failed"), ClassAuth, KindHelperFailed},
+		{"generic getting credentials", errors.New("getting credentials: boom"), ClassAuth, KindHelperFailed},
+
+		// Cluster rejected the credentials (structured HTTP 401/403).
+		{"structured 401", apierrors.NewUnauthorized("Unauthorized"), ClassAuth, KindRejected},
+		{"structured 403", apierrors.NewForbidden(schema.GroupResource{Resource: "nodes"}, "node-1", errors.New("forbidden")), ClassAuth, KindRejected},
+
+		// Cluster rejected the credentials (string patterns).
+		{"unauthorized string", errors.New("the server has asked for the client to provide credentials (get pods): Unauthorized"), ClassAuth, KindRejected},
+		{"access denied", errors.New("access denied for user"), ClassAuth, KindRejected},
+		{"permission denied", errors.New("permission denied"), ClassAuth, KindRejected},
+		{"authentication required", errors.New("authentication required"), ClassAuth, KindRejected},
+
+		// Expired credentials.
+		{"token has expired", errors.New("token has expired"), ClassAuth, KindExpired},
+		{"token is expired", errors.New("the token is expired"), ClassAuth, KindExpired},
+		{"sso session expired", errors.New("sso session has expired"), ClassAuth, KindExpired},
+		{"refresh token invalid", errors.New("refresh token is invalid"), ClassAuth, KindExpired},
+
+		// Connectivity — says nothing about credential validity.
+		{"connection refused", errors.New("dial tcp 10.0.0.1:6443: connect: connection refused"), ClassConnectivity, KindConnectivity},
+		{"timeout", errors.New("context deadline exceeded"), ClassConnectivity, KindConnectivity},
+		{"dns failure", errors.New("lookup example.com: no such host"), ClassConnectivity, KindConnectivity},
+
+		// Nil error.
+		{"nil error", nil, ClassUnknown, KindNone},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Classify(tt.err, Context{})
+			require.Equal(t, tt.wantClass, got.Class, "class")
+			require.Equal(t, tt.wantKind, got.Kind, "kind")
+			if tt.wantClass == ClassUnknown {
+				require.Empty(t, got.Summary, "unknown should have no summary")
+			} else {
+				require.NotEmpty(t, got.Summary, "classified error should have a sanitized summary")
+			}
+		})
+	}
+}
+
+// TestClassifySummaryIsSanitized proves the summary never echoes raw provider
+// stderr — it is a fixed, provider-neutral phrase.
+func TestClassifySummaryIsSanitized(t *testing.T) {
+	raw := "getting credentials: exec: executable aws failed with exit code 255: SSO token for https://sso.example.com expired"
+	got := Classify(errors.New(raw), Context{})
+	require.Equal(t, ClassAuth, got.Class)
+	require.NotContains(t, got.Summary, "sso.example.com", "summary must not leak raw stderr")
+	require.NotContains(t, got.Summary, "exit code", "summary must not leak raw stderr")
+}
+
+// TestClassifyExecCommandPassthrough proves the caller-supplied exec command is
+// surfaced on the diagnostic (the reliable source; never scraped from the error).
+func TestClassifyExecCommandPassthrough(t *testing.T) {
+	got := Classify(errors.New("getting credentials: exec: executable gke-gcloud-auth-plugin not found"),
+		Context{ExecCommand: "gke-gcloud-auth-plugin"})
+	require.Equal(t, "gke-gcloud-auth-plugin", got.ExecCommand)
+	require.Equal(t, KindMissingHelper, got.Kind)
+}

--- a/backend/internal/credentialerrors/credentialerrors_test.go
+++ b/backend/internal/credentialerrors/credentialerrors_test.go
@@ -66,6 +66,50 @@ func TestClassify(t *testing.T) {
 	}
 }
 
+// TestClassifyWindowsErrorShapes confirms the classifier handles the error
+// strings produced on Windows, where kubeconfig exec helpers run through the
+// app's wrapper binary (see backend/exec_wrapper.go) and Go's exec error names
+// %PATH% rather than $PATH. Every shape must still classify as auth-class so the
+// affected cluster enters auth handling rather than being treated as a network
+// blip.
+func TestClassifyWindowsErrorShapes(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		wantClass Class
+		wantKind  Kind
+	}{
+		{
+			"helper not found (windows %PATH%)",
+			errors.New(`exec: "gke-gcloud-auth-plugin": executable file not found in %PATH%`),
+			ClassAuth, KindMissingHelper,
+		},
+		{
+			"wrapped helper non-zero exit (windows)",
+			errors.New(`getting credentials: exec: executable C:\Program Files\LuxuryYacht\app.exe failed with exit code 1`),
+			ClassAuth, KindHelperFailed,
+		},
+		{
+			"helper .exe non-zero exit (windows)",
+			errors.New(`getting credentials: exec: executable aws.exe failed with exit code 255`),
+			ClassAuth, KindHelperFailed,
+		},
+		{
+			"wrapped failure carrying not-found stderr (windows)",
+			errors.New(`getting credentials: exec: executable app.exe failed with exit code 1: exec: "gke-gcloud-auth-plugin": executable file not found in %PATH%`),
+			ClassAuth, KindMissingHelper,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Classify(tt.err, Context{})
+			require.True(t, got.IsAuth(), "windows credential error must be auth-class")
+			require.Equal(t, tt.wantClass, got.Class, "class")
+			require.Equal(t, tt.wantKind, got.Kind, "kind")
+		})
+	}
+}
+
 // TestClassifySummaryIsSanitized proves the summary never echoes raw provider
 // stderr — it is a fixed, provider-neutral phrase.
 func TestClassifySummaryIsSanitized(t *testing.T) {

--- a/backend/kubeconfig_selection_coordinator_test.go
+++ b/backend/kubeconfig_selection_coordinator_test.go
@@ -101,7 +101,7 @@ func TestHandleClusterAuthStateChangeUsesSelectionMutationBoundary(t *testing.T)
 	app := newTestAppWithDefaults(t)
 	before := app.selectionGeneration.Load()
 
-	app.handleClusterAuthStateChange("cluster-a", authstate.StateRecovering, "unit-test")
+	app.handleClusterAuthStateChange("cluster-a", authstate.StateRecovering, authstate.FailureDiagnostic{Reason: "unit-test"})
 
 	require.Eventually(t, func() bool {
 		return app.selectionGeneration.Load() >= before+1

--- a/backend/kubeconfigs_test.go
+++ b/backend/kubeconfigs_test.go
@@ -143,6 +143,43 @@ func TestApp_discoverKubeconfigs(t *testing.T) {
 	}
 }
 
+// TestAppendKubeconfigFromFileAcceptsMissingExecHelper pins the target contract:
+// kubeconfig discovery validates by parsing YAML only and must accept a kubeconfig
+// whose user declares an exec credential plugin, even when that helper binary does
+// not exist. Discovery must never require a provider binary to be installed.
+func TestAppendKubeconfigFromFileAcceptsMissingExecHelper(t *testing.T) {
+	dir := t.TempDir()
+	content := `apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://127.0.0.1:6443
+  name: exec-cluster
+contexts:
+- context:
+    cluster: exec-cluster
+    user: exec-user
+  name: exec-context
+current-context: exec-context
+kind: Config
+preferences: {}
+users:
+- name: exec-user
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      command: definitely-missing-helper
+`
+	path := filepath.Join(dir, "exec-config")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	app := newTestAppWithDefaults(t)
+	app.appendKubeconfigFromFile(path, "exec-config", "", false, map[string]struct{}{})
+
+	require.True(t, hasKubeconfig(app.availableKubeconfigs, path, "exec-context"),
+		"discovery must accept a kubeconfig whose user.exec.command helper is missing")
+}
+
 func TestApp_GetKubeconfigs(t *testing.T) {
 	setTestConfigEnv(t)
 	// Setup temp directory with kubeconfig

--- a/docs/plans/remove-provider-binary-auth-coupling.md
+++ b/docs/plans/remove-provider-binary-auth-coupling.md
@@ -91,21 +91,23 @@ Kubernetes Authentication docs, "client-go credential plugins":
 
 ## Phase 1: Characterize The Contract With Tests
 
-- [ ] Add a **characterization/guard** backend test proving kubeconfig discovery
+- [x] Add a **characterization/guard** backend test proving kubeconfig discovery
       accepts a kubeconfig whose user has
       `exec.command: definitely-missing-helper`; app discovery calls
       `clientcmd.LoadFromFile` (`backend/kubeconfigs.go:102`), and
       client-go v0.36.2 `LoadFromFile` reads file bytes and decodes config
       (`k8s.io/client-go@v0.36.2/tools/clientcmd/loader.go:397`).
-- [ ] Keep or rename the existing **guard** coverage proving
+- [x] Keep or rename the existing **guard** coverage proving
       `setupEnvironment` keeps generic executable directories such as
       `$HOME/.local/bin`; current coverage asserts that path
       (`backend/app_lifecycle_test.go:27`).
-- [ ] Add an **expected-red** backend test proving `setupEnvironment` does not
+- [x] Add an **expected-red** backend test proving `setupEnvironment` does not
       append Google Cloud SDK directories when those directories exist under a
       temp `HOME`. The current `authHelperDirectories` list includes those
       directories, so this is the Phase 2 behavior pin
-      (`backend/auth_providers.go:146`).
+      (`backend/auth_providers.go:146`). Implemented as
+      `TestDefaultExecutableSearchDirectoriesExcludesProviderPaths`
+      (`backend/auth_providers_paths_test.go`).
 - [ ] Add a **guard** backend test proving the selected kubeconfig's
       `ExecProvider.Command` is preserved by `buildRestConfigForSelection`
       except for existing Windows wrapper behavior
@@ -132,24 +134,26 @@ Kubernetes Authentication docs, "client-go credential plugins":
 
 ## Phase 2: Remove Provider-Specific PATH Logic
 
-- [ ] Delete the discarded `exec.LookPath("gke-gcloud-auth-plugin")` probe; both
+- [x] Delete the discarded `exec.LookPath("gke-gcloud-auth-plugin")` probe; both
       return values are assigned to blank identifiers today
       (`backend/auth_providers.go:61`).
-- [ ] Replace `authHelperDirectories` with a provider-neutral helper, for
+- [x] Replace `authHelperDirectories` with a provider-neutral helper, for
       example `defaultExecutableSearchDirectories`, containing only generic
       locations:
       - `/usr/local/bin`
       - `/opt/homebrew/bin`
       - `/usr/bin`
       - `$HOME/.local/bin`
-- [ ] Remove Google Cloud SDK home/share/Caskroom paths from the app-owned list
+- [x] Remove Google Cloud SDK home/share/Caskroom paths from the app-owned list
       as an explicit behavior change, not as mechanical cleanup
       (`backend/auth_providers.go:153`, `backend/auth_providers.go:160`).
-- [ ] Keep login-shell PATH merging, because `setupEnvironment` already reads a
+- [x] Keep login-shell PATH merging, because `setupEnvironment` already reads a
       login shell PATH before merging app process PATH (`backend/auth_providers.go:47`).
-- [ ] Update tests in `backend/auth_providers_paths_test.go` and
+- [x] Update tests in `backend/auth_providers_paths_test.go` and
       `backend/app_lifecycle_test.go` to describe generic desktop executable
       discovery instead of provider-specific auth helper discovery.
+      (`app_lifecycle_test.go` already asserted only the generic `$HOME/.local/bin`
+      path, so no provider-specific assertion needed removing.)
 
 ## Phase 3: Centralize Exec Credential Diagnostics
 

--- a/docs/plans/remove-provider-binary-auth-coupling.md
+++ b/docs/plans/remove-provider-binary-auth-coupling.md
@@ -1,6 +1,8 @@
 # Remove Provider-Binary Auth Coupling
 
-Status: **Planned, not started.**
+Status: **Implemented.** All five phases landed across three PR-sized changes
+(PATH cleanup; classifier consolidation; typed diagnostics + frontend). Validated
+with `mage qc:prerelease` (green, including `go test ./... -race`).
 
 ## Problem
 
@@ -108,23 +110,28 @@ Kubernetes Authentication docs, "client-go credential plugins":
       (`backend/auth_providers.go:146`). Implemented as
       `TestDefaultExecutableSearchDirectoriesExcludesProviderPaths`
       (`backend/auth_providers_paths_test.go`).
-- [ ] Add a **guard** backend test proving the selected kubeconfig's
+- [x] Add a **guard** backend test proving the selected kubeconfig's
       `ExecProvider.Command` is preserved by `buildRestConfigForSelection`
       except for existing Windows wrapper behavior
       (`backend/cluster_clients.go:505`, `backend/exec_wrapper.go:60`).
-- [ ] Add backend tests for an `execDisplayCommand` helper:
+      Covered by `TestWrapExecProviderForWindowsNoop` (the only step in
+      `buildRestConfigForSelection` that touches `ExecProvider.Command`, a no-op
+      on non-Windows) plus the `execDisplayCommand` unwrap tests below.
+- [x] Add backend tests for an `execDisplayCommand` helper
+      (`TestExecDisplayCommand`, `backend/exec_wrapper_test.go`):
       - non-Windows/unwrapped config displays `ExecProvider.Command`
         (`backend/cluster_clients.go:505`);
       - Windows-wrapped config displays the original command stored after
         `--ly-exec-wrapper`, not the app executable
         (`backend/exec_wrapper.go:82`);
       - missing `ExecProvider` produces no command.
-- [ ] Add classifier tests covering missing helper, helper non-zero exit, HTTP
+- [x] Add classifier tests covering missing helper, helper non-zero exit, HTTP
       401/403, expired token strings, SSO strings, and connectivity errors. The
       current classifier fixtures include provider-named AWS/GCloud examples in
       heartbeat tests (`backend/app_heartbeat_test.go:518`); keep provider names
-      as input examples, not as app-owned branches.
-- [ ] Before consolidating classifiers, pin each current call site's verdicts:
+      as input examples, not as app-owned branches. Implemented as `TestClassify`
+      (`backend/internal/credentialerrors/credentialerrors_test.go`).
+- [x] Before consolidating classifiers, pin each current call site's verdicts:
       preflight/recovery (`backend/cluster_clients.go:399`,
       `backend/cluster_clients.go:475`), auth transport
       (`backend/internal/authstate/transport.go:61`), and heartbeat
@@ -157,87 +164,90 @@ Kubernetes Authentication docs, "client-go credential plugins":
 
 ## Phase 3: Centralize Exec Credential Diagnostics
 
-- [ ] Introduce one backend classifier for credential-plugin failures, cluster
+- [x] Introduce one backend classifier for credential-plugin failures, cluster
       credential rejection, and connectivity. Candidate package:
       `backend/internal/credentialerrors`.
-- [ ] Make the classifier API accept contextual data in addition to `error`,
+- [x] Make the classifier API accept contextual data in addition to `error`,
       because `execCommand` comes from `rest.Config.ExecProvider`
       (`backend/cluster_clients.go:505`), while current classifiers only accept
       `error` (`backend/cluster_clients.go:535`,
-      `backend/app_heartbeat.go:139`).
-- [ ] Replace `isCredentialError` in cluster client setup
+      `backend/app_heartbeat.go:139`). Done via `credentialerrors.Context`.
+- [x] Replace `isCredentialError` in cluster client setup
       (`backend/cluster_clients.go:532`) with the shared classifier.
-- [ ] Replace `isCredentialError` in auth transport
+- [x] Replace `isCredentialError` in auth transport
       (`backend/internal/authstate/transport.go:96`) with the shared classifier.
-- [ ] Replace `isExecCredentialError` in heartbeat health
+- [x] Replace `isExecCredentialError` in heartbeat health
       (`backend/app_heartbeat.go:136`) with the shared classifier.
-- [ ] Return a typed diagnostic from the classifier, not only a boolean:
+- [x] Return a typed diagnostic from the classifier, not only a boolean:
       `class`, `kind`, sanitized `summary`, and optional `execCommand`.
-- [ ] Preserve or deliberately change each call site's verdict table. A wider
+- [x] Preserve or deliberately change each call site's verdict table. A wider
       classifier would change heartbeat behavior if it turns current
       connectivity-class strings into `healthAuthFailure`; heartbeat maps
       auth-class errors to `healthAuthFailure` and all other errors to
       `healthConnectivityFailure` (`backend/app_heartbeat.go:124`,
-      `backend/app_heartbeat.go:133`).
-- [ ] Keep raw provider stderr out of default UI copy unless a separate
-      diagnostic/details surface deliberately exposes it.
+      `backend/app_heartbeat.go:133`). Heartbeat deliberately broadened (expired/
+      SSO transport errors now auth-class), pinned by
+      `TestCheckClusterHealth/expired_credential...`.
+- [x] Keep raw provider stderr out of default UI copy unless a separate
+      diagnostic/details surface deliberately exposes it. `Diagnostic.Summary` is
+      a fixed provider-neutral phrase, pinned by `TestClassifySummaryIsSanitized`.
 
 ## Phase 4: Carry Typed Auth Diagnostics To The Frontend
 
-- [ ] Change the `authstate.Manager` producer contract by name instead of
+- [x] Change the `authstate.Manager` producer contract by name instead of
       routing diagnostics around it. The current path is
       `ReportFailure(reason string)` (`backend/internal/authstate/manager.go:155`)
       to `OnStateChange(state, reason string)`
       (`backend/internal/authstate/manager.go:48`) to
       `handleClusterAuthStateChange(clusterID, state, reason)`
       (`backend/cluster_auth.go:29`).
-- [ ] Add an `authstate.FailureDiagnostic` (or equivalent) that contains the
+- [x] Add an `authstate.FailureDiagnostic` (or equivalent) that contains the
       existing reason plus `class`, `kind`, sanitized `summary`, and optional
       `execCommand`.
-- [ ] Store the latest failure diagnostic in the manager alongside
+- [x] Store the latest failure diagnostic in the manager alongside
       `failureReason`; `State()` and the initial auth-state RPC currently expose
       only `state`, `reason`, `secondsUntilRetry`, and `errorClass`
       (`backend/internal/authstate/manager.go:138`,
       `backend/cluster_auth.go:359`).
-- [ ] Capture `execCommand` during REST config construction before Windows
+- [x] Capture `execCommand` during REST config construction before Windows
       wrapping, or with an explicit unwrap helper for already-wrapped configs
       (`backend/cluster_clients.go:505`, `backend/exec_wrapper.go:82`).
-- [ ] Extend backend auth state/events so failed, recovering, progress, and
+- [x] Extend backend auth state/events so failed, recovering, progress, and
       initial-state payloads can carry typed diagnostic fields alongside the
       existing `clusterId`, `clusterName`, `reason`, and `errorClass`
       (`backend/cluster_auth.go:62`, `backend/cluster_auth.go:83`,
       `backend/cluster_auth.go:388`).
-- [ ] Extend `ClusterAuthState` and auth event payload types with typed
+- [x] Extend `ClusterAuthState` and auth event payload types with typed
       diagnostic fields (`frontend/src/core/contexts/AuthErrorContext.tsx:23`).
-- [ ] Update `applyAuthFailedEvent`, `applyAuthRecoveringEvent`,
+- [x] Update `applyAuthFailedEvent`, `applyAuthRecoveringEvent`,
       `applyAuthProgressEvent`, and initial-state hydration to preserve the
       typed diagnostic fields (`frontend/src/core/contexts/AuthErrorContext.tsx:89`,
       `frontend/src/core/contexts/AuthErrorContext.tsx:114`,
       `frontend/src/core/contexts/AuthErrorContext.tsx:139`,
       `frontend/src/core/contexts/AuthErrorContext.tsx:201`).
-- [ ] Update `AuthFailureOverlay` to render kubeconfig-centered copy. Example:
+- [x] Update `AuthFailureOverlay` to render kubeconfig-centered copy. Example:
       "This kubeconfig asks Kubernetes to run `<command>` for credentials. Install
       that command, add it to PATH, or update the kubeconfig, then retry."
       Existing overlay rendering starts at
       `frontend/src/ui/overlays/AuthFailureOverlay.tsx:45`.
-- [ ] Add frontend tests for missing exec command, failed exec command, cluster
+- [x] Add frontend tests for missing exec command, failed exec command, cluster
       rejected credentials, and connectivity-class recovery. Existing
       subscription tests cover the four auth event names
       (`frontend/src/core/contexts/AuthErrorContext.test.tsx:105`).
 
 ## Phase 5: Preserve Multi-Cluster Recovery Behavior
 
-- [ ] Keep every new backend event and frontend state update keyed by
+- [x] Keep every new backend event and frontend state update keyed by
       `clusterId`, matching the auth architecture contract
       (`docs/architecture/auth.md:8`) and multi-cluster contract
       (`docs/architecture/multi-cluster.md:9`).
-- [ ] Confirm one cluster with a missing/failing exec plugin pauses only that
+- [x] Confirm one cluster with a missing/failing exec plugin pauses only that
       cluster's refresh/action surface. The auth doc requires unrelated clusters
       to continue operating (`docs/architecture/auth.md:3`).
-- [ ] Confirm recovery still builds a fresh kubeconfig-derived client instead of
+- [x] Confirm recovery still builds a fresh kubeconfig-derived client instead of
       using the wrapped transport (`docs/architecture/auth.md:75`,
       `backend/cluster_clients.go:361`).
-- [ ] Confirm rebuilt cluster transports reuse the existing auth manager, because
+- [x] Confirm rebuilt cluster transports reuse the existing auth manager, because
       the auth doc records that invariant and its pinned test
       (`docs/architecture/auth.md:79`).
 

--- a/docs/plans/remove-provider-binary-auth-coupling.md
+++ b/docs/plans/remove-provider-binary-auth-coupling.md
@@ -1,0 +1,275 @@
+# Remove Provider-Binary Auth Coupling
+
+Status: **Planned, not started.**
+
+## Problem
+
+The app should treat kubeconfig as the auth contract. If a kubeconfig uses a
+`user.exec` credential plugin, the app should let `client-go` honor that
+kubeconfig entry; the app should not carry provider-specific assumptions for
+AWS, Google, Azure, or any other provider.
+
+This distinction matters because the app currently has both:
+
+- kubeconfig-owned exec support: `auth_providers.go` imports
+  `k8s.io/client-go/plugin/pkg/client/auth` and its comment says the import
+  registers `client-go` auth plugins so helpers declared in kubeconfigs can run
+  (`backend/auth_providers.go:17`).
+- app-owned provider coupling: `setupEnvironment` calls
+  `exec.LookPath("gke-gcloud-auth-plugin")` and discards the result
+  (`backend/auth_providers.go:61`), and `authHelperDirectories` hard-codes
+  Google Cloud SDK paths and Caskroom globs (`backend/auth_providers.go:146`).
+
+External reference to keep aligned with during implementation:
+Kubernetes Authentication docs, "client-go credential plugins":
+<https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins>.
+
+## Current Contract Evidence
+
+- Kubeconfig discovery validates files by parsing kubeconfig YAML with
+  `clientcmd.LoadFromFile`, checks clusters/contexts, and appends each context
+  (`backend/kubeconfigs.go:102`). This path should not require any provider
+  binary to exist.
+- REST config construction loads the selected kubeconfig path/context with
+  `clientcmd.NewNonInteractiveDeferredLoadingClientConfig` and
+  `ClientConfig()` (`backend/cluster_clients.go:488`). This is the point where
+  selected kubeconfig auth configuration belongs.
+- The displayable exec command must come from kubeconfig-derived config, not
+  from error-string scraping: `buildRestConfigForSelection` has
+  `config.ExecProvider` before Windows wrapping (`backend/cluster_clients.go:505`).
+  On Windows, the wrapper replaces `ExecProvider.Command` with the app binary
+  and moves the original command into wrapper args
+  (`backend/exec_wrapper.go:82`).
+- Exec credential errors can happen before HTTP transport sees a request; the
+  preflight comment says the exec credential provider runs above the HTTP
+  transport and must be checked explicitly (`backend/cluster_clients.go:392`).
+- Auth state is per cluster: the architecture doc requires auth state to be
+  tracked by `clusterId` and says only the affected cluster's refresh, streams,
+  actions, and diagnostics should pause/block (`docs/architecture/auth.md:8`).
+- Multi-cluster state must carry `clusterId` through APIs, refresh scopes,
+  caches, stores, events, persistence keys, navigation, diagnostics, and object
+  actions (`docs/architecture/multi-cluster.md:9`).
+- Recovery probes rebuild a fresh client from kubeconfig so refreshed external
+  credentials can be picked up (`backend/cluster_clients.go:361`).
+- The Windows wrapper only rewrites an existing `ExecProvider` command through
+  the app binary on Windows (`backend/exec_wrapper.go:60`).
+- `authstate.Manager` currently stores and emits only a string reason:
+  `ReportFailure(reason string)` (`backend/internal/authstate/manager.go:155`),
+  `Config.OnStateChange func(state State, reason string)`
+  (`backend/internal/authstate/manager.go:48`), and `setState` forwards only
+  `newState, reason` (`backend/internal/authstate/manager.go:232`).
+- Auth event payloads currently carry `clusterId`, `clusterName`, and raw
+  `reason` for failed/recovering events (`backend/cluster_auth.go:62`,
+  `backend/cluster_auth.go:83`), and progress events carry `errorClass`
+  (`backend/cluster_auth.go:388`).
+- The frontend auth state currently stores `reason` and `errorClass`
+  (`frontend/src/core/contexts/AuthErrorContext.tsx:23`), and the auth overlay
+  renders `authState.reason` directly (`frontend/src/ui/overlays/AuthFailureOverlay.tsx:45`).
+- Credential-error classification is duplicated in cluster client setup
+  (`backend/cluster_clients.go:532`), auth transport
+  (`backend/internal/authstate/transport.go:96`), and heartbeat health
+  (`backend/app_heartbeat.go:136`).
+- The heartbeat classifier is narrower than the cluster-client/auth-transport
+  classifier: heartbeat checks three exec-plugin patterns
+  (`backend/app_heartbeat.go:144`), while cluster client setup checks eleven
+  credential patterns (`backend/cluster_clients.go:541`).
+
+## Target Contract
+
+- Discovery and selection never require cloud-provider binaries.
+- A selected kubeconfig may require an external command because that command is
+  declared by kubeconfig, not by app provider logic.
+- The app may improve generic desktop PATH handling, but it must not hard-code
+  provider install locations or probe for a provider-specific command.
+- Missing or failing exec plugins are reported as kubeconfig credential-plugin
+  diagnostics for the affected `clusterId`.
+- `execCommand` diagnostics are captured from `rest.Config.ExecProvider` during
+  config construction, with Windows wrapper unwrapping handled explicitly; do
+  not scrape the command out of the error string.
+- Auth failure and recovery behavior stays per-cluster and continues to rebuild
+  fresh kubeconfig-derived clients during recovery.
+
+## Phase 1: Characterize The Contract With Tests
+
+- [ ] Add a **characterization/guard** backend test proving kubeconfig discovery
+      accepts a kubeconfig whose user has
+      `exec.command: definitely-missing-helper`; app discovery calls
+      `clientcmd.LoadFromFile` (`backend/kubeconfigs.go:102`), and
+      client-go v0.36.2 `LoadFromFile` reads file bytes and decodes config
+      (`k8s.io/client-go@v0.36.2/tools/clientcmd/loader.go:397`).
+- [ ] Keep or rename the existing **guard** coverage proving
+      `setupEnvironment` keeps generic executable directories such as
+      `$HOME/.local/bin`; current coverage asserts that path
+      (`backend/app_lifecycle_test.go:27`).
+- [ ] Add an **expected-red** backend test proving `setupEnvironment` does not
+      append Google Cloud SDK directories when those directories exist under a
+      temp `HOME`. The current `authHelperDirectories` list includes those
+      directories, so this is the Phase 2 behavior pin
+      (`backend/auth_providers.go:146`).
+- [ ] Add a **guard** backend test proving the selected kubeconfig's
+      `ExecProvider.Command` is preserved by `buildRestConfigForSelection`
+      except for existing Windows wrapper behavior
+      (`backend/cluster_clients.go:505`, `backend/exec_wrapper.go:60`).
+- [ ] Add backend tests for an `execDisplayCommand` helper:
+      - non-Windows/unwrapped config displays `ExecProvider.Command`
+        (`backend/cluster_clients.go:505`);
+      - Windows-wrapped config displays the original command stored after
+        `--ly-exec-wrapper`, not the app executable
+        (`backend/exec_wrapper.go:82`);
+      - missing `ExecProvider` produces no command.
+- [ ] Add classifier tests covering missing helper, helper non-zero exit, HTTP
+      401/403, expired token strings, SSO strings, and connectivity errors. The
+      current classifier fixtures include provider-named AWS/GCloud examples in
+      heartbeat tests (`backend/app_heartbeat_test.go:518`); keep provider names
+      as input examples, not as app-owned branches.
+- [ ] Before consolidating classifiers, pin each current call site's verdicts:
+      preflight/recovery (`backend/cluster_clients.go:399`,
+      `backend/cluster_clients.go:475`), auth transport
+      (`backend/internal/authstate/transport.go:61`), and heartbeat
+      (`backend/app_heartbeat.go:124`). The heartbeat helper currently uses a
+      narrower pattern set (`backend/app_heartbeat.go:144`) than
+      `isCredentialError` (`backend/cluster_clients.go:541`).
+
+## Phase 2: Remove Provider-Specific PATH Logic
+
+- [ ] Delete the discarded `exec.LookPath("gke-gcloud-auth-plugin")` probe; both
+      return values are assigned to blank identifiers today
+      (`backend/auth_providers.go:61`).
+- [ ] Replace `authHelperDirectories` with a provider-neutral helper, for
+      example `defaultExecutableSearchDirectories`, containing only generic
+      locations:
+      - `/usr/local/bin`
+      - `/opt/homebrew/bin`
+      - `/usr/bin`
+      - `$HOME/.local/bin`
+- [ ] Remove Google Cloud SDK home/share/Caskroom paths from the app-owned list
+      as an explicit behavior change, not as mechanical cleanup
+      (`backend/auth_providers.go:153`, `backend/auth_providers.go:160`).
+- [ ] Keep login-shell PATH merging, because `setupEnvironment` already reads a
+      login shell PATH before merging app process PATH (`backend/auth_providers.go:47`).
+- [ ] Update tests in `backend/auth_providers_paths_test.go` and
+      `backend/app_lifecycle_test.go` to describe generic desktop executable
+      discovery instead of provider-specific auth helper discovery.
+
+## Phase 3: Centralize Exec Credential Diagnostics
+
+- [ ] Introduce one backend classifier for credential-plugin failures, cluster
+      credential rejection, and connectivity. Candidate package:
+      `backend/internal/credentialerrors`.
+- [ ] Make the classifier API accept contextual data in addition to `error`,
+      because `execCommand` comes from `rest.Config.ExecProvider`
+      (`backend/cluster_clients.go:505`), while current classifiers only accept
+      `error` (`backend/cluster_clients.go:535`,
+      `backend/app_heartbeat.go:139`).
+- [ ] Replace `isCredentialError` in cluster client setup
+      (`backend/cluster_clients.go:532`) with the shared classifier.
+- [ ] Replace `isCredentialError` in auth transport
+      (`backend/internal/authstate/transport.go:96`) with the shared classifier.
+- [ ] Replace `isExecCredentialError` in heartbeat health
+      (`backend/app_heartbeat.go:136`) with the shared classifier.
+- [ ] Return a typed diagnostic from the classifier, not only a boolean:
+      `class`, `kind`, sanitized `summary`, and optional `execCommand`.
+- [ ] Preserve or deliberately change each call site's verdict table. A wider
+      classifier would change heartbeat behavior if it turns current
+      connectivity-class strings into `healthAuthFailure`; heartbeat maps
+      auth-class errors to `healthAuthFailure` and all other errors to
+      `healthConnectivityFailure` (`backend/app_heartbeat.go:124`,
+      `backend/app_heartbeat.go:133`).
+- [ ] Keep raw provider stderr out of default UI copy unless a separate
+      diagnostic/details surface deliberately exposes it.
+
+## Phase 4: Carry Typed Auth Diagnostics To The Frontend
+
+- [ ] Change the `authstate.Manager` producer contract by name instead of
+      routing diagnostics around it. The current path is
+      `ReportFailure(reason string)` (`backend/internal/authstate/manager.go:155`)
+      to `OnStateChange(state, reason string)`
+      (`backend/internal/authstate/manager.go:48`) to
+      `handleClusterAuthStateChange(clusterID, state, reason)`
+      (`backend/cluster_auth.go:29`).
+- [ ] Add an `authstate.FailureDiagnostic` (or equivalent) that contains the
+      existing reason plus `class`, `kind`, sanitized `summary`, and optional
+      `execCommand`.
+- [ ] Store the latest failure diagnostic in the manager alongside
+      `failureReason`; `State()` and the initial auth-state RPC currently expose
+      only `state`, `reason`, `secondsUntilRetry`, and `errorClass`
+      (`backend/internal/authstate/manager.go:138`,
+      `backend/cluster_auth.go:359`).
+- [ ] Capture `execCommand` during REST config construction before Windows
+      wrapping, or with an explicit unwrap helper for already-wrapped configs
+      (`backend/cluster_clients.go:505`, `backend/exec_wrapper.go:82`).
+- [ ] Extend backend auth state/events so failed, recovering, progress, and
+      initial-state payloads can carry typed diagnostic fields alongside the
+      existing `clusterId`, `clusterName`, `reason`, and `errorClass`
+      (`backend/cluster_auth.go:62`, `backend/cluster_auth.go:83`,
+      `backend/cluster_auth.go:388`).
+- [ ] Extend `ClusterAuthState` and auth event payload types with typed
+      diagnostic fields (`frontend/src/core/contexts/AuthErrorContext.tsx:23`).
+- [ ] Update `applyAuthFailedEvent`, `applyAuthRecoveringEvent`,
+      `applyAuthProgressEvent`, and initial-state hydration to preserve the
+      typed diagnostic fields (`frontend/src/core/contexts/AuthErrorContext.tsx:89`,
+      `frontend/src/core/contexts/AuthErrorContext.tsx:114`,
+      `frontend/src/core/contexts/AuthErrorContext.tsx:139`,
+      `frontend/src/core/contexts/AuthErrorContext.tsx:201`).
+- [ ] Update `AuthFailureOverlay` to render kubeconfig-centered copy. Example:
+      "This kubeconfig asks Kubernetes to run `<command>` for credentials. Install
+      that command, add it to PATH, or update the kubeconfig, then retry."
+      Existing overlay rendering starts at
+      `frontend/src/ui/overlays/AuthFailureOverlay.tsx:45`.
+- [ ] Add frontend tests for missing exec command, failed exec command, cluster
+      rejected credentials, and connectivity-class recovery. Existing
+      subscription tests cover the four auth event names
+      (`frontend/src/core/contexts/AuthErrorContext.test.tsx:105`).
+
+## Phase 5: Preserve Multi-Cluster Recovery Behavior
+
+- [ ] Keep every new backend event and frontend state update keyed by
+      `clusterId`, matching the auth architecture contract
+      (`docs/architecture/auth.md:8`) and multi-cluster contract
+      (`docs/architecture/multi-cluster.md:9`).
+- [ ] Confirm one cluster with a missing/failing exec plugin pauses only that
+      cluster's refresh/action surface. The auth doc requires unrelated clusters
+      to continue operating (`docs/architecture/auth.md:3`).
+- [ ] Confirm recovery still builds a fresh kubeconfig-derived client instead of
+      using the wrapped transport (`docs/architecture/auth.md:75`,
+      `backend/cluster_clients.go:361`).
+- [ ] Confirm rebuilt cluster transports reuse the existing auth manager, because
+      the auth doc records that invariant and its pinned test
+      (`docs/architecture/auth.md:79`).
+
+## Validation
+
+Documentation-only changes to this plan do not require prerelease validation
+under the root AGENTS rule (`AGENTS.md:106`, `AGENTS.md:112`). Implementation
+work should use red/green/refactor TDD for each behavior change
+(`AGENTS.md:52`).
+
+Targeted implementation checks:
+
+- `go test ./backend ./backend/internal/authstate`
+- `npm run test --prefix frontend -- AuthErrorContext AuthFailureOverlay`
+- `npm run typecheck --prefix frontend`
+- `mage qc:prerelease` before presenting non-documentation work as ready
+  (`AGENTS.md:106`)
+
+## Rollout Notes
+
+- Split implementation into separate PRs where possible:
+  1. provider-specific PATH cleanup;
+  2. classifier consolidation with call-site verdict pins;
+  3. typed auth diagnostics and frontend copy.
+- Backend cleanup can land before frontend copy changes if typed diagnostics are
+  added compatibly with existing `reason` and `errorClass` fields.
+- Removing Google Cloud SDK directory injection can affect users whose
+  `gke-gcloud-auth-plugin` or `gcloud` binary is installed only under one of the
+  removed paths and not present in login-shell PATH. Migration guidance: put the
+  credential helper on login-shell PATH, use an absolute `exec.command` in the
+  kubeconfig, or install the provider helper in a generic executable directory
+  such as `/usr/local/bin`, `/opt/homebrew/bin`, or `$HOME/.local/bin`
+  (`backend/auth_providers.go:153`, `backend/auth_providers.go:160`,
+  `backend/auth_providers.go:47`).
+- Frontend copy should avoid naming AWS, Google, Azure, or any provider unless
+  the kubeconfig command itself contains that provider's command name.
+- This plan intentionally keeps kubeconfig `exec` support. Removing `exec`
+  support would reject valid kubeconfigs that depend on `client-go` credential
+  plugins, which is not the target contract described above.

--- a/docs/release/pending.md
+++ b/docs/release/pending.md
@@ -2,6 +2,12 @@
 
 ### Changed
 
+- The authentication-failure overlay now explains credential-plugin failures in
+  terms of the kubeconfig. When a cluster's kubeconfig declares an `exec` credential
+  helper the app could not run, the overlay names that command ("This kubeconfig asks
+  Kubernetes to run `<command>` for credentials…") and suggests installing it, adding it
+  to `PATH`, or updating the kubeconfig — instead of showing a raw, provider-specific
+  error string.
 - The app no longer injects cloud-provider install locations (Google Cloud SDK and
   Caskroom paths) into `PATH` at startup, and no longer probes for
   `gke-gcloud-auth-plugin`. Kubeconfig is treated as the auth contract: a kubeconfig's
@@ -13,6 +19,11 @@
 
 ### Fixed
 
+- Cluster credential errors are now classified consistently across the initial
+  connection, live requests, and the periodic health check. An expired token, expired
+  SSO session, or failed/missing credential-plugin error detected by the heartbeat is now
+  treated as an authentication failure (and triggers recovery), where it could previously
+  be misreported as a connectivity issue and skip auth recovery.
 - Object Panel → Details now refreshes when the underlying object changes (e.g. a
   Deployment's container image tag). The details snapshot previously carried a constant
   source-version ETag, so the backend kept replying "not modified" and the panel showed

--- a/docs/release/pending.md
+++ b/docs/release/pending.md
@@ -2,6 +2,15 @@
 
 ### Changed
 
+- The app no longer injects cloud-provider install locations (Google Cloud SDK and
+  Caskroom paths) into `PATH` at startup, and no longer probes for
+  `gke-gcloud-auth-plugin`. Kubeconfig is treated as the auth contract: a kubeconfig's
+  `exec` credential helper is still honored, resolved through your login-shell `PATH`
+  plus generic desktop directories (`/usr/local/bin`, `/opt/homebrew/bin`, `/usr/bin`,
+  `$HOME/.local/bin`). If a credential helper was previously found only because the app
+  added a provider-specific directory, put that helper on your login-shell `PATH`, use an
+  absolute `command` in the kubeconfig, or install it in one of the generic directories.
+
 ### Fixed
 
 - Object Panel → Details now refreshes when the underlying object changes (e.g. a

--- a/frontend/src/core/connection/connectivityPresentation.test.ts
+++ b/frontend/src/core/connection/connectivityPresentation.test.ts
@@ -18,6 +18,9 @@ describe('buildConnectivityPresentation', () => {
         clusterName: '',
         secondsUntilRetry: 0,
         errorClass: '',
+        execCommand: '',
+        diagnosticKind: '',
+        diagnosticSummary: '',
       },
     });
 
@@ -43,6 +46,9 @@ describe('buildConnectivityPresentation', () => {
         clusterName: 'alpha',
         secondsUntilRetry: 15,
         errorClass: 'connectivity',
+        execCommand: '',
+        diagnosticKind: '',
+        diagnosticSummary: '',
       },
     });
 
@@ -67,6 +73,9 @@ describe('buildConnectivityPresentation', () => {
         clusterName: 'alpha',
         secondsUntilRetry: 5,
         errorClass: 'auth',
+        execCommand: '',
+        diagnosticKind: '',
+        diagnosticSummary: '',
       },
     });
 

--- a/frontend/src/core/contexts/AuthErrorContext.test.tsx
+++ b/frontend/src/core/contexts/AuthErrorContext.test.tsx
@@ -253,6 +253,53 @@ describe('auth error state transitions', () => {
     expect(isConfirmedAuthFailure(map.get('c1')!)).toBe(true);
   });
 
+  it('carries the exec command, kind, and summary from a failed event', () => {
+    const next = applyAuthFailedEvent(empty(), {
+      clusterId: 'c1',
+      reason: 'exec: executable gke-gcloud-auth-plugin not found',
+      kind: 'missing-helper',
+      summary: "The kubeconfig's credential helper could not be found.",
+      execCommand: 'gke-gcloud-auth-plugin',
+    });
+
+    const state = next.get('c1')!;
+    expect(state.execCommand).toBe('gke-gcloud-auth-plugin');
+    expect(state.diagnosticKind).toBe('missing-helper');
+    expect(state.diagnosticSummary).toBe("The kubeconfig's credential helper could not be found.");
+  });
+
+  it('carries the exec command from a recovering event', () => {
+    const next = applyAuthRecoveringEvent(empty(), {
+      clusterId: 'c1',
+      reason: 'exec: executable aws not found',
+      execCommand: 'aws',
+    });
+
+    expect(next.get('c1')!.execCommand).toBe('aws');
+  });
+
+  it('keeps the exec command sticky across a progress event without one', () => {
+    let map = applyAuthRecoveringEvent(empty(), {
+      clusterId: 'c1',
+      reason: 'missing helper',
+      execCommand: 'gke-gcloud-auth-plugin',
+    });
+    map = applyAuthProgressEvent(map, { clusterId: 'c1', secondsUntilRetry: 5 });
+
+    expect(map.get('c1')!.execCommand).toBe('gke-gcloud-auth-plugin');
+  });
+
+  it('adopts the exec command from a progress event that carries one', () => {
+    let map = applyAuthRecoveringEvent(empty(), { clusterId: 'c1', reason: 'x' });
+    map = applyAuthProgressEvent(map, {
+      clusterId: 'c1',
+      secondsUntilRetry: 5,
+      execCommand: 'aws',
+    });
+
+    expect(map.get('c1')!.execCommand).toBe('aws');
+  });
+
   it('keeps the previous verdict when a progress event has no verdict yet', () => {
     let map = applyAuthFailedEvent(empty(), { clusterId: 'c1', reason: 'expired' });
     map = applyAuthRecoveringEvent(map, { clusterId: 'c1' });

--- a/frontend/src/core/contexts/AuthErrorContext.tsx
+++ b/frontend/src/core/contexts/AuthErrorContext.tsx
@@ -33,6 +33,15 @@ export interface ClusterAuthState {
   secondsUntilRetry: number;
   /** Latest recovery verdict; sticky until a probe result contradicts it. */
   errorClass: AuthErrorClass;
+  /**
+   * The kubeconfig exec credential command, when the failure is exec-plugin
+   * related (e.g. a missing helper). '' when unknown or not exec-based.
+   */
+  execCommand: string;
+  /** Finer backend failure classification (e.g. 'missing-helper'); '' when unknown. */
+  diagnosticKind: string;
+  /** Sanitized, provider-neutral one-line summary of the failure; '' when unknown. */
+  diagnosticSummary: string;
 }
 
 /**
@@ -45,6 +54,9 @@ const DEFAULT_AUTH_STATE: ClusterAuthState = {
   isRecovering: false,
   secondsUntilRetry: 0,
   errorClass: '',
+  execCommand: '',
+  diagnosticKind: '',
+  diagnosticSummary: '',
 };
 
 /**
@@ -54,6 +66,12 @@ interface AuthEventPayload {
   clusterId?: string;
   clusterName?: string;
   reason?: string;
+  /** Finer credential classification (credentialerrors.Kind). */
+  kind?: string;
+  /** Sanitized, provider-neutral summary. */
+  summary?: string;
+  /** Kubeconfig exec credential command, when known. */
+  execCommand?: string;
 }
 
 /**
@@ -64,6 +82,9 @@ interface AuthProgressPayload {
   clusterName?: string;
   secondsUntilRetry?: number;
   errorClass?: string;
+  kind?: string;
+  summary?: string;
+  execCommand?: string;
 }
 
 /** Narrows an event payload value to a known error class. */
@@ -102,6 +123,9 @@ export const applyAuthFailedEvent = (
     isRecovering: false,
     secondsUntilRetry: existing?.secondsUntilRetry || 0,
     errorClass: 'auth',
+    execCommand: payload.execCommand || existing?.execCommand || '',
+    diagnosticKind: payload.kind || existing?.diagnosticKind || '',
+    diagnosticSummary: payload.summary || existing?.diagnosticSummary || '',
   });
   return next;
 };
@@ -127,6 +151,9 @@ export const applyAuthRecoveringEvent = (
     isRecovering: true,
     secondsUntilRetry: existing?.secondsUntilRetry || 0,
     errorClass: existing?.errorClass ?? '',
+    execCommand: existing?.execCommand || payload.execCommand || '',
+    diagnosticKind: existing?.diagnosticKind || payload.kind || '',
+    diagnosticSummary: existing?.diagnosticSummary || payload.summary || '',
   });
   return next;
 };
@@ -154,6 +181,9 @@ export const applyAuthProgressEvent = (
     clusterName: payload.clusterName || existing.clusterName,
     secondsUntilRetry: payload.secondsUntilRetry ?? existing.secondsUntilRetry,
     errorClass: normalizeAuthErrorClass(payload.errorClass) || existing.errorClass,
+    execCommand: payload.execCommand || existing.execCommand,
+    diagnosticKind: payload.kind || existing.diagnosticKind,
+    diagnosticSummary: payload.summary || existing.diagnosticSummary,
   });
   return next;
 };
@@ -215,6 +245,9 @@ export const AuthErrorProvider: React.FC<{ children: React.ReactNode }> = ({ chi
           const reason = (stateInfo.reason as string) || '';
           const clusterName = (stateInfo.clusterName as string) || clusterId;
           const secondsUntilRetry = (stateInfo.secondsUntilRetry as number) || 0;
+          const execCommand = (stateInfo.execCommand as string) || '';
+          const diagnosticKind = (stateInfo.kind as string) || '';
+          const diagnosticSummary = (stateInfo.summary as string) || '';
 
           // Only add clusters that are in error or recovering state
           if (state === 'recovering') {
@@ -225,6 +258,9 @@ export const AuthErrorProvider: React.FC<{ children: React.ReactNode }> = ({ chi
               isRecovering: true,
               secondsUntilRetry,
               errorClass: normalizeAuthErrorClass(stateInfo.errorClass),
+              execCommand,
+              diagnosticKind,
+              diagnosticSummary,
             });
           } else if (state === 'invalid') {
             initialErrors.set(clusterId, {
@@ -237,6 +273,9 @@ export const AuthErrorProvider: React.FC<{ children: React.ReactNode }> = ({ chi
               secondsUntilRetry,
               // Invalid is only reached by exhausting auth-class failures.
               errorClass: 'auth',
+              execCommand,
+              diagnosticKind,
+              diagnosticSummary,
             });
           }
         }

--- a/frontend/src/ui/overlays/AuthFailureOverlay.test.tsx
+++ b/frontend/src/ui/overlays/AuthFailureOverlay.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * frontend/src/ui/overlays/AuthFailureOverlay.test.tsx
+ *
+ * Tests the presentational copy of the auth failure overlay, in particular the
+ * kubeconfig-centered exec-credential guidance and the avoidance of raw
+ * provider stderr in the default copy.
+ */
+
+import ReactDOM from 'react-dom/client';
+import { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { AuthFailureOverlayContent } from './AuthFailureOverlay';
+import type { ClusterAuthState } from '@/core/contexts/AuthErrorContext';
+
+const baseState: ClusterAuthState = {
+  hasError: true,
+  reason: 'Authentication failed',
+  clusterName: 'prod',
+  isRecovering: false,
+  secondsUntilRetry: 0,
+  errorClass: 'auth',
+  execCommand: '',
+  diagnosticKind: '',
+  diagnosticSummary: '',
+};
+
+describe('AuthFailureOverlayContent', () => {
+  let container: HTMLDivElement;
+  let root: ReactDOM.Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = ReactDOM.createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const renderContent = async (authState: ClusterAuthState) => {
+    await act(async () => {
+      root.render(
+        <AuthFailureOverlayContent authState={authState} clusterId="c1" onRetry={() => {}} />
+      );
+    });
+  };
+
+  it('renders kubeconfig-centered copy naming the exec command', async () => {
+    await renderContent({ ...baseState, execCommand: 'gke-gcloud-auth-plugin' });
+
+    expect(container.textContent).toContain('This kubeconfig asks Kubernetes to run');
+    const code = container.querySelector('code');
+    expect(code?.textContent).toBe('gke-gcloud-auth-plugin');
+  });
+
+  it('prefers the sanitized summary and never leaks raw provider stderr', async () => {
+    await renderContent({
+      ...baseState,
+      reason:
+        'getting credentials: exec: executable aws failed: SSO token at https://secret.example expired',
+      diagnosticSummary: 'The cluster credentials have expired.',
+    });
+
+    expect(container.textContent).toContain('The cluster credentials have expired.');
+    expect(container.textContent).not.toContain('secret.example');
+  });
+
+  it('falls back to generic copy when there is no exec command', async () => {
+    await renderContent(baseState);
+
+    expect(container.textContent).not.toContain('This kubeconfig asks Kubernetes to run');
+    expect(container.textContent).toContain('Retry Now');
+  });
+});

--- a/frontend/src/ui/overlays/AuthFailureOverlay.tsx
+++ b/frontend/src/ui/overlays/AuthFailureOverlay.tsx
@@ -25,14 +25,15 @@ interface AuthFailureOverlayContentProps {
 /**
  * Content for the auth failure overlay.
  * Shows different messages based on whether recovery is in progress.
+ * Exported for unit testing of the presentational copy.
  */
-const AuthFailureOverlayContent: React.FC<AuthFailureOverlayContentProps> = ({
+export const AuthFailureOverlayContent: React.FC<AuthFailureOverlayContentProps> = ({
   authState,
   clusterId,
   onRetry,
 }) => {
   const clusterName = authState.clusterName || clusterId;
-  const { secondsUntilRetry } = authState;
+  const { secondsUntilRetry, execCommand, diagnosticSummary, reason } = authState;
 
   // The recovery loop never stops, so the message is the same throughout:
   // the cluster reconnects on its own once the problem is resolved, and the
@@ -42,16 +43,33 @@ const AuthFailureOverlayContent: React.FC<AuthFailureOverlayContentProps> = ({
       ? `Next retry in ${secondsUntilRetry} second${secondsUntilRetry !== 1 ? 's' : ''}.`
       : 'Rechecking now…';
 
+  // Prefer the sanitized, provider-neutral summary over the raw reason, which
+  // may contain provider stderr. Fall back to the raw reason only when no
+  // summary is available.
+  const detail = diagnosticSummary || reason;
+
   return (
     <div className="auth-failure-overlay-content">
       <div className="auth-failure-icon">⚠️</div>
       <h2 className="auth-failure-title">Authentication Failure</h2>
       <p className="auth-failure-cluster">Cluster: {clusterName}</p>
-      {authState.reason && <p className="auth-failure-reason">{authState.reason}</p>}
-      <p className="auth-failure-message">
-        The app will attempt to reconnect automatically, but you may need to refresh your
-        credentials.
-      </p>
+      {execCommand ? (
+        // The kubeconfig declares an exec credential plugin the app could not
+        // run. Point at the kubeconfig contract, not at any specific provider.
+        <p className="auth-failure-message">
+          This kubeconfig asks Kubernetes to run{' '}
+          <code className="auth-failure-command">{execCommand}</code> for credentials. Install that
+          command, add it to your PATH, or update the kubeconfig, then retry.
+        </p>
+      ) : (
+        <>
+          {detail && <p className="auth-failure-reason">{detail}</p>}
+          <p className="auth-failure-message">
+            The app will attempt to reconnect automatically, but you may need to refresh your
+            credentials.
+          </p>
+        </>
+      )}
       <p className="auth-failure-message">{recheckMessage}</p>
       <button className="button generic" onClick={onRetry}>
         Retry Now

--- a/frontend/src/ui/status/ConnectivityStatus.test.tsx
+++ b/frontend/src/ui/status/ConnectivityStatus.test.tsx
@@ -19,6 +19,9 @@ let mockAuthState: ClusterAuthState = {
   clusterName: '',
   secondsUntilRetry: 0,
   errorClass: '',
+  execCommand: '',
+  diagnosticKind: '',
+  diagnosticSummary: '',
 };
 
 vi.mock('@shared/components/status/StatusIndicator', () => ({
@@ -124,6 +127,9 @@ describe('ConnectivityStatus', () => {
       clusterName: '',
       secondsUntilRetry: 0,
       errorClass: '',
+      execCommand: '',
+      diagnosticKind: '',
+      diagnosticSummary: '',
     };
   });
 
@@ -172,6 +178,9 @@ describe('ConnectivityStatus', () => {
       clusterName: 'alpha',
       secondsUntilRetry: 0,
       errorClass: 'auth',
+      execCommand: '',
+      diagnosticKind: '',
+      diagnosticSummary: '',
     };
 
     const indicator = renderStatus();


### PR DESCRIPTION
🤞 Hopefully fixes https://github.com/luxury-yacht/app/issues/240

The app no longer hardcodes provider-specific helper paths. To find the binary that a kubeconfig exec plugin uses, it builds a search `PATH` once at startup, then the OS resolves the command against it.

1. Your login shell's `$PATH` (whatever `$SHELL -lc 'printf %s "$PATH"'` returns). Environment-dependent -- on Windows this should return "no shell available."
2. The app process's own `$PATH` at launch. Environment-dependent, and it varies by how the app was started:
  - macOS: a Finder/Dock launch inherits a minimal launchd PATH; a terminal launch inherits that terminal's.
  - Linux: similar — a desktop-launcher PATH can be narrower than a shell's.
  - Windows: an Explorer/Start launch inherits the full user + system PATH (where CLI installers normally register their bin dir).
3. A few generic bin directories, but only the ones that actually exist and aren't already in `$PATH` (These are POSIX paths, so on Windows none of them exist and all are filtered out):
  - `/usr/local/bin`
  - `/opt/homebrew/bin`
  - `/usr/bin`
  - `$HOME/.local/bin`

Note that using an absolute path in kubeconfig bypasses path resolution entirely. This is the fallback workaround.
- macOS/Linux: `command: /opt/homebrew/bin/aws`
- Windows: `command: C:\Program Files\Amazon\AWSCLIV2\aws.exe`