### PR TITLE
Cluster overview restricted

### DIFF
--- a/backend/refresh/domainpermissions/spec.go
+++ b/backend/refresh/domainpermissions/spec.go
@@ -419,9 +419,18 @@ var policySpecs = []policySpec{
 		Stream:  []Resource{fromIdentity(nodes.Identity)},
 	},
 	{
-		Domain:  "cluster-overview",
-		Mode:    ModeAll,
-		Runtime: []Resource{fromIdentity(nodes.Identity)},
+		// ModeAny: the overview stays useful for identities without node access
+		// (issue #244 — the standard view role has pods+namespaces but no nodes).
+		// The builder marks the denied sources in the payload instead of the
+		// domain failing outright.
+		Domain: "cluster-overview",
+		Mode:   ModeAny,
+		Reason: "cluster overview requires nodes, pods, or namespaces",
+		Runtime: []Resource{
+			fromIdentity(nodes.Identity),
+			fromIdentity(pods.Identity),
+			fromIdentity(namespaces.Identity),
+		},
 	},
 	{
 		Domain:  "cluster-rbac",

--- a/backend/refresh/domainpermissions/spec_test.go
+++ b/backend/refresh/domainpermissions/spec_test.go
@@ -5,7 +5,27 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/luxury-yacht/app/backend/refresh/permissions"
 )
+
+// The cluster overview must stay useful for identities without node access
+// (issue #244): the runtime policy allows the domain when ANY of its primary
+// resources is readable, and the per-resource decisions flow to the builder
+// so it can mark the denied sources instead of failing the whole domain.
+func TestClusterOverviewRuntimePolicyAllowsAnyPrimaryResource(t *testing.T) {
+	policy, ok := RuntimePoliciesByDomain()["cluster-overview"]
+	require.True(t, ok, "cluster-overview must have a runtime policy")
+	require.Equal(t, ModeAny, policy.Mode,
+		"cluster overview must serve when any primary resource is readable, not require nodes")
+
+	keys := make([]string, 0, len(policy.Runtime))
+	for _, req := range policy.Runtime {
+		keys = append(keys, permissions.ResourceKey(req.Group, req.Resource))
+	}
+	require.ElementsMatch(t, []string{"core/nodes", "core/pods", "core/namespaces"}, keys)
+	require.NotEmpty(t, policy.Reason, "ModeAny denial needs an explicit human-readable reason")
+}
 
 func TestStreamDomainsDeriveFromCompositions(t *testing.T) {
 	compositions := CompositionByDomain()

--- a/backend/refresh/ingest/manager.go
+++ b/backend/refresh/ingest/manager.go
@@ -962,6 +962,22 @@ func (m *IngestManager) HasSyncedFor(gvr schema.GroupVersionResource) bool {
 	return m.entrySettled(e)
 }
 
+// PermissionSkippedFor reports whether gvr's reflector was permission-skipped at Start —
+// the identity cannot list+watch the kind, so its store is settled but PERMANENTLY empty
+// for this identity (until a rebuild re-evaluates permissions). Consumers use this to
+// mark the kind's data as permission-unavailable instead of rendering silent zeros; it is
+// deliberately distinct from deadline-degrade, which is a liveness state, not a
+// permission state. False for untracked GVRs and before Start.
+func (m *IngestManager) PermissionSkippedFor(gvr schema.GroupVersionResource) bool {
+	m.mu.Lock()
+	e, ok := m.entries[gvr]
+	m.mu.Unlock()
+	if !ok {
+		return false
+	}
+	return e.skipped.Load()
+}
+
 // resyncDisabled documents that ingest reflectors run with no periodic resync:
 // the store is always current, and a relist only happens on watch expiry/error.
 // It exists so the 0 passed to NewProjectingReflector reads as a deliberate

--- a/backend/refresh/ingest/manager_readiness_test.go
+++ b/backend/refresh/ingest/manager_readiness_test.go
@@ -96,6 +96,51 @@ func TestIngestManagerSkipsDeniedKindsAtStart(t *testing.T) {
 	}
 }
 
+// TestIngestManagerPermissionSkippedFor pins the skip-visibility contract: a consumer
+// (the cluster-overview builder) must be able to distinguish a permission-skipped store
+// (the identity cannot list+watch the kind, so its data is absent for permission
+// reasons) from a merely unsynced or degraded one, so it can mark the source as
+// permission-unavailable instead of rendering silent zeros.
+func TestIngestManagerPermissionSkippedFor(t *testing.T) {
+	mgr := NewIngestManager(testMeta, unreachableKube(t), nil, nil)
+	var deniedGVR, allowedGVR schema.GroupVersionResource
+	for g := range mgr.entries {
+		if deniedGVR.Resource == "" {
+			deniedGVR = g
+			continue
+		}
+		allowedGVR = g
+		break
+	}
+	if deniedGVR.Resource == "" || allowedGVR.Resource == "" {
+		t.Fatal("need at least two entries to exercise deny-one/allow-one")
+	}
+	mgr.SetPermissionFilter(func(group, resource string) bool {
+		return !(group == deniedGVR.Group && resource == deniedGVR.Resource)
+	})
+	mgr.now = func() time.Time { return time.Unix(1_700_000_000, 0) }
+	mgr.syncDeadline = time.Hour
+
+	if mgr.PermissionSkippedFor(deniedGVR) {
+		t.Fatalf("no kind may report skipped before Start")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mgr.Start(ctx)
+
+	if !mgr.PermissionSkippedFor(deniedGVR) {
+		t.Fatalf("denied kind %s must report permission-skipped after Start", deniedGVR)
+	}
+	if mgr.PermissionSkippedFor(allowedGVR) {
+		t.Fatalf("allowed kind %s must not report permission-skipped", allowedGVR)
+	}
+	unknown := schema.GroupVersionResource{Group: "nope.example.com", Version: "v1", Resource: "nopes"}
+	if mgr.PermissionSkippedFor(unknown) {
+		t.Fatal("untracked gvr must not report permission-skipped")
+	}
+}
+
 // TestIngestManagerHasSyncedForDegradesAfterDeadline pins the same contract on the
 // per-GVR readiness path (ingest_hub.go ingestKeySettled -> HasSyncedFor), which each
 // cut domain's ResourcesSettled gate uses to decide it can serve.

--- a/backend/refresh/snapshot/cluster_overview.go
+++ b/backend/refresh/snapshot/cluster_overview.go
@@ -34,6 +34,7 @@ import (
 	"github.com/luxury-yacht/app/backend/refresh"
 	"github.com/luxury-yacht/app/backend/refresh/domain"
 	"github.com/luxury-yacht/app/backend/refresh/metrics"
+	"github.com/luxury-yacht/app/backend/refresh/permissions"
 	"github.com/luxury-yacht/app/backend/resourcemodel"
 	eventres "github.com/luxury-yacht/app/backend/resources/events"
 )
@@ -53,6 +54,11 @@ type clusterOverviewIngestSource interface {
 	// Rows returns the whole per-object bundle for a GVR in one consistent store read; the
 	// overview reads the node store's Aggregate halves (nodeOverviewFact) through it.
 	Rows(gvr schema.GroupVersionResource) []interface{}
+	// PermissionSkippedFor reports whether the gvr's reflector was permission-skipped at
+	// Start (the identity cannot list+watch the kind). The overview marks such a source
+	// permission-unavailable: its store settles empty, and the runtime list SSAR alone
+	// misses the list-without-watch identity.
+	PermissionSkippedFor(gvr schema.GroupVersionResource) bool
 }
 
 // ClusterOverviewBuilder constructs aggregated cluster statistics using informer caches.
@@ -159,6 +165,13 @@ type ClusterOverviewPayload struct {
 	WorkloadResourceUsage WorkloadResourceUsage `json:"workloadResourceUsage"`
 
 	RecentEvents []RecentEvent `json:"recentEvents"`
+
+	// UnavailableResources lists the overview's primary sources (canonical
+	// group/resource keys — core/nodes, core/pods, core/namespaces) the current
+	// identity cannot list, so the frontend renders the affected cards as
+	// permission-gated instead of zero-valued (issue #244). Empty/omitted means
+	// every source was readable.
+	UnavailableResources []string `json:"unavailableResources,omitempty"`
 }
 
 type WorkloadResourceUsage struct {
@@ -282,6 +295,7 @@ func (b *ClusterOverviewListBuilder) Build(ctx context.Context, scope string) (*
 		statefulSetCount int
 		daemonSetCount   int
 		cronJobCount     int
+		nodesForbidden   bool
 		podsForbidden    bool
 		namespacesDenied bool
 		mu               sync.Mutex
@@ -290,13 +304,23 @@ func (b *ClusterOverviewListBuilder) Build(ctx context.Context, scope string) (*
 	tasks := []func(context.Context) error{
 		func(ctx context.Context) error {
 			resp, err := b.client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
-			if err != nil {
+			switch {
+			case err == nil:
+				mu.Lock()
+				nodes = parallel.CopyToPointers(resp.Items)
+				mu.Unlock()
+				return nil
+			case apierrors.IsForbidden(err):
+				// Issue #244: a namespaces- or pods-only identity still gets a
+				// partial overview; the denied source is marked in the payload.
+				klog.V(2).Info("cluster-overview fallback: node list forbidden; proceeding without node summary")
+				mu.Lock()
+				nodesForbidden = true
+				mu.Unlock()
+				return nil
+			default:
 				return err
 			}
-			mu.Lock()
-			nodes = parallel.CopyToPointers(resp.Items)
-			mu.Unlock()
-			return nil
 		},
 		func(ctx context.Context) error {
 			resp, err := b.client.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
@@ -475,13 +499,31 @@ func (b *ClusterOverviewListBuilder) Build(ctx context.Context, scope string) (*
 		return nil, err
 	}
 	applyClusterOverviewExtras(snapshot, clusterOverviewExtras{
-		totalDeployments:  deploymentCount,
-		totalStatefulSets: statefulSetCount,
-		totalDaemonSets:   daemonSetCount,
-		totalCronJobs:     cronJobCount,
-		recentEvents:      recentEvents,
+		totalDeployments:     deploymentCount,
+		totalStatefulSets:    statefulSetCount,
+		totalDaemonSets:      daemonSetCount,
+		totalCronJobs:        cronJobCount,
+		recentEvents:         recentEvents,
+		unavailableResources: clusterOverviewUnavailable(!nodesForbidden, !podsForbidden, !namespacesDenied),
 	})
 	return snapshot, nil
+}
+
+// clusterOverviewUnavailable returns the canonical group/resource keys of the
+// overview's primary sources denied for this build, the payload's
+// UnavailableResources contract.
+func clusterOverviewUnavailable(nodesAllowed, podsAllowed, namespacesAllowed bool) []string {
+	var out []string
+	if !nodesAllowed {
+		out = append(out, permissions.ResourceKey("", "nodes"))
+	}
+	if !podsAllowed {
+		out = append(out, permissions.ResourceKey("", "pods"))
+	}
+	if !namespacesAllowed {
+		out = append(out, permissions.ResourceKey("", "namespaces"))
+	}
+	return out
 }
 
 // Build assembles the cluster overview payload from cached resources and metrics.
@@ -925,11 +967,12 @@ func podMetricKey(namespace, name string) string {
 }
 
 type clusterOverviewExtras struct {
-	totalDeployments  int
-	totalStatefulSets int
-	totalDaemonSets   int
-	totalCronJobs     int
-	recentEvents      []RecentEvent
+	totalDeployments     int
+	totalStatefulSets    int
+	totalDaemonSets      int
+	totalCronJobs        int
+	recentEvents         []RecentEvent
+	unavailableResources []string
 }
 
 func applyClusterOverviewExtras(snapshot *refresh.Snapshot, extras clusterOverviewExtras) {
@@ -945,6 +988,7 @@ func applyClusterOverviewExtras(snapshot *refresh.Snapshot, extras clusterOvervi
 	payload.Overview.TotalDaemonSets = extras.totalDaemonSets
 	payload.Overview.TotalCronJobs = extras.totalCronJobs
 	payload.Overview.RecentEvents = extras.recentEvents
+	payload.Overview.UnavailableResources = extras.unavailableResources
 	snapshot.Payload = payload
 }
 
@@ -956,6 +1000,20 @@ func (b *ClusterOverviewBuilder) buildFromListers(ctx context.Context, scope str
 	if err := b.waitForInformerSync(ctx); err != nil {
 		return nil, err
 	}
+
+	// Per-source runtime permission gates (issue #244): a denied primary source
+	// is dropped from the build and marked in the payload instead of failing
+	// the whole domain. The serve path injects the per-resource decisions into
+	// ctx (service.go ensurePermissions); absent decisions default to allowed.
+	// A permission-skipped ingest store (identity has list but not watch — the
+	// runtime list SSAR passes while the reflector never launches) counts as
+	// unavailable too, so its permanently empty store is not read as an empty
+	// cluster.
+	nodesAllowed := runtimeResourceAllowed(ctx, clusterOverviewDomainName, "", "nodes") &&
+		!(b.ingest != nil && b.ingest.PermissionSkippedFor(NodeGVR))
+	podsAllowed := runtimeResourceAllowed(ctx, clusterOverviewDomainName, "", "pods") &&
+		!(b.ingest != nil && b.ingest.PermissionSkippedFor(PodGVR))
+	namespacesAllowed := runtimeResourceAllowed(ctx, clusterOverviewDomainName, "", "namespaces")
 
 	type listResult[T any] struct {
 		items []*T
@@ -970,6 +1028,9 @@ func (b *ClusterOverviewBuilder) buildFromListers(ctx context.Context, scope str
 
 	tasks := []func(context.Context) error{
 		func(context.Context) error {
+			if b.namespaceLister == nil || !namespacesAllowed {
+				return nil
+			}
 			list, err := b.namespaceLister.List(labels.Everything())
 			namespaceRes.items = list
 			namespaceRes.err = err
@@ -1018,24 +1079,30 @@ func (b *ClusterOverviewBuilder) buildFromListers(ctx context.Context, scope str
 	// Nodes are cut to the ingest path: the per-node overview facts come from the projected
 	// node store, gated on the store having synced (the ingest equivalent of the prior node
 	// informer HasSynced gate, so an unsynced store contributes no nodes rather than a partial
-	// count). Pods likewise come from the ingest store: the projected PodAggregate rows plus
-	// the store's latest RV as the pod version watermark.
+	// count; a permission-skipped store settles empty). Pods likewise come from the ingest
+	// store: the projected PodAggregate rows plus the store's latest RV as the pod version
+	// watermark. A runtime-denied source is dropped even when its store still holds rows.
 	var nodeFacts []nodeOverviewFact
-	if b.ingest != nil && b.ingest.HasSyncedFor(NodeGVR) {
+	if nodesAllowed && b.ingest != nil && b.ingest.HasSyncedFor(NodeGVR) {
 		nodeFacts = nodeOverviewFactsFromIngest(b.ingest)
 	}
-	podAggregates := podAggregatesFromIngest(b.ingest)
-	podVersion := podIngestVersion(b.ingest)
+	var podAggregates []streamrows.PodAggregate
+	var podVersion uint64
+	if podsAllowed {
+		podAggregates = podAggregatesFromIngest(b.ingest)
+		podVersion = podIngestVersion(b.ingest)
+	}
 	snapshot, err := buildClusterOverviewSnapshot(ctx, scope, nodeFacts, podAggregates, podVersion, namespaceRes.items, b.metrics, b.serverVersion, b.serverHost)
 	if err != nil {
 		return nil, err
 	}
 	applyClusterOverviewExtras(snapshot, clusterOverviewExtras{
-		totalDeployments:  deploymentCount,
-		totalStatefulSets: statefulSetCount,
-		totalDaemonSets:   daemonSetCount,
-		totalCronJobs:     cronJobCount,
-		recentEvents:      recentEvents,
+		totalDeployments:     deploymentCount,
+		totalStatefulSets:    statefulSetCount,
+		totalDaemonSets:      daemonSetCount,
+		totalCronJobs:        cronJobCount,
+		recentEvents:         recentEvents,
+		unavailableResources: clusterOverviewUnavailable(nodesAllowed, podsAllowed, namespacesAllowed),
 	})
 	return snapshot, nil
 }

--- a/backend/refresh/snapshot/cluster_overview_test.go
+++ b/backend/refresh/snapshot/cluster_overview_test.go
@@ -20,6 +20,7 @@ import (
 	cgotesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/luxury-yacht/app/backend/refresh/domainpermissions"
 	"github.com/luxury-yacht/app/backend/refresh/metrics"
 	"github.com/luxury-yacht/app/backend/testsupport"
 )
@@ -639,6 +640,150 @@ func TestClusterOverviewListBuilderIncludesOptionalCountsAndRecentEvents(t *test
 	require.Equal(t, "pod-uid-1", event.InvolvedObject.Ref.UID)
 }
 
+// An identity without node access (issue #244) still gets an overview: the
+// informer path drops the node contribution and records the denied source so
+// the frontend can mark the affected cards instead of rendering zeros.
+func TestClusterOverviewBuilderMarksRuntimeDeniedNodes(t *testing.T) {
+	now := time.Now()
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-a", ResourceVersion: "5"},
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1000m"),
+				corev1.ResourceMemory: resource.MustParse("4Gi"),
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-a", Namespace: "default", ResourceVersion: "9"},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default", ResourceVersion: "2"}}
+
+	builder := &ClusterOverviewBuilder{
+		ingest:          newFakePodAggregateSource(nil, pod).withNodes(ClusterMeta{}, "", node),
+		namespaceLister: testsupport.NewNamespaceLister(t, namespace),
+		metrics:         fakeClusterMetrics{},
+		cachedVersion:   "v1.28.1",
+		versionFetched:  now,
+	}
+
+	ctx := domainpermissions.WithAllowedResources(context.Background(), clusterOverviewDomainName, domainpermissions.AllowedResources{
+		"core/nodes":      false,
+		"core/pods":       true,
+		"core/namespaces": true,
+	})
+	snapshot, err := builder.Build(ctx, "")
+	require.NoError(t, err)
+
+	payload, ok := snapshot.Payload.(ClusterOverviewSnapshot)
+	require.True(t, ok)
+	require.Zero(t, payload.Overview.TotalNodes, "denied nodes must not be counted")
+	require.Equal(t, "0", payload.Overview.CPUAllocatable, "allocatable derives from nodes")
+	require.Equal(t, 1, payload.Overview.TotalPods)
+	require.Equal(t, 1, payload.Overview.TotalNamespaces)
+	require.Equal(t, []string{"core/nodes"}, payload.Overview.UnavailableResources)
+}
+
+// Runtime-denied pods and namespaces degrade the same way on the informer path.
+func TestClusterOverviewBuilderMarksRuntimeDeniedPodsAndNamespaces(t *testing.T) {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a", ResourceVersion: "5"}}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-a", Namespace: "default", ResourceVersion: "9"},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default", ResourceVersion: "2"}}
+
+	builder := &ClusterOverviewBuilder{
+		ingest:          newFakePodAggregateSource(nil, pod).withNodes(ClusterMeta{}, "", node),
+		namespaceLister: testsupport.NewNamespaceLister(t, namespace),
+		metrics:         fakeClusterMetrics{},
+	}
+
+	ctx := domainpermissions.WithAllowedResources(context.Background(), clusterOverviewDomainName, domainpermissions.AllowedResources{
+		"core/nodes":      true,
+		"core/pods":       false,
+		"core/namespaces": false,
+	})
+	snapshot, err := builder.Build(ctx, "")
+	require.NoError(t, err)
+
+	payload, ok := snapshot.Payload.(ClusterOverviewSnapshot)
+	require.True(t, ok)
+	require.Equal(t, 1, payload.Overview.TotalNodes)
+	require.Zero(t, payload.Overview.TotalPods)
+	require.Zero(t, payload.Overview.TotalNamespaces)
+	require.ElementsMatch(t, []string{"core/pods", "core/namespaces"}, payload.Overview.UnavailableResources)
+}
+
+// A kind whose ingest reflector was permission-skipped must be marked
+// unavailable even when the runtime list SSAR passes (an identity with list
+// but not watch): its store is settled but permanently empty for this
+// identity, and silent zeros would misread as an empty cluster.
+func TestClusterOverviewBuilderMarksPermissionSkippedIngestKinds(t *testing.T) {
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default", ResourceVersion: "2"}}
+
+	builder := &ClusterOverviewBuilder{
+		ingest: newFakePodAggregateSource(nil).
+			withPermissionSkipped(NodeGVR).
+			withPermissionSkipped(PodGVR),
+		namespaceLister: testsupport.NewNamespaceLister(t, namespace),
+		metrics:         fakeClusterMetrics{},
+	}
+
+	ctx := domainpermissions.WithAllowedResources(context.Background(), clusterOverviewDomainName, domainpermissions.AllowedResources{
+		"core/nodes":      true,
+		"core/pods":       true,
+		"core/namespaces": true,
+	})
+	snapshot, err := builder.Build(ctx, "")
+	require.NoError(t, err)
+
+	payload, ok := snapshot.Payload.(ClusterOverviewSnapshot)
+	require.True(t, ok)
+	require.Zero(t, payload.Overview.TotalNodes)
+	require.Zero(t, payload.Overview.TotalPods)
+	require.Equal(t, 1, payload.Overview.TotalNamespaces)
+	require.ElementsMatch(t, []string{"core/nodes", "core/pods"}, payload.Overview.UnavailableResources)
+}
+
+// The list fallback tolerates a forbidden nodes LIST (issue #244): a
+// namespaces- or pods-only identity gets a partial overview with the denied
+// source marked, instead of the whole domain failing.
+func TestClusterOverviewListBuilderToleratesForbiddenNodesAndMarksUnavailable(t *testing.T) {
+	client := kubefake.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-a", Namespace: "default"},
+			Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+		},
+	)
+	client.PrependReactor("list", "nodes", func(cgotesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(
+			schema.GroupResource{Group: "", Resource: "nodes"},
+			"nodes",
+			errors.New("forbidden"),
+		)
+	})
+
+	builder := &ClusterOverviewListBuilder{
+		client:     client,
+		metrics:    fakeClusterMetrics{},
+		versionFn:  func(context.Context) string { return "v1.30.0" },
+		serverHost: "https://cluster.example.com",
+	}
+
+	snapshot, err := builder.Build(context.Background(), "cluster-a|")
+	require.NoError(t, err)
+
+	payload, ok := snapshot.Payload.(ClusterOverviewSnapshot)
+	require.True(t, ok)
+	require.Zero(t, payload.Overview.TotalNodes)
+	require.Equal(t, 1, payload.Overview.TotalPods)
+	require.Equal(t, 1, payload.Overview.TotalNamespaces)
+	require.Equal(t, []string{"core/nodes"}, payload.Overview.UnavailableResources)
+}
+
 func TestClusterOverviewListBuilderKeepsRequiredFallbackPartialWhenPodsAndNamespacesForbidden(t *testing.T) {
 	client := kubefake.NewSimpleClientset(
 		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}},
@@ -676,6 +821,7 @@ func TestClusterOverviewListBuilderKeepsRequiredFallbackPartialWhenPodsAndNamesp
 	require.Equal(t, 1, payload.Overview.TotalNodes)
 	require.Zero(t, payload.Overview.TotalPods)
 	require.Zero(t, payload.Overview.TotalNamespaces)
+	require.ElementsMatch(t, []string{"core/pods", "core/namespaces"}, payload.Overview.UnavailableResources)
 }
 
 func TestClusterOverviewListBuilderIgnoresForbiddenOptionalResources(t *testing.T) {

--- a/backend/refresh/snapshot/pod_aggregate_source_testhelper_test.go
+++ b/backend/refresh/snapshot/pod_aggregate_source_testhelper_test.go
@@ -30,6 +30,10 @@ type fakePodAggregateSource struct {
 	nodeBundles []ingest.Bundle
 	nodeSynced  bool
 	nodeRV      string
+	// permissionSkipped marks GVRs whose reflector the ingest permission filter
+	// skipped at Start (identity cannot list+watch), so a test can drive the
+	// cluster-overview permission-unavailable marking.
+	permissionSkipped map[schema.GroupVersionResource]bool
 }
 
 func (s fakePodAggregateSource) AggregateRows(gvr schema.GroupVersionResource) []interface{} {
@@ -93,6 +97,22 @@ func (s fakePodAggregateSource) HasSyncedFor(gvr schema.GroupVersionResource) bo
 
 func (s fakePodAggregateSource) withPodSynced(synced bool) fakePodAggregateSource {
 	s.podSynced = &synced
+	return s
+}
+
+// PermissionSkippedFor mirrors the ingest manager's permission-skip visibility (default
+// false), so a test can drive the cluster-overview permission-unavailable marking.
+func (s fakePodAggregateSource) PermissionSkippedFor(gvr schema.GroupVersionResource) bool {
+	return s.permissionSkipped[gvr]
+}
+
+// withPermissionSkipped returns a copy of the source reporting gvr's reflector as
+// permission-skipped at Start.
+func (s fakePodAggregateSource) withPermissionSkipped(gvr schema.GroupVersionResource) fakePodAggregateSource {
+	if s.permissionSkipped == nil {
+		s.permissionSkipped = map[schema.GroupVersionResource]bool{}
+	}
+	s.permissionSkipped[gvr] = true
 	return s
 }
 

--- a/backend/refresh/system/permission_gate.go
+++ b/backend/refresh/system/permission_gate.go
@@ -53,6 +53,10 @@ type listWatchDomainConfig struct {
 	checks           []listWatchCheck
 	registerInformer func() error
 	fallbackChecks   []listCheck
+	// fallbackAllowAny lets the list fallback register when ANY fallback check
+	// passes (each resource qualifies on its own), instead of requiring all of
+	// them. Used by ModeAny domains whose builder degrades per resource.
+	fallbackAllowAny bool
 	registerFallback func() error
 	fallbackLog      string
 	deniedReason     string
@@ -225,15 +229,7 @@ func (g *permissionGate) registerListWatchDomain(cfg listWatchDomainConfig) erro
 
 	if cfg.registerFallback != nil && len(cfg.fallbackChecks) > 0 {
 		fallbackResults := g.runListChecks(cfg.fallbackChecks)
-		fallbackErrs := g.listErrors(fallbackResults)
-		fallbackWatchErr := false
-		for _, fallbackCheck := range cfg.fallbackChecks {
-			if err := g.listWatchErrFor(results, fallbackCheck.group, fallbackCheck.resource); err != nil {
-				fallbackWatchErr = true
-				break
-			}
-		}
-		if len(fallbackErrs) == 0 && !fallbackWatchErr && g.allListAllowed(fallbackResults) {
+		if g.fallbackEligible(cfg, results, fallbackResults) {
 			if cfg.fallbackLog != "" {
 				klog.V(2).Info(cfg.fallbackLog)
 			}
@@ -243,4 +239,36 @@ func (g *permissionGate) registerListWatchDomain(cfg listWatchDomainConfig) erro
 
 	g.logSkip(cfg.name, cfg.logGroup, cfg.logResource)
 	return snapshot.RegisterPermissionDeniedDomain(g.registry, cfg.name, cfg.deniedReason)
+}
+
+// fallbackEligible decides whether a domain's list fallback may register.
+// Default (all-of): every fallback resource must be list-allowed with no SSAR
+// errors on the fallback checks or on the same resources' main list+watch
+// checks. fallbackAllowAny (ModeAny domains whose builder degrades per
+// resource): one resource qualifies on its own — its list SSAR succeeded and
+// allowed, and its own main check (when present) did not error — regardless of
+// the other resources' denials or errors.
+func (g *permissionGate) fallbackEligible(cfg listWatchDomainConfig, results []listWatchCheckResult, fallbackResults []listCheckResult) bool {
+	if cfg.fallbackAllowAny {
+		for _, result := range fallbackResults {
+			if result.err != nil || !result.allowed {
+				continue
+			}
+			if g.listWatchErrFor(results, result.check.group, result.check.resource) != nil {
+				continue
+			}
+			return true
+		}
+		return false
+	}
+
+	if len(g.listErrors(fallbackResults)) != 0 {
+		return false
+	}
+	for _, fallbackCheck := range cfg.fallbackChecks {
+		if err := g.listWatchErrFor(results, fallbackCheck.group, fallbackCheck.resource); err != nil {
+			return false
+		}
+	}
+	return g.allListAllowed(fallbackResults)
 }

--- a/backend/refresh/system/permission_gate_test.go
+++ b/backend/refresh/system/permission_gate_test.go
@@ -1,0 +1,179 @@
+package system
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubernetesfake "k8s.io/client-go/kubernetes/fake"
+	cgotesting "k8s.io/client-go/testing"
+
+	"github.com/luxury-yacht/app/backend/refresh/domain"
+	"github.com/luxury-yacht/app/backend/refresh/informer"
+	"github.com/luxury-yacht/app/backend/refresh/permissions"
+)
+
+// permissionGateFixture wires a gate against a fake clientset whose SSAR
+// responses are controlled per "resource/verb" key: entries in errOn fail the
+// review, entries in allow grant it, everything else is denied.
+func permissionGateFixture(t *testing.T, allow map[string]bool, errOn map[string]bool) (*permissionGate, *domain.Registry) {
+	t.Helper()
+
+	client := kubernetesfake.NewClientset()
+	client.PrependReactor("create", "selfsubjectaccessreviews", func(action cgotesting.Action) (bool, runtime.Object, error) {
+		create, ok := action.(cgotesting.CreateAction)
+		require.True(t, ok)
+		review, ok := create.GetObject().(*authorizationv1.SelfSubjectAccessReview)
+		require.True(t, ok)
+		attrs := review.Spec.ResourceAttributes
+		require.NotNil(t, attrs)
+		key := attrs.Resource + "/" + attrs.Verb
+		if errOn[key] {
+			return true, nil, errors.New("ssar unavailable")
+		}
+		review = review.DeepCopy()
+		review.Status.Allowed = allow[key]
+		return true, review, nil
+	})
+
+	checker := permissions.NewChecker(client, "test-cluster", time.Minute)
+	factory := informer.New(client, nil, 0, checker)
+	registry := domain.New()
+	gate := newPermissionGate(registry, factory,
+		func(domain, resource string, errs ...error) {},
+		func(domain, group, resource string) {})
+	return gate, registry
+}
+
+// A ModeAny domain's list fallback must register when ANY fallback resource is
+// list-allowed, so an identity with only one readable primary resource still
+// gets a (partial) snapshot instead of a permission-denied placeholder.
+func TestRegisterListWatchDomainFallbackAllowAnyRegistersOnSingleAllowedResource(t *testing.T) {
+	gate, registry := permissionGateFixture(t,
+		map[string]bool{"pods/list": true},
+		nil,
+	)
+
+	informerRegistered := false
+	fallbackRegistered := false
+	err := gate.registerListWatchDomain(listWatchDomainConfig{
+		name:   "test-overview",
+		checks: []listWatchCheck{{group: "", resource: "namespaces"}},
+		registerInformer: func() error {
+			informerRegistered = true
+			return nil
+		},
+		fallbackChecks: []listCheck{
+			{group: "", resource: "nodes"},
+			{group: "", resource: "pods"},
+			{group: "", resource: "namespaces"},
+		},
+		fallbackAllowAny: true,
+		registerFallback: func() error {
+			fallbackRegistered = true
+			return nil
+		},
+		deniedReason: "test denied",
+	})
+
+	require.NoError(t, err)
+	require.False(t, informerRegistered)
+	require.True(t, fallbackRegistered, "one allowed fallback resource must be enough with fallbackAllowAny")
+	require.False(t, registry.IsPermissionDenied("test-overview"))
+}
+
+// An SSAR error on one fallback resource must not disqualify the others under
+// fallbackAllowAny: each resource qualifies (or not) on its own checks.
+func TestRegisterListWatchDomainFallbackAllowAnyToleratesOtherResourceErrors(t *testing.T) {
+	gate, registry := permissionGateFixture(t,
+		map[string]bool{"pods/list": true},
+		map[string]bool{"nodes/list": true, "nodes/watch": true},
+	)
+
+	fallbackRegistered := false
+	err := gate.registerListWatchDomain(listWatchDomainConfig{
+		name:   "test-overview",
+		checks: []listWatchCheck{{group: "", resource: "namespaces"}},
+		registerInformer: func() error {
+			return nil
+		},
+		fallbackChecks: []listCheck{
+			{group: "", resource: "nodes"},
+			{group: "", resource: "pods"},
+		},
+		fallbackAllowAny: true,
+		registerFallback: func() error {
+			fallbackRegistered = true
+			return nil
+		},
+		deniedReason: "test denied",
+	})
+
+	require.NoError(t, err)
+	require.True(t, fallbackRegistered, "pods qualifies on its own despite the nodes SSAR error")
+	require.False(t, registry.IsPermissionDenied("test-overview"))
+}
+
+// With no fallback resource allowed the domain still lands on the
+// permission-denied placeholder.
+func TestRegisterListWatchDomainFallbackAllowAnyDeniesWhenNothingAllowed(t *testing.T) {
+	gate, registry := permissionGateFixture(t, nil, nil)
+
+	fallbackRegistered := false
+	err := gate.registerListWatchDomain(listWatchDomainConfig{
+		name:   "test-overview",
+		checks: []listWatchCheck{{group: "", resource: "namespaces"}},
+		registerInformer: func() error {
+			return nil
+		},
+		fallbackChecks: []listCheck{
+			{group: "", resource: "nodes"},
+			{group: "", resource: "pods"},
+			{group: "", resource: "namespaces"},
+		},
+		fallbackAllowAny: true,
+		registerFallback: func() error {
+			fallbackRegistered = true
+			return nil
+		},
+		deniedReason: "test denied",
+	})
+
+	require.NoError(t, err)
+	require.False(t, fallbackRegistered)
+	require.True(t, registry.IsPermissionDenied("test-overview"))
+}
+
+// The default (all-of) fallback semantics are unchanged: a partially allowed
+// fallback set stays denied without fallbackAllowAny.
+func TestRegisterListWatchDomainFallbackDefaultStillRequiresAllResources(t *testing.T) {
+	gate, registry := permissionGateFixture(t,
+		map[string]bool{"pods/list": true},
+		nil,
+	)
+
+	fallbackRegistered := false
+	err := gate.registerListWatchDomain(listWatchDomainConfig{
+		name:   "test-nodes",
+		checks: []listWatchCheck{{group: "", resource: "nodes"}, {group: "", resource: "pods"}},
+		registerInformer: func() error {
+			return nil
+		},
+		fallbackChecks: []listCheck{
+			{group: "", resource: "nodes"},
+			{group: "", resource: "pods"},
+		},
+		registerFallback: func() error {
+			fallbackRegistered = true
+			return nil
+		},
+		deniedReason: "test denied",
+	})
+
+	require.NoError(t, err)
+	require.False(t, fallbackRegistered)
+	require.True(t, registry.IsPermissionDenied("test-nodes"))
+}

--- a/backend/refresh/system/registrations.go
+++ b/backend/refresh/system/registrations.go
@@ -283,14 +283,20 @@ func domainRegistrations(deps registrationDeps) []domainRegistration {
 			deniedReason: "core/namespaces",
 		}),
 
+		// Cluster overview degrades per resource (issue #244): the informer path
+		// needs only the namespaces informer — nodes, pods, and the workload
+		// counts come from ingest stores that are permission-skipped when the
+		// identity cannot read them, and the builder marks those sources
+		// unavailable in the payload. Identities without namespaces watch fall
+		// back to the polling list builder when ANY primary resource is
+		// listable, so a nodes-only or pods-only identity still gets a partial
+		// overview instead of a permission-denied placeholder.
 		listWatchRegistration(listWatchDomainConfig{
 			name:          "cluster-overview",
-			issueResource: "core/nodes,pods,namespaces",
+			issueResource: "core/namespaces",
 			logGroup:      "",
 			logResource:   "nodes/namespaces",
 			checks: []listWatchCheck{
-				{group: "", resource: "nodes"},
-				{group: "", resource: "pods"},
 				{group: "", resource: "namespaces"},
 			},
 			registerInformer: func() error {
@@ -305,7 +311,10 @@ func domainRegistrations(deps registrationDeps) []domainRegistration {
 			},
 			fallbackChecks: []listCheck{
 				{group: "", resource: "nodes"},
+				{group: "", resource: "pods"},
+				{group: "", resource: "namespaces"},
 			},
+			fallbackAllowAny: true,
 			registerFallback: func() error {
 				return snapshot.RegisterClusterOverviewDomainList(
 					deps.registry,
@@ -315,7 +324,7 @@ func domainRegistrations(deps registrationDeps) []domainRegistration {
 				)
 			},
 			fallbackLog:  "Registering cluster overview domain using list fallback due to missing informer permissions",
-			deniedReason: "cluster overview requires nodes",
+			deniedReason: "cluster overview requires nodes, pods, or namespaces",
 		}),
 
 		withSkipUnless(directRegistration("catalog", func() error {

--- a/backend/refresh/system/registrations_test.go
+++ b/backend/refresh/system/registrations_test.go
@@ -357,21 +357,28 @@ func TestSnapshotAndAggregateDomainRegistrationContracts(t *testing.T) {
 		"no fallback: denial must serve the permission-denied domain, not a degraded list")
 	require.Equal(t, "core/namespaces", namespaces.listWatch.deniedReason)
 
+	// Cluster overview degrades per resource (issue #244): the informer path is
+	// gated only on namespaces (the one informer the builder still owns — nodes,
+	// pods, and workload counts come from permission-skip-safe ingest stores),
+	// and the list fallback registers when ANY primary resource is listable, so
+	// an identity without node access still gets a partial overview.
 	overview := byDomain["cluster-overview"]
 	require.Nil(t, overview.direct)
 	require.Nil(t, overview.list)
 	require.NotNil(t, overview.listWatch, "cluster-overview must keep listWatch registration with list fallback")
 	require.Equal(t, []listWatchCheck{
-		{group: "", resource: "nodes"},
-		{group: "", resource: "pods"},
 		{group: "", resource: "namespaces"},
 	}, overview.listWatch.checks)
 	require.Equal(t, []listCheck{
 		{group: "", resource: "nodes"},
+		{group: "", resource: "pods"},
+		{group: "", resource: "namespaces"},
 	}, overview.listWatch.fallbackChecks)
+	require.True(t, overview.listWatch.fallbackAllowAny,
+		"any listable primary resource must be enough for the list fallback")
 	require.NotNil(t, overview.listWatch.registerInformer)
 	require.NotNil(t, overview.listWatch.registerFallback)
-	require.Equal(t, "cluster overview requires nodes", overview.listWatch.deniedReason)
+	require.Equal(t, "cluster overview requires nodes, pods, or namespaces", overview.listWatch.deniedReason)
 }
 
 func TestResourceStreamDomainsAreRegisteredRefreshDomains(t *testing.T) {

--- a/docs/release/pending.md
+++ b/docs/release/pending.md
@@ -5,5 +5,6 @@
 ### Changed
 
 - Clusters where the user lacks permission to list namespaces now fail fast. The sidebar shows "You do not have permission to list namespaces."
+- The Cluster Overview no longer requires node permissions ([#244](https://github.com/luxury-yacht/app/issues/244)). Identities without node access (such as the standard `view` role) now see pods, namespaces, workloads, and events instead of the page failing with "permission denied". Each affected card explains its own gap in place: the Nodes card notes the missing node permission, and Resource Utilization indicates when cluster capacity or pod requests/limits are unavailable.
 
 ### Fixed

--- a/docs/release/pending.md
+++ b/docs/release/pending.md
@@ -6,5 +6,6 @@
 
 - Clusters where the user lacks permission to list namespaces now fail fast. The sidebar shows "You do not have permission to list namespaces."
 - The Cluster Overview no longer requires node permissions ([#244](https://github.com/luxury-yacht/app/issues/244)). Identities without node access (such as the standard `view` role) now see pods, namespaces, workloads, and events instead of the page failing with "permission denied". Each affected card explains its own gap in place: the Nodes card notes the missing node permission, and Resource Utilization indicates when cluster capacity or pod requests/limits are unavailable.
+- Resource bars now render the portion of usage that exceeds the declared limits as a striped overlay, so the limit position stays visible even when the bar is fully red.
 
 ### Fixed

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,7 +1,6 @@
 - Need a restricted-permissions pass to make the app behave better when the user is missing important permissions.
   - Allow the user to manually add namespaces if they don't have list namespaces permissions
   - Fail fast instead of attempting loads (ex: Nodes shows loading spinner that will never work)
-  - What can we do with Cluster Overview when permissions are limited?
 
 - Build a plugin architecture
   - AI

--- a/frontend/src/core/refresh/types.ts
+++ b/frontend/src/core/refresh/types.ts
@@ -300,6 +300,11 @@ export interface ClusterOverviewPayload {
   notReadyNodes: number;
   cordonedNodes: number;
   recentEvents: RecentEventEntry[];
+  // Canonical group/resource keys (core/nodes, core/pods, core/namespaces) the
+  // current identity cannot list; the affected cards render as
+  // permission-gated instead of zero-valued. Absent when all sources are
+  // readable.
+  unavailableResources?: string[];
 }
 
 export interface RecentEventEntry {

--- a/frontend/src/modules/cluster/components/ClusterOverview.css
+++ b/frontend/src/modules/cluster/components/ClusterOverview.css
@@ -223,9 +223,11 @@
   margin-bottom: 0;
 }
 
-/* Compact metrics-state indicator: small muted text with a status dot,
-   truncating long API errors (the title tooltip carries the full text). */
-.overview-section-header .metrics-warning-banner {
+/* Compact header indicators (metrics state, permission gaps): small muted
+   text with a status dot, truncating long messages (the title tooltip
+   carries the full text). */
+.overview-section-header .metrics-warning-banner,
+.overview-section-header .overview-permission-chip {
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
@@ -623,6 +625,22 @@
   justify-content: center;
   align-items: center;
   padding: 2rem 0;
+}
+
+/* Permission-gated data (issue #244): each affected card explains its own
+   gap in place — a compact header chip for derived values (capacity,
+   requests/limits) and a note where counts would render. */
+.overview-permission-note {
+  color: var(--color-text-secondary);
+  font-size: 0.85rem;
+  padding: 0.5rem 0;
+}
+
+/* The chip's ⓘ tooltip trigger: keep the icon vertically centered in the
+   chip's flex row instead of sitting on the text baseline. */
+.overview-permission-chip .tooltip-trigger {
+  display: inline-flex;
+  align-items: center;
 }
 
 .cluster-overview-error {

--- a/frontend/src/modules/cluster/components/ClusterOverview.css
+++ b/frontend/src/modules/cluster/components/ClusterOverview.css
@@ -645,9 +645,12 @@
 
 /* Collapsible legend explaining the utilization bar vocabulary. Swatches
    reuse the ResourceBar theme variables so they can never drift from the
-   bar's actual rendering. */
+   bar's actual rendering. Divider matches the card's other sub-sections
+   (.pod-status / .node-health) so the row reads as part of the card. */
 .utilization-legend {
-  margin-top: 0.75rem;
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--color-border);
 }
 
 .utilization-legend__toggle {

--- a/frontend/src/modules/cluster/components/ClusterOverview.css
+++ b/frontend/src/modules/cluster/components/ClusterOverview.css
@@ -708,8 +708,22 @@
   overflow: hidden;
 }
 
-.utilization-legend__swatch--usage {
+.utilization-legend__swatch--usage-normal {
   background: var(--resourcebar-usage-normal);
+}
+
+.utilization-legend__swatch--usage-high {
+  background: var(--resourcebar-usage-warning);
+}
+
+.utilization-legend__swatch--usage-critical {
+  background: var(--resourcebar-usage-critical);
+}
+
+.utilization-legend__footnote {
+  color: var(--color-text-tertiary);
+  font-size: var(--font-size-small);
+  margin-bottom: 0.5rem;
 }
 
 .utilization-legend__swatch--reserved {

--- a/frontend/src/modules/cluster/components/ClusterOverview.css
+++ b/frontend/src/modules/cluster/components/ClusterOverview.css
@@ -653,6 +653,8 @@
   border-top: 1px solid var(--color-border);
 }
 
+/* Toggle text matches the CPU/MEMORY group headers (.metric-header h3 in
+   ResourceBar.css) so the legend reads as a peer section. */
 .utilization-legend__toggle {
   display: inline-flex;
   align-items: center;
@@ -660,7 +662,10 @@
   background: none;
   border: none;
   padding: 0;
-  font-size: var(--font-size-small);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
   color: var(--color-text-secondary);
   cursor: pointer;
   user-select: none;

--- a/frontend/src/modules/cluster/components/ClusterOverview.css
+++ b/frontend/src/modules/cluster/components/ClusterOverview.css
@@ -643,6 +643,100 @@
   align-items: center;
 }
 
+/* Collapsible legend explaining the utilization bar vocabulary. Swatches
+   reuse the ResourceBar theme variables so they can never drift from the
+   bar's actual rendering. */
+.utilization-legend {
+  margin-top: 0.75rem;
+}
+
+.utilization-legend__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: var(--font-size-small);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  user-select: none;
+}
+
+.utilization-legend__toggle:hover {
+  color: var(--color-text);
+}
+
+.utilization-legend__chevron {
+  width: 0;
+  height: 0;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  border-left: 5px solid currentColor;
+  transition: transform 0.15s ease;
+}
+
+.utilization-legend__chevron--open {
+  transform: rotate(90deg);
+}
+
+.utilization-legend__items {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-top: 0.6rem;
+  font-size: var(--font-size-small);
+  color: var(--color-text-secondary);
+}
+
+.utilization-legend__item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.utilization-legend__swatch {
+  flex: none;
+  width: 26px;
+  height: 10px;
+  border-radius: 2px;
+  background-color: var(--resourcebar-track-bg);
+  position: relative;
+  overflow: hidden;
+}
+
+.utilization-legend__swatch--usage {
+  background: var(--resourcebar-usage-normal);
+}
+
+.utilization-legend__swatch--reserved {
+  background: var(--resourcebar-reserved-fill);
+}
+
+.utilization-legend__swatch--overlimit {
+  background: var(--resourcebar-overlimit-fill), var(--resourcebar-usage-critical);
+}
+
+.utilization-legend__swatch--request-marker::after,
+.utilization-legend__swatch--limit-marker::after {
+  content: "";
+  position: absolute;
+  left: 12px;
+  top: 0;
+  width: 2px;
+  height: 100%;
+}
+
+.utilization-legend__swatch--request-marker::after {
+  background-color: var(--resourcebar-marker-request);
+  box-shadow: var(--resourcebar-marker-request-shadow);
+}
+
+.utilization-legend__swatch--limit-marker::after {
+  background-color: var(--resourcebar-marker-limit);
+  box-shadow: var(--resourcebar-marker-limit-shadow);
+}
+
 .cluster-overview-error {
   display: flex;
   flex-direction: column;

--- a/frontend/src/modules/cluster/components/ClusterOverview.test.tsx
+++ b/frontend/src/modules/cluster/components/ClusterOverview.test.tsx
@@ -1033,6 +1033,13 @@ describe('ClusterOverview', () => {
     // one visual with no other in-UI explanation.
     expect(legend?.textContent).toContain('limits');
     expect(legend?.textContent).toContain('Total requests marker');
+    // One row per usage color, stating the capacity percentage where the
+    // color changes (single-sourced with the bar's threshold logic).
+    expect(legend?.querySelectorAll('.utilization-legend__swatch--usage-normal')).toHaveLength(1);
+    expect(legend?.querySelectorAll('.utilization-legend__swatch--usage-high')).toHaveLength(1);
+    expect(legend?.querySelectorAll('.utilization-legend__swatch--usage-critical')).toHaveLength(1);
+    expect(legend?.textContent).toContain('81');
+    expect(legend?.textContent).toContain('95');
 
     act(() => {
       toggle?.click();

--- a/frontend/src/modules/cluster/components/ClusterOverview.test.tsx
+++ b/frontend/src/modules/cluster/components/ClusterOverview.test.tsx
@@ -884,6 +884,150 @@ describe('ClusterOverview', () => {
     );
   });
 
+  it('renders the nodes card as permission-gated when nodes are unavailable', async () => {
+    const { container, rerender, cleanup } = renderClusterOverview();
+    cleanupRoot = cleanup;
+
+    domainStateRef.current = createDomainState('ready', {
+      overview: {
+        ...EMPTY_OVERVIEW_DATA,
+        clusterType: 'Unmanaged',
+        cpuUsage: '400m',
+        cpuLimits: '1000m',
+        memoryUsage: '2Gi',
+        memoryLimits: '8Gi',
+        totalPods: 42,
+        totalNamespaces: 6,
+        unavailableResources: ['core/nodes'],
+      },
+    });
+
+    rerender();
+    await flushEffects();
+
+    // The Nodes card explains the gap instead of rendering misleading zeros.
+    // "list, watch" are the actual RBAC verbs the app needs for node data —
+    // never "view", which is a ClusterRole name, not a permission.
+    expect(
+      container.querySelector('[data-testid="cluster-nodes-permission-note"]')?.textContent
+    ).toContain('Node permissions: list, watch');
+    expect(container.querySelector('[data-testid="cluster-nodes-total"]')).toBeNull();
+    expect(statValueFor(container, 'total')).toBe('');
+
+    // Capacity-derived values have no denominator without nodes: the usage
+    // summaries drop the "of <allocatable>" part and the percentages dash out
+    // (calculateResourceMetrics would silently rescale them against limits).
+    expect(container.textContent).toContain('400m used');
+    expect(container.textContent).toContain('2.0Gi used');
+    expect(
+      Array.from(container.querySelectorAll('.metric-header__percent')).map(
+        (element) => element.textContent
+      )
+    ).toEqual(['—', '—']);
+
+    // The warning lives in the affected card: the Resource Utilization header
+    // carries a capacity chip (no page-level banner).
+    expect(container.querySelector('[data-testid="overview-permission-banner"]')).toBeNull();
+    const capacityChip = container.querySelector(
+      '[data-testid="utilization-capacity-permission-chip"]'
+    );
+    expect(capacityChip?.textContent).toContain('Capacity unavailable');
+    // The explanation is a visible ⓘ-triggered tooltip, not an invisible
+    // title attribute.
+    expect(capacityChip?.getAttribute('title')).toBeNull();
+    expect(capacityChip?.querySelector('[data-testid="tooltip-content"]')?.textContent).toContain(
+      'Node permissions: list, watch'
+    );
+
+    // Pod and namespace data still render, with no pods/namespaces warnings.
+    expect(statValueFor(container, 'pods')).toBe('42');
+    expect(statValueFor(container, 'namespaces')).toBe('6');
+    expect(
+      container.querySelector('[data-testid="utilization-requests-permission-chip"]')
+    ).toBeNull();
+    expect(container.querySelector('[data-testid="workloads-pods-permission-note"]')).toBeNull();
+    expect(
+      container.querySelector('[data-testid="workloads-namespaces-permission-note"]')
+    ).toBeNull();
+  });
+
+  it('warns inside the affected cards when pods and namespaces are hidden, keeping the nodes card', async () => {
+    const { container, rerender, cleanup } = renderClusterOverview();
+    cleanupRoot = cleanup;
+
+    domainStateRef.current = createDomainState('ready', {
+      overview: {
+        ...EMPTY_OVERVIEW_DATA,
+        clusterType: 'Unmanaged',
+        totalNodes: 2,
+        readyNodes: 2,
+        cpuUsage: '400m',
+        cpuAllocatable: '2000m',
+        unavailableResources: ['core/pods', 'core/namespaces'],
+      },
+    });
+
+    rerender();
+    await flushEffects();
+
+    // Requests/limits derive from pods: the Resource Utilization header says so.
+    const requestsChip = container.querySelector(
+      '[data-testid="utilization-requests-permission-chip"]'
+    );
+    expect(requestsChip?.textContent).toContain('Requests and limits unavailable');
+    expect(requestsChip?.getAttribute('title')).toBeNull();
+    expect(requestsChip?.querySelector('[data-testid="tooltip-content"]')?.textContent).toContain(
+      'Pod permissions: list, watch'
+    );
+    expect(requestsChip?.querySelector('[data-testid="tooltip-content"]')?.textContent).toContain(
+      'Only current usage is shown'
+    );
+
+    // The Workloads card explains its hidden counts in place.
+    expect(
+      container.querySelector('[data-testid="workloads-pods-permission-note"]')?.textContent
+    ).toContain('Pod permissions: list, watch');
+    expect(
+      container.querySelector('[data-testid="workloads-namespaces-permission-note"]')?.textContent
+    ).toContain('Namespace permission: list');
+
+    // Nodes remain fully rendered, including capacity-derived percentages.
+    expect(container.querySelector('[data-testid="cluster-nodes-permission-note"]')).toBeNull();
+    expect(
+      container.querySelector('[data-testid="utilization-capacity-permission-chip"]')
+    ).toBeNull();
+    expect(statValueFor(container, 'total')).toBe('2');
+    expect(container.textContent).toContain('400m of 2 cores');
+    expect(container.textContent).toContain('20.0%');
+  });
+
+  it('shows no permission warnings when every source is readable', async () => {
+    const { container, rerender, cleanup } = renderClusterOverview();
+    cleanupRoot = cleanup;
+
+    domainStateRef.current = createDomainState('ready', {
+      overview: {
+        ...EMPTY_OVERVIEW_DATA,
+        totalNodes: 1,
+      },
+    });
+
+    rerender();
+    await flushEffects();
+
+    expect(container.querySelector('[data-testid="cluster-nodes-permission-note"]')).toBeNull();
+    expect(
+      container.querySelector('[data-testid="utilization-capacity-permission-chip"]')
+    ).toBeNull();
+    expect(
+      container.querySelector('[data-testid="utilization-requests-permission-chip"]')
+    ).toBeNull();
+    expect(container.querySelector('[data-testid="workloads-pods-permission-note"]')).toBeNull();
+    expect(
+      container.querySelector('[data-testid="workloads-namespaces-permission-note"]')
+    ).toBeNull();
+  });
+
   it('keeps cluster-overview disabled before data services start and suppresses the transient unavailable error', async () => {
     mockLifecycleState = 'connecting';
     domainStateRef.current = createDomainState('error', {

--- a/frontend/src/modules/cluster/components/ClusterOverview.test.tsx
+++ b/frontend/src/modules/cluster/components/ClusterOverview.test.tsx
@@ -1001,6 +1001,46 @@ describe('ClusterOverview', () => {
     expect(container.textContent).toContain('20.0%');
   });
 
+  it('explains the utilization bar vocabulary in a collapsible legend', async () => {
+    const { container, rerender, cleanup } = renderClusterOverview();
+    cleanupRoot = cleanup;
+
+    domainStateRef.current = createDomainState('ready', {
+      overview: {
+        ...EMPTY_OVERVIEW_DATA,
+        totalNodes: 1,
+      },
+    });
+
+    rerender();
+    await flushEffects();
+
+    const toggle = container.querySelector<HTMLButtonElement>(
+      '[data-testid="utilization-legend-toggle"]'
+    );
+    expect(toggle).not.toBeNull();
+    expect(toggle?.getAttribute('aria-expanded')).toBe('false');
+    expect(container.querySelector('[data-testid="utilization-legend"]')).toBeNull();
+
+    act(() => {
+      toggle?.click();
+    });
+
+    expect(toggle?.getAttribute('aria-expanded')).toBe('true');
+    const legend = container.querySelector('[data-testid="utilization-legend"]');
+    expect(legend).not.toBeNull();
+    // The striping introduced for over-limit usage must be named — it is the
+    // one visual with no other in-UI explanation.
+    expect(legend?.textContent).toContain('limits');
+    expect(legend?.textContent).toContain('Total requests marker');
+
+    act(() => {
+      toggle?.click();
+    });
+    expect(toggle?.getAttribute('aria-expanded')).toBe('false');
+    expect(container.querySelector('[data-testid="utilization-legend"]')).toBeNull();
+  });
+
   it('shows no permission warnings when every source is readable', async () => {
     const { container, rerender, cleanup } = renderClusterOverview();
     cleanupRoot = cleanup;

--- a/frontend/src/modules/cluster/components/ClusterOverview.tsx
+++ b/frontend/src/modules/cluster/components/ClusterOverview.tsx
@@ -176,6 +176,9 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
     ]
   );
   const [overviewData, setOverviewData] = useState<ClusterOverviewPayload>(EMPTY_OVERVIEW);
+  // Disclosure for the Resource Utilization legend; collapsed by default so
+  // the card stays compact.
+  const [legendExpanded, setLegendExpanded] = useState(false);
   const [isHydrated, setIsHydrated] = useState(false);
   const [hydratedClusterId, setHydratedClusterId] = useState<string | null>(null);
   const [isSwitching, setIsSwitching] = useState(false);
@@ -1005,6 +1008,48 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
             memoryWorkloadUsageTotal,
             memoryWorkloadUsageItems
           )}
+
+          <div className="utilization-legend">
+            <button
+              type="button"
+              className="utilization-legend__toggle"
+              aria-expanded={legendExpanded}
+              onClick={() => setLegendExpanded((expanded) => !expanded)}
+              data-testid="utilization-legend-toggle"
+            >
+              <span
+                className={`utilization-legend__chevron${
+                  legendExpanded ? ' utilization-legend__chevron--open' : ''
+                }`}
+                aria-hidden="true"
+              />
+              Legend
+            </button>
+            {legendExpanded && (
+              <div className="utilization-legend__items" data-testid="utilization-legend">
+                <div className="utilization-legend__item">
+                  <span className="utilization-legend__swatch utilization-legend__swatch--usage" />
+                  <span>Current usage (color changes 🟢 🟡 🔴 as pressure rises)</span>
+                </div>
+                <div className="utilization-legend__item">
+                  <span className="utilization-legend__swatch utilization-legend__swatch--reserved" />
+                  <span>Requested but currently unused</span>
+                </div>
+                <div className="utilization-legend__item">
+                  <span className="utilization-legend__swatch utilization-legend__swatch--overlimit" />
+                  <span>Usage above total limits</span>
+                </div>
+                <div className="utilization-legend__item">
+                  <span className="utilization-legend__swatch utilization-legend__swatch--request-marker" />
+                  <span>Total requests marker</span>
+                </div>
+                <div className="utilization-legend__item">
+                  <span className="utilization-legend__swatch utilization-legend__swatch--limit-marker" />
+                  <span>Total limits marker</span>
+                </div>
+              </div>
+            )}
+          </div>
         </div>
 
         <div className="overview-section nodes-summary">

--- a/frontend/src/modules/cluster/components/ClusterOverview.tsx
+++ b/frontend/src/modules/cluster/components/ClusterOverview.tsx
@@ -503,7 +503,9 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
         aria-disabled={!clickable}
         data-testid={`cluster-pod-status-${item.key}`}
       >
-        <span className="pod-status-card__count">{showSkeleton ? DASH : item.value}</span>
+        <span className="pod-status-card__count">
+          {showSkeleton || podsUnavailable ? DASH : item.value}
+        </span>
         <span className="pod-status-card__label" title={item.label}>
           {item.label}
         </span>
@@ -587,6 +589,13 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
     (sum, item) => sum + item.value,
     0
   );
+  // Sources the backend could not read for this identity (issue #244): each
+  // affected card explains its own gap in place instead of rendering zeros.
+  const unavailableResources = displayOverview.unavailableResources ?? [];
+  const nodesUnavailable = unavailableResources.includes('core/nodes');
+  const podsUnavailable = unavailableResources.includes('core/pods');
+  const namespacesUnavailable = unavailableResources.includes('core/namespaces');
+
   const overviewResourceMetrics = clusterOverviewResourceMetrics(displayOverview, metricsInfo);
   const memoryResourceMetrics = calculateResourceMetrics(
     overviewResourceMetrics.memory ?? {},
@@ -605,12 +614,20 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
   };
   const formatResourceTooltipValue = (value: number, type: 'cpu' | 'memory') =>
     type === 'cpu' ? formatCpuTooltipValue(value) : formatMemoryValue(value);
-  const cpuUsageSummary = `${formatCpuValue(cpuResourceMetrics.usage)} of ${formatCpuValue(
-    cpuResourceMetrics.allocatable
-  )} cores`;
-  const memoryUsageSummary = `${formatMemoryValue(memoryResourceMetrics.usage)} of ${formatMemoryValue(
-    memoryResourceMetrics.allocatable
-  )}`;
+  // Without node access the cluster's allocatable capacity is unknown, so the
+  // summaries drop the "of <allocatable>" denominator and the utilization
+  // percentages dash out below (calculateResourceMetrics would otherwise
+  // silently rescale them against limits).
+  const cpuUsageSummary = nodesUnavailable
+    ? `${formatCpuValue(cpuResourceMetrics.usage)} used`
+    : `${formatCpuValue(cpuResourceMetrics.usage)} of ${formatCpuValue(
+        cpuResourceMetrics.allocatable
+      )} cores`;
+  const memoryUsageSummary = nodesUnavailable
+    ? `${formatMemoryValue(memoryResourceMetrics.usage)} used`
+    : `${formatMemoryValue(memoryResourceMetrics.usage)} of ${formatMemoryValue(
+        memoryResourceMetrics.allocatable
+      )}`;
 
   const renderResourceUtilizationTooltip = (
     type: 'cpu' | 'memory',
@@ -643,7 +660,7 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
             {formatResourceTooltipValue(row.value, type)}
           </span>
           <span className={percentClassName('resource-utilization-tooltip__percent', row.percent)}>
-            {formatPercent(row.percent)}
+            {nodesUnavailable ? DASH : formatPercent(row.percent)}
           </span>
         </React.Fragment>
       ))}
@@ -860,14 +877,43 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
 
       <div className="overview-grid">
         <div className="overview-section resource-usage">
-          {/* Header row: the metrics indicator sits in the card's upper right
-              so its presence never shifts the utilization content below. */}
+          {/* Header row: the metrics/permission indicators sit in the card's
+              upper right so their presence never shifts the utilization
+              content below. */}
           <div className="overview-section-header">
             <h2>Resource Utilization</h2>
             {metricsBanner && !errorMessage && (
               <div className="metrics-warning-banner" title={metricsBanner.tooltip}>
                 <span className="metrics-warning-banner__dot" />
                 <span className="metrics-warning-banner__text">{metricsBanner.message}</span>
+              </div>
+            )}
+            {nodesUnavailable && !showSkeleton && (
+              <div
+                className="overview-permission-chip"
+                data-testid="utilization-capacity-permission-chip"
+              >
+                <span className="metrics-warning-banner__dot" />
+                <span className="metrics-warning-banner__text">Capacity unavailable</span>
+                <Tooltip
+                  content="Cluster capacity data is unavailable. Your account is missing required Node permissions: list, watch."
+                  maxWidth={320}
+                />
+              </div>
+            )}
+            {podsUnavailable && !showSkeleton && (
+              <div
+                className="overview-permission-chip"
+                data-testid="utilization-requests-permission-chip"
+              >
+                <span className="metrics-warning-banner__dot" />
+                <span className="metrics-warning-banner__text">
+                  Requests and limits unavailable (no pod access)
+                </span>
+                <Tooltip
+                  content="Pod requests and limits data is unavailable. Only current usage is shown. Your account is missing required Pod permissions: list, watch."
+                  maxWidth={320}
+                />
               </div>
             )}
           </div>
@@ -886,7 +932,9 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
                   cpuResourceMetrics.usagePercent
                 )}
               >
-                {showSkeleton ? DASH : formatPercent(cpuResourceMetrics.usagePercent)}
+                {showSkeleton || nodesUnavailable
+                  ? DASH
+                  : formatPercent(cpuResourceMetrics.usagePercent)}
               </div>
             </div>
             <Tooltip
@@ -927,7 +975,9 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
                   memoryResourceMetrics.usagePercent
                 )}
               >
-                {showSkeleton ? DASH : formatPercent(memoryResourceMetrics.usagePercent)}
+                {showSkeleton || nodesUnavailable
+                  ? DASH
+                  : formatPercent(memoryResourceMetrics.usagePercent)}
               </div>
             </div>
             <Tooltip
@@ -959,102 +1009,126 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
 
         <div className="overview-section nodes-summary">
           <h2>Nodes</h2>
-          <div className="metric-stats">
-            <div className="metric-stat" data-testid="cluster-nodes-total">
-              <span className="metric-stat__count">
-                {showSkeleton ? DASH : displayOverview.totalNodes}
-              </span>
-              <span className="metric-stat__label">total</span>
+          {nodesUnavailable && !showSkeleton ? (
+            <div className="overview-permission-note" data-testid="cluster-nodes-permission-note">
+              Node details are hidden. Your account has insufficient access (requires Node
+              permissions: list, watch).
             </div>
-            {displayOverview.clusterType === 'EKS' && (
-              <>
-                <div className="metric-stat" data-testid="cluster-nodes-ec2">
+          ) : (
+            <>
+              <div className="metric-stats">
+                <div className="metric-stat" data-testid="cluster-nodes-total">
                   <span className="metric-stat__count">
-                    {showSkeleton ? DASH : displayOverview.ec2Nodes}
+                    {showSkeleton ? DASH : displayOverview.totalNodes}
                   </span>
-                  <span className="metric-stat__label">ec2</span>
+                  <span className="metric-stat__label">total</span>
                 </div>
-                <div className="metric-stat" data-testid="cluster-nodes-fargate">
-                  <span className="metric-stat__count">
-                    {showSkeleton ? DASH : displayOverview.fargateNodes}
-                  </span>
-                  <span className="metric-stat__label">fargate</span>
-                </div>
-              </>
-            )}
-            {displayOverview.clusterType === 'AKS' && (
-              <>
-                <div className="metric-stat" data-testid="cluster-nodes-vm">
-                  <span className="metric-stat__count">
-                    {showSkeleton ? DASH : displayOverview.vmNodes}
-                  </span>
-                  <span className="metric-stat__label">vm</span>
-                </div>
-                <div className="metric-stat" data-testid="cluster-nodes-virtual">
-                  <span className="metric-stat__count">
-                    {showSkeleton ? DASH : displayOverview.virtualNodes}
-                  </span>
-                  <span className="metric-stat__label">virtual</span>
-                </div>
-              </>
-            )}
-          </div>
+                {displayOverview.clusterType === 'EKS' && (
+                  <>
+                    <div className="metric-stat" data-testid="cluster-nodes-ec2">
+                      <span className="metric-stat__count">
+                        {showSkeleton ? DASH : displayOverview.ec2Nodes}
+                      </span>
+                      <span className="metric-stat__label">ec2</span>
+                    </div>
+                    <div className="metric-stat" data-testid="cluster-nodes-fargate">
+                      <span className="metric-stat__count">
+                        {showSkeleton ? DASH : displayOverview.fargateNodes}
+                      </span>
+                      <span className="metric-stat__label">fargate</span>
+                    </div>
+                  </>
+                )}
+                {displayOverview.clusterType === 'AKS' && (
+                  <>
+                    <div className="metric-stat" data-testid="cluster-nodes-vm">
+                      <span className="metric-stat__count">
+                        {showSkeleton ? DASH : displayOverview.vmNodes}
+                      </span>
+                      <span className="metric-stat__label">vm</span>
+                    </div>
+                    <div className="metric-stat" data-testid="cluster-nodes-virtual">
+                      <span className="metric-stat__count">
+                        {showSkeleton ? DASH : displayOverview.virtualNodes}
+                      </span>
+                      <span className="metric-stat__label">virtual</span>
+                    </div>
+                  </>
+                )}
+              </div>
 
-          <div className="node-health">
-            <div className="metric-header">
-              <h3>Node Health</h3>
-              <div className="metric-legend__total">
-                <span className="metric-legend__total-value">
-                  {showSkeleton ? DASH : displayOverview.totalNodes}
-                </span>
-                <span className="metric-legend__total-label"> total</span>
+              <div className="node-health">
+                <div className="metric-header">
+                  <h3>Node Health</h3>
+                  <div className="metric-legend__total">
+                    <span className="metric-legend__total-value">
+                      {showSkeleton ? DASH : displayOverview.totalNodes}
+                    </span>
+                    <span className="metric-legend__total-label"> total</span>
+                  </div>
+                </div>
+                <div className="stacked-bar" role="presentation" aria-hidden="true">
+                  {!showSkeleton &&
+                    nodeHealthPhaseItems.map((item) => {
+                      const width = nodeHealthPct(item.value);
+                      if (width <= 0) {
+                        return null;
+                      }
+                      return (
+                        <div
+                          key={item.key}
+                          className={`stacked-bar__segment stacked-bar__segment--${item.variant}`}
+                          style={{ width: `${width}%` }}
+                        />
+                      );
+                    })}
+                </div>
+                <div className="metric-legend">
+                  <div className="metric-legend__items">
+                    {nodeHealthPhaseItems.map((item) => renderNodeHealthLegendItem(item))}
+                  </div>
+                  <div className="metric-legend__items metric-legend__items--restarted">
+                    {renderNodeHealthLegendItem(nodeCordonedItem)}
+                  </div>
+                </div>
               </div>
-            </div>
-            <div className="stacked-bar" role="presentation" aria-hidden="true">
-              {!showSkeleton &&
-                nodeHealthPhaseItems.map((item) => {
-                  const width = nodeHealthPct(item.value);
-                  if (width <= 0) {
-                    return null;
-                  }
-                  return (
-                    <div
-                      key={item.key}
-                      className={`stacked-bar__segment stacked-bar__segment--${item.variant}`}
-                      style={{ width: `${width}%` }}
-                    />
-                  );
-                })}
-            </div>
-            <div className="metric-legend">
-              <div className="metric-legend__items">
-                {nodeHealthPhaseItems.map((item) => renderNodeHealthLegendItem(item))}
-              </div>
-              <div className="metric-legend__items metric-legend__items--restarted">
-                {renderNodeHealthLegendItem(nodeCordonedItem)}
-              </div>
-            </div>
-          </div>
+            </>
+          )}
         </div>
 
         <div className="overview-section workloads-summary">
           <h2>Workloads</h2>
+          {podsUnavailable && !showSkeleton && (
+            <div className="overview-permission-note" data-testid="workloads-pods-permission-note">
+              Pod and container counts are hidden. Your account has insufficient access (requires
+              Pod permissions: list, watch).
+            </div>
+          )}
+          {namespacesUnavailable && !showSkeleton && (
+            <div
+              className="overview-permission-note"
+              data-testid="workloads-namespaces-permission-note"
+            >
+              The namespace count is hidden. Your account has insufficient access (requires
+              Namespace permission: list).
+            </div>
+          )}
           <div className="metric-stats">
             <div className="metric-stat" data-testid="cluster-workloads-namespaces">
               <span className="metric-stat__count">
-                {showSkeleton ? DASH : displayOverview.totalNamespaces}
+                {showSkeleton || namespacesUnavailable ? DASH : displayOverview.totalNamespaces}
               </span>
               <span className="metric-stat__label">namespaces</span>
             </div>
             <div className="metric-stat" data-testid="cluster-workloads-pods">
               <span className="metric-stat__count">
-                {showSkeleton ? DASH : displayOverview.totalPods}
+                {showSkeleton || podsUnavailable ? DASH : displayOverview.totalPods}
               </span>
               <span className="metric-stat__label">pods</span>
             </div>
             <div className="metric-stat" data-testid="cluster-workloads-containers">
               <span className="metric-stat__count">
-                {showSkeleton ? DASH : displayOverview.totalContainers}
+                {showSkeleton || podsUnavailable ? DASH : displayOverview.totalContainers}
               </span>
               <span className="metric-stat__label">containers</span>
             </div>
@@ -1114,7 +1188,7 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
                   <h3>Pod Status</h3>
                   <div className="metric-legend__total">
                     <span className="metric-legend__total-value">
-                      {showSkeleton ? DASH : displayOverview.totalPods}
+                      {showSkeleton || podsUnavailable ? DASH : displayOverview.totalPods}
                     </span>
                     <span className="metric-legend__total-label"> total</span>
                   </div>

--- a/frontend/src/modules/cluster/components/ClusterOverview.tsx
+++ b/frontend/src/modules/cluster/components/ClusterOverview.tsx
@@ -7,6 +7,10 @@
  */
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import ResourceBar from '@shared/components/ResourceBar';
+import {
+  USAGE_CRITICAL_THRESHOLD_PERCENT,
+  USAGE_HIGH_THRESHOLD_PERCENT,
+} from '@shared/components/resourceBarThresholds';
 import Tooltip from '@shared/components/Tooltip';
 import {
   calculateResourceMetrics,
@@ -1028,8 +1032,22 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
             {legendExpanded && (
               <div className="utilization-legend__items" data-testid="utilization-legend">
                 <div className="utilization-legend__item">
-                  <span className="utilization-legend__swatch utilization-legend__swatch--usage" />
-                  <span>Current usage (color changes 🟢 🟡 🔴 as pressure rises)</span>
+                  <span className="utilization-legend__swatch utilization-legend__swatch--usage-normal" />
+                  <span>Usage below {USAGE_HIGH_THRESHOLD_PERCENT}% of capacity</span>
+                </div>
+                <div className="utilization-legend__item">
+                  <span className="utilization-legend__swatch utilization-legend__swatch--usage-high" />
+                  <span>
+                    Usage at {USAGE_HIGH_THRESHOLD_PERCENT}–{USAGE_CRITICAL_THRESHOLD_PERCENT}% of
+                    capacity
+                  </span>
+                </div>
+                <div className="utilization-legend__item">
+                  <span className="utilization-legend__swatch utilization-legend__swatch--usage-critical" />
+                  <span>Usage above {USAGE_CRITICAL_THRESHOLD_PERCENT}% of capacity</span>
+                </div>
+                <div className="utilization-legend__footnote">
+                  Usage thresholds derived from requests/limits when node capacity is unavailable.
                 </div>
                 <div className="utilization-legend__item">
                   <span className="utilization-legend__swatch utilization-legend__swatch--reserved" />

--- a/frontend/src/modules/cluster/components/ClusterOverview.tsx
+++ b/frontend/src/modules/cluster/components/ClusterOverview.tsx
@@ -1033,21 +1033,20 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
               <div className="utilization-legend__items" data-testid="utilization-legend">
                 <div className="utilization-legend__item">
                   <span className="utilization-legend__swatch utilization-legend__swatch--usage-normal" />
-                  <span>Usage below {USAGE_HIGH_THRESHOLD_PERCENT}% of capacity</span>
+                  <span>Usage below {USAGE_HIGH_THRESHOLD_PERCENT}%</span>
                 </div>
                 <div className="utilization-legend__item">
                   <span className="utilization-legend__swatch utilization-legend__swatch--usage-high" />
                   <span>
-                    Usage at {USAGE_HIGH_THRESHOLD_PERCENT}–{USAGE_CRITICAL_THRESHOLD_PERCENT}% of
-                    capacity
+                    Usage at {USAGE_HIGH_THRESHOLD_PERCENT}–{USAGE_CRITICAL_THRESHOLD_PERCENT}%
                   </span>
                 </div>
                 <div className="utilization-legend__item">
                   <span className="utilization-legend__swatch utilization-legend__swatch--usage-critical" />
-                  <span>Usage above {USAGE_CRITICAL_THRESHOLD_PERCENT}% of capacity</span>
+                  <span>Usage above {USAGE_CRITICAL_THRESHOLD_PERCENT}%</span>
                 </div>
                 <div className="utilization-legend__footnote">
-                  Usage thresholds derived from requests/limits when node capacity is unavailable.
+                  Thresholds derived from requests/limits when node capacity is unavailable.
                 </div>
                 <div className="utilization-legend__item">
                   <span className="utilization-legend__swatch utilization-legend__swatch--reserved" />

--- a/frontend/src/shared/components/ResourceBar.css
+++ b/frontend/src/shared/components/ResourceBar.css
@@ -203,6 +203,15 @@
   z-index: 1;
 }
 
+/* Usage past the limit position: striped overlay on the usage fill whose
+   left edge marks the limit. */
+.resource-bar-overlimit {
+  position: absolute;
+  height: 100%;
+  background: var(--resourcebar-overlimit-fill);
+  z-index: 2;
+}
+
 /* Resource markers */
 .resource-bar-marker {
   position: absolute;

--- a/frontend/src/shared/components/ResourceBar.test.tsx
+++ b/frontend/src/shared/components/ResourceBar.test.tsx
@@ -137,6 +137,30 @@ describe('ResourceBar', () => {
     cleanup();
   });
 
+  it('keeps request and limit markers visible when aggregate requests exceed limits (no allocatable)', async () => {
+    // Cluster-overview aggregates without node access: across pods, total
+    // requests can exceed total limits (per-container request<=limit only
+    // holds when both are set). Scaling to limits pinned every marker at the
+    // clamped right edge (left: 100%) — invisible on the track border.
+    const { container, cleanup } = await renderBar({
+      type: 'memory',
+      usage: '671.0 Mi',
+      request: '590.0 Mi',
+      limit: '490.0 Mi',
+      showTooltip: false,
+    });
+
+    const markers = container.querySelectorAll<HTMLElement>('.resource-bar-marker');
+    expect(markers).toHaveLength(2);
+    for (const marker of Array.from(markers)) {
+      const position = parseFloat(marker.style.left);
+      expect(position).toBeGreaterThan(0);
+      expect(position).toBeLessThan(100);
+    }
+
+    cleanup();
+  });
+
   it('toggles tooltip in compact mode and handles overcommit tracking', async () => {
     vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
       cb(0);

--- a/frontend/src/shared/components/ResourceBar.test.tsx
+++ b/frontend/src/shared/components/ResourceBar.test.tsx
@@ -137,6 +137,43 @@ describe('ResourceBar', () => {
     cleanup();
   });
 
+  it('stripes the over-limit region when usage exceeds the limit', async () => {
+    // The limit line marker is the same red as the critical fill, so when
+    // usage covers it the striped overlay's left edge marks the limit
+    // instead. 671Mi usage vs 490Mi limit on a 708Mi scale (request*1.2).
+    const { container, cleanup } = await renderBar({
+      type: 'memory',
+      usage: '671.0 Mi',
+      request: '590.0 Mi',
+      limit: '490.0 Mi',
+      showTooltip: false,
+    });
+
+    const overlimit = container.querySelector<HTMLElement>('.resource-bar-overlimit');
+    expect(overlimit).not.toBeNull();
+    const left = parseFloat(overlimit?.style.left ?? '');
+    const width = parseFloat(overlimit?.style.width ?? '');
+    expect(left).toBeCloseTo((490 / 708) * 100, 0);
+    expect(left + width).toBeCloseTo((671 / 708) * 100, 0);
+    expect(overlimit?.getAttribute('title')).toBeNull();
+
+    cleanup();
+  });
+
+  it('renders no over-limit stripes while usage stays within the limit', async () => {
+    const { container, cleanup } = await renderBar({
+      type: 'memory',
+      usage: '100.0 Mi',
+      request: '200.0 Mi',
+      limit: '400.0 Mi',
+      showTooltip: false,
+    });
+
+    expect(container.querySelector('.resource-bar-overlimit')).toBeNull();
+
+    cleanup();
+  });
+
   it('keeps request and limit markers visible when aggregate requests exceed limits (no allocatable)', async () => {
     // Cluster-overview aggregates without node access: across pods, total
     // requests can exceed total limits (per-container request<=limit only

--- a/frontend/src/shared/components/ResourceBar.tsx
+++ b/frontend/src/shared/components/ResourceBar.tsx
@@ -391,6 +391,20 @@ const ResourceBar: React.FC<ResourceBarProps> = ({
               />
             )}
 
+            {/* Over-limit area (usage past the limit position): striped
+                overlay whose left edge marks the limit — a line marker on a
+                critical fill is the same red and disappears. */}
+            {currentLimit > 0 && currentUsage > currentLimit && usagePercent > limitPercent && (
+              <div
+                className="resource-bar-overlimit"
+                style={{
+                  left: `${limitPercent}%`,
+                  width: `${usagePercent - limitPercent}%`,
+                }}
+                title={`Limit: ${tooltipLimit}`}
+              />
+            )}
+
             {/* Request marker - show in default variant, and in compact for pods (no allocatable) */}
             {currentRequest > 0 &&
               (variant === 'default' || (variant === 'compact' && !currentAllocatable)) && (

--- a/frontend/src/shared/components/ResourceBar.tsx
+++ b/frontend/src/shared/components/ResourceBar.tsx
@@ -401,7 +401,6 @@ const ResourceBar: React.FC<ResourceBarProps> = ({
                   left: `${limitPercent}%`,
                   width: `${usagePercent - limitPercent}%`,
                 }}
-                title={`Limit: ${tooltipLimit}`}
               />
             )}
 

--- a/frontend/src/shared/components/ResourceBar.tsx
+++ b/frontend/src/shared/components/ResourceBar.tsx
@@ -7,6 +7,10 @@
 
 import React, { useState, useRef, useEffect } from 'react';
 import Tooltip from './Tooltip';
+import {
+  USAGE_CRITICAL_THRESHOLD_PERCENT,
+  USAGE_HIGH_THRESHOLD_PERCENT,
+} from './resourceBarThresholds';
 import './ResourceBar.css';
 
 interface ResourceBarProps {
@@ -164,9 +168,9 @@ const ResourceBar: React.FC<ResourceBarProps> = ({
 
   if (currentAllocatable > 0) {
     // For nodes: use usage vs allocatable
-    if (usageVsAllocatable >= 95) {
+    if (usageVsAllocatable >= USAGE_CRITICAL_THRESHOLD_PERCENT) {
       statusClass = 'critical';
-    } else if (usageVsAllocatable >= 81) {
+    } else if (usageVsAllocatable >= USAGE_HIGH_THRESHOLD_PERCENT) {
       statusClass = 'warning';
     } else {
       statusClass = 'normal';

--- a/frontend/src/shared/components/ResourceBar.tsx
+++ b/frontend/src/shared/components/ResourceBar.tsx
@@ -135,6 +135,14 @@ const ResourceBar: React.FC<ResourceBarProps> = ({
   if (currentAllocatable > 0) {
     // Node resources - scale to allocatable capacity
     maxScale = currentAllocatable;
+  } else if (currentLimit > 0 && currentRequest > currentLimit) {
+    // Requests exceed limits: cluster-overview aggregates without node
+    // access (and pods where only some containers declare limits) can sum
+    // requests past the limits total. Scaling to limits would clamp the
+    // request marker — and possibly the usage fill — to the bar's right
+    // edge, hiding them. Widen the scale so usage, request, and limit all
+    // stay visible (same headroom idiom as the no-limit branch below).
+    maxScale = Math.max(currentUsage, currentRequest * 1.2);
   } else if (currentLimit > 0) {
     // Pod resources - scale to limit
     maxScale = currentLimit;

--- a/frontend/src/shared/components/resourceBarThresholds.ts
+++ b/frontend/src/shared/components/resourceBarThresholds.ts
@@ -1,0 +1,13 @@
+/**
+ * frontend/src/shared/components/resourceBarThresholds.ts
+ *
+ * Usage-color thresholds for capacity-scaled resource bars (bars with an
+ * allocatable value): below HIGH is normal, HIGH up to CRITICAL is high
+ * pressure, at or above CRITICAL is critical. A separate module (rather than
+ * ResourceBar exports) so the cluster-overview legend can state the same
+ * numbers without importing the component, which tests mock wholesale.
+ * ResourceBar's no-allocatable branch keys on requests/limits with its own
+ * thresholds and is deliberately not described by these constants.
+ */
+export const USAGE_HIGH_THRESHOLD_PERCENT = 81;
+export const USAGE_CRITICAL_THRESHOLD_PERCENT = 95;

--- a/frontend/styles/appearance-modes/dark.css
+++ b/frontend/styles/appearance-modes/dark.css
@@ -426,6 +426,15 @@
   --resourcebar-marker-request-shadow: 0 0 3px rgba(255, 255, 255, 0.4);
   --resourcebar-marker-limit: #dc2626;
   --resourcebar-marker-limit-shadow: 0 0 3px rgba(220, 38, 38, 0.4);
+  /* Over-limit region (usage past the limit position): dark diagonal stripes
+     over the critical fill; the stripe boundary marks the limit. */
+  --resourcebar-overlimit-fill: repeating-linear-gradient(
+    -45deg,
+    rgba(0, 0, 0, 0.28),
+    rgba(0, 0, 0, 0.28) 4px,
+    rgba(0, 0, 0, 0) 4px,
+    rgba(0, 0, 0, 0) 8px
+  );
   --resourcebar-empty-bg: rgba(255, 255, 255, 0.04);
   --resourcebar-status-stale: var(--color-accent-dark-400);
   --resourcebar-status-error: #f87171;

--- a/frontend/styles/appearance-modes/light.css
+++ b/frontend/styles/appearance-modes/light.css
@@ -418,6 +418,15 @@
   --resourcebar-marker-request-shadow: 0 0 3px rgba(0, 0, 0, 0.3);
   --resourcebar-marker-limit: #dc2626;
   --resourcebar-marker-limit-shadow: 0 0 3px rgba(220, 38, 38, 0.4);
+  /* Over-limit region (usage past the limit position): dark diagonal stripes
+     over the critical fill; the stripe boundary marks the limit. */
+  --resourcebar-overlimit-fill: repeating-linear-gradient(
+    -45deg,
+    rgba(0, 0, 0, 0.22),
+    rgba(0, 0, 0, 0.22) 4px,
+    rgba(0, 0, 0, 0) 4px,
+    rgba(0, 0, 0, 0) 8px
+  );
   --resourcebar-empty-bg: var(--color-base-100);
   --resourcebar-status-stale: #f59e0b;
   --resourcebar-status-error: #ef4444;


### PR DESCRIPTION
Fixes #244

- Cluster Overview previously failed for any identity without cluster-wide node access. The overview now degrades gracefully, renders whatever the identity can read, and explains each gap instead of failing the entire page.
- Added new usage-over-limit striping on resource bars: usage beyond the total declared limits renders as a striped overlay whose boundary marks the limit position. Previously the limit marker (red on red) was invisible.
- Added a collapsible Legend to explain the resource bar's colors and markers.
