### PR TITLE
Restricted namespace handling

### DIFF
--- a/backend/app.go
+++ b/backend/app.go
@@ -115,6 +115,10 @@ type App struct {
 	// issued when a cluster's allowed-namespaces scope changes (tests inject a
 	// recorder). Nil selects the production teardown+rebuild path.
 	requestClusterScopeRebuildFn func(clusterID string)
+	// scopeRebuildQueued tracks clusters with a scope rebuild queued but not
+	// yet started, so rapid successive scope edits coalesce into one rebuild
+	// that reads the latest persisted scope.
+	scopeRebuildQueued sync.Map
 
 	clusterClientsMu sync.Mutex
 	clusterClients   map[string]*clusterClients

--- a/backend/app.go
+++ b/backend/app.go
@@ -111,6 +111,10 @@ type App struct {
 	selectionDiag       selectionDiagnosticsState
 	// settingsMu guards appSettings access in runtime watcher/selection/settings flows.
 	settingsMu sync.Mutex
+	// requestClusterScopeRebuildFn overrides the per-cluster rebuild request
+	// issued when a cluster's allowed-namespaces scope changes (tests inject a
+	// recorder). Nil selects the production teardown+rebuild path.
+	requestClusterScopeRebuildFn func(clusterID string)
 
 	clusterClientsMu sync.Mutex
 	clusterClients   map[string]*clusterClients

--- a/backend/app_cluster_settings.go
+++ b/backend/app_cluster_settings.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"strings"
@@ -95,12 +96,15 @@ func (a *App) allowedNamespacesForCluster(clusterID string) []string {
 	return namespaces
 }
 
-// requestClusterScopeRebuild tears down and rebuilds one cluster's refresh
-// subsystem so a changed namespace scope takes effect — the same pattern the
-// kubeconfig-change watcher uses. The rebuild recreates the permission
-// checker, so the SSAR cache resets with it. A cluster that is not currently
-// connected has nothing to rebuild; its persisted scope applies on the next
-// connect.
+// requestClusterScopeRebuild rebuilds one cluster's refresh subsystem so a
+// changed namespace scope takes effect. It runs through the coordinated
+// selection-mutation + per-cluster operation path (the same routing auth
+// recovery uses), and rapid successive edits coalesce: while a rebuild is
+// QUEUED, further requests are dropped — the queued rebuild reads the latest
+// persisted scope; once it STARTS, the next edit queues a fresh one. The
+// rebuild recreates the permission checker, so the SSAR cache resets with
+// it. A cluster that is not currently connected has nothing to rebuild; its
+// persisted scope applies on the next connect.
 func (a *App) requestClusterScopeRebuild(clusterID string) {
 	if a.requestClusterScopeRebuildFn != nil {
 		a.requestClusterScopeRebuildFn(clusterID)
@@ -109,10 +113,46 @@ func (a *App) requestClusterScopeRebuild(clusterID string) {
 	if a.clusterClientsForID(clusterID) == nil {
 		return
 	}
-	go func() {
-		a.teardownClusterSubsystem(clusterID)
-		a.rebuildClusterSubsystem(clusterID)
-	}()
+	if !a.tryQueueScopeRebuild(clusterID) {
+		return
+	}
+	a.runSelectionMutationAsync(fmt.Sprintf("cluster-scope-rebuild:%s", clusterID), func(_ *selectionMutation) error {
+		return a.runClusterOperation(context.Background(), clusterID, func(opCtx context.Context) error {
+			// From here on this rebuild may already be reading the previous
+			// scope, so a new edit must queue a fresh rebuild.
+			a.markScopeRebuildStarted(clusterID)
+			if err := opCtx.Err(); err != nil {
+				return err
+			}
+			a.performClusterScopeRebuild(clusterID)
+			return opCtx.Err()
+		})
+	})
+}
+
+// tryQueueScopeRebuild reports whether the caller should enqueue a scope
+// rebuild for the cluster: false while one is already queued (the pending
+// rebuild will read the caller's just-persisted scope anyway).
+func (a *App) tryQueueScopeRebuild(clusterID string) bool {
+	_, alreadyQueued := a.scopeRebuildQueued.LoadOrStore(clusterID, struct{}{})
+	return !alreadyQueued
+}
+
+// markScopeRebuildStarted releases the cluster's queued slot at rebuild
+// start, so edits landing mid-rebuild queue a fresh one.
+func (a *App) markScopeRebuildStarted(clusterID string) {
+	a.scopeRebuildQueued.Delete(clusterID)
+}
+
+// performClusterScopeRebuild tears down and rebuilds the cluster's subsystem
+// (the kubeconfig-change pattern), then emits cluster:scope:changed so the
+// frontend restarts the cluster's streams and refetches its domains — without
+// this event the sidebar would keep serving the pre-rebuild snapshot (the
+// namespaces list would never show a newly added scope entry).
+func (a *App) performClusterScopeRebuild(clusterID string) {
+	a.teardownClusterSubsystem(clusterID)
+	a.rebuildClusterSubsystem(clusterID)
+	a.emitEvent("cluster:scope:changed", map[string]any{"clusterId": clusterID})
 }
 
 // normalizeAllowedNamespaces trims entries, drops empties, dedupes while

--- a/backend/app_cluster_settings.go
+++ b/backend/app_cluster_settings.go
@@ -1,0 +1,157 @@
+package backend
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+
+	"github.com/luxury-yacht/app/backend/internal/logsources"
+)
+
+// Per-cluster namespace scope ("accessible namespaces",
+// docs/plans/namespace-scope.md). The scope is persisted in the Clusters
+// section of settings.json keyed by clusterId and, when non-empty, makes all
+// namespaced data paths for that cluster run per-namespace instead of
+// cluster-wide (enforcement lands in later plan phases).
+
+// GetClusterAllowedNamespaces returns the persisted namespace scope for the
+// cluster in the order the user saved it. Empty means no scope.
+func (a *App) GetClusterAllowedNamespaces(clusterID string) ([]string, error) {
+	if clusterID == "" {
+		return nil, fmt.Errorf("clusterID is required")
+	}
+	a.settingsMu.Lock()
+	defer a.settingsMu.Unlock()
+	settings, err := a.loadSettingsFile()
+	if err != nil {
+		return nil, err
+	}
+	return append([]string(nil), settings.Clusters[clusterID].AllowedNamespaces...), nil
+}
+
+// SetClusterAllowedNamespaces validates, normalizes, and persists the
+// namespace scope for one cluster, then requests a rebuild of that cluster's
+// refresh subsystem when the scope's namespace SET changed — reordering
+// persists but does not rebuild. It returns the normalized list. An
+// empty/nil list clears the scope. The whole batch is rejected on the first
+// invalid name: nothing is persisted and no rebuild is requested.
+func (a *App) SetClusterAllowedNamespaces(clusterID string, namespaces []string) ([]string, error) {
+	if clusterID == "" {
+		return nil, fmt.Errorf("clusterID is required")
+	}
+	normalized, err := normalizeAllowedNamespaces(namespaces)
+	if err != nil {
+		return nil, err
+	}
+
+	a.settingsMu.Lock()
+	settings, err := a.loadSettingsFile()
+	if err != nil {
+		a.settingsMu.Unlock()
+		return nil, err
+	}
+	previous := settings.Clusters[clusterID].AllowedNamespaces
+	scopeChanged := !equalStringSets(previous, normalized)
+	if !slices.Equal(previous, normalized) {
+		if len(normalized) == 0 {
+			delete(settings.Clusters, clusterID)
+		} else {
+			if settings.Clusters == nil {
+				settings.Clusters = map[string]settingsClusterSection{}
+			}
+			settings.Clusters[clusterID] = settingsClusterSection{
+				AllowedNamespaces: normalized,
+			}
+		}
+		if err := a.saveSettingsFile(settings); err != nil {
+			a.settingsMu.Unlock()
+			return nil, err
+		}
+	}
+	a.settingsMu.Unlock()
+
+	// Persist BEFORE rebuilding so the rebuilt subsystem reads the new scope.
+	if scopeChanged {
+		a.requestClusterScopeRebuild(clusterID)
+	}
+	return normalized, nil
+}
+
+// allowedNamespacesForCluster is the subsystem-construction read of the
+// persisted scope. A settings read failure degrades to cluster-wide (empty)
+// with a warning — the same degradation every settings consumer applies when
+// settings.json is unreadable — rather than failing the whole cluster build.
+func (a *App) allowedNamespacesForCluster(clusterID string) []string {
+	namespaces, err := a.GetClusterAllowedNamespaces(clusterID)
+	if err != nil {
+		a.logger.Warn(
+			fmt.Sprintf("Could not read allowed namespaces for cluster %s (running cluster-wide): %v", clusterID, err),
+			logsources.Settings, clusterID, clusterID,
+		)
+		return nil
+	}
+	return namespaces
+}
+
+// requestClusterScopeRebuild tears down and rebuilds one cluster's refresh
+// subsystem so a changed namespace scope takes effect — the same pattern the
+// kubeconfig-change watcher uses. The rebuild recreates the permission
+// checker, so the SSAR cache resets with it. A cluster that is not currently
+// connected has nothing to rebuild; its persisted scope applies on the next
+// connect.
+func (a *App) requestClusterScopeRebuild(clusterID string) {
+	if a.requestClusterScopeRebuildFn != nil {
+		a.requestClusterScopeRebuildFn(clusterID)
+		return
+	}
+	if a.clusterClientsForID(clusterID) == nil {
+		return
+	}
+	go func() {
+		a.teardownClusterSubsystem(clusterID)
+		a.rebuildClusterSubsystem(clusterID)
+	}()
+}
+
+// normalizeAllowedNamespaces trims entries, drops empties, dedupes while
+// preserving first-seen order, and rejects any name that is not a valid
+// DNS-1123 label (the namespace name grammar).
+func normalizeAllowedNamespaces(namespaces []string) ([]string, error) {
+	normalized := make([]string, 0, len(namespaces))
+	seen := make(map[string]struct{}, len(namespaces))
+	for _, raw := range namespaces {
+		name := strings.TrimSpace(raw)
+		if name == "" {
+			continue
+		}
+		if errs := validation.IsDNS1123Label(name); len(errs) > 0 {
+			return nil, fmt.Errorf("invalid namespace name %q: %s", name, strings.Join(errs, "; "))
+		}
+		if _, dup := seen[name]; dup {
+			continue
+		}
+		seen[name] = struct{}{}
+		normalized = append(normalized, name)
+	}
+	return normalized, nil
+}
+
+// equalStringSets reports whether two already-deduplicated slices contain the
+// same members regardless of order.
+func equalStringSets(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	members := make(map[string]struct{}, len(a))
+	for _, s := range a {
+		members[s] = struct{}{}
+	}
+	for _, s := range b {
+		if _, ok := members[s]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/backend/app_cluster_settings_test.go
+++ b/backend/app_cluster_settings_test.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -153,4 +154,33 @@ func TestAllowedNamespacesForClusterReadsPersistedScope(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []string{"prod", "dev"}, app.allowedNamespacesForCluster("kc:ctx"))
 	require.Empty(t, app.allowedNamespacesForCluster("kc:other"))
+}
+
+func TestScopeRebuildQueueCoalescesUntilStarted(t *testing.T) {
+	app := newTestAppWithDefaults(t)
+
+	require.True(t, app.tryQueueScopeRebuild("kc:ctx"))
+	require.False(t, app.tryQueueScopeRebuild("kc:ctx"),
+		"edits while a rebuild is queued coalesce into it (it reads the latest persisted scope)")
+	require.True(t, app.tryQueueScopeRebuild("kc:other"), "the queue is per cluster")
+
+	app.markScopeRebuildStarted("kc:ctx")
+	require.True(t, app.tryQueueScopeRebuild("kc:ctx"),
+		"an edit after the rebuild started needs a fresh rebuild")
+}
+
+func TestPerformClusterScopeRebuildEmitsScopeChangedEvent(t *testing.T) {
+	app := newTestAppWithDefaults(t)
+	app.Ctx = context.Background()
+	var events []string
+	app.eventEmitter = func(_ context.Context, name string, _ ...interface{}) {
+		events = append(events, name)
+	}
+
+	// No live subsystem/clients: teardown and rebuild are warn-level no-ops,
+	// but the frontend must still hear that the scope epoch changed.
+	app.performClusterScopeRebuild("kc:ctx")
+
+	require.Equal(t, []string{"cluster:scope:changed"}, events,
+		"the frontend restarts streams and refetches on this event")
 }

--- a/backend/app_cluster_settings_test.go
+++ b/backend/app_cluster_settings_test.go
@@ -1,0 +1,156 @@
+package backend
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetClusterAllowedNamespacesEmptyByDefault(t *testing.T) {
+	setTestConfigEnv(t)
+	app := newTestAppWithDefaults(t)
+
+	namespaces, err := app.GetClusterAllowedNamespaces("kc:ctx")
+	require.NoError(t, err)
+	require.Empty(t, namespaces)
+}
+
+func TestSetClusterAllowedNamespacesPersistsPerCluster(t *testing.T) {
+	setTestConfigEnv(t)
+	app := newTestAppWithDefaults(t)
+
+	_, err := app.SetClusterAllowedNamespaces("kc:alpha", []string{"prod", "staging"})
+	require.NoError(t, err)
+	_, err = app.SetClusterAllowedNamespaces("kc:beta", []string{"dev"})
+	require.NoError(t, err)
+
+	alpha, err := app.GetClusterAllowedNamespaces("kc:alpha")
+	require.NoError(t, err)
+	require.Equal(t, []string{"prod", "staging"}, alpha)
+
+	beta, err := app.GetClusterAllowedNamespaces("kc:beta")
+	require.NoError(t, err)
+	require.Equal(t, []string{"dev"}, beta)
+
+	// The section must be on disk, not only in memory: a fresh load sees it.
+	file, err := app.loadSettingsFile()
+	require.NoError(t, err)
+	require.Equal(t, []string{"prod", "staging"}, file.Clusters["kc:alpha"].AllowedNamespaces)
+	require.Equal(t, []string{"dev"}, file.Clusters["kc:beta"].AllowedNamespaces)
+}
+
+func TestSetClusterAllowedNamespacesNormalizes(t *testing.T) {
+	setTestConfigEnv(t)
+	app := newTestAppWithDefaults(t)
+
+	normalized, err := app.SetClusterAllowedNamespaces("kc:ctx", []string{" prod ", "prod", "", "dev"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"prod", "dev"}, normalized)
+
+	stored, err := app.GetClusterAllowedNamespaces("kc:ctx")
+	require.NoError(t, err)
+	require.Equal(t, []string{"prod", "dev"}, stored)
+}
+
+func TestSetClusterAllowedNamespacesRejectsInvalidName(t *testing.T) {
+	setTestConfigEnv(t)
+	app := newTestAppWithDefaults(t)
+
+	_, err := app.SetClusterAllowedNamespaces("kc:ctx", []string{"prod", "Not_Valid!"})
+	require.ErrorContains(t, err, "Not_Valid!")
+
+	// The whole batch is rejected: nothing persisted.
+	stored, getErr := app.GetClusterAllowedNamespaces("kc:ctx")
+	require.NoError(t, getErr)
+	require.Empty(t, stored)
+}
+
+func TestSetClusterAllowedNamespacesRequiresClusterID(t *testing.T) {
+	setTestConfigEnv(t)
+	app := newTestAppWithDefaults(t)
+
+	_, err := app.SetClusterAllowedNamespaces("", []string{"prod"})
+	require.Error(t, err)
+}
+
+func TestSetClusterAllowedNamespacesClearsEntryWhenEmpty(t *testing.T) {
+	setTestConfigEnv(t)
+	app := newTestAppWithDefaults(t)
+
+	_, err := app.SetClusterAllowedNamespaces("kc:ctx", []string{"prod"})
+	require.NoError(t, err)
+	_, err = app.SetClusterAllowedNamespaces("kc:ctx", nil)
+	require.NoError(t, err)
+
+	stored, err := app.GetClusterAllowedNamespaces("kc:ctx")
+	require.NoError(t, err)
+	require.Empty(t, stored)
+
+	file, err := app.loadSettingsFile()
+	require.NoError(t, err)
+	_, exists := file.Clusters["kc:ctx"]
+	require.False(t, exists, "cleared cluster entry must be removed from settings.json")
+}
+
+func TestClusterAllowedNamespacesSurviveSaveAppSettings(t *testing.T) {
+	setTestConfigEnv(t)
+	app := newTestAppWithDefaults(t)
+
+	_, err := app.SetClusterAllowedNamespaces("kc:ctx", []string{"prod"})
+	require.NoError(t, err)
+
+	// A global-preferences save (load-mutate-save) must not drop the
+	// per-cluster section.
+	require.NoError(t, app.loadAppSettings())
+	require.NoError(t, app.saveAppSettings())
+
+	stored, err := app.GetClusterAllowedNamespaces("kc:ctx")
+	require.NoError(t, err)
+	require.Equal(t, []string{"prod"}, stored)
+}
+
+func TestSetClusterAllowedNamespacesRequestsRebuildOnlyOnChange(t *testing.T) {
+	setTestConfigEnv(t)
+	app := newTestAppWithDefaults(t)
+
+	var rebuilt []string
+	app.requestClusterScopeRebuildFn = func(clusterID string) {
+		rebuilt = append(rebuilt, clusterID)
+	}
+
+	_, err := app.SetClusterAllowedNamespaces("kc:ctx", []string{"prod", "dev"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"kc:ctx"}, rebuilt, "first set must rebuild the affected cluster")
+
+	// Same set, same order: no rebuild.
+	_, err = app.SetClusterAllowedNamespaces("kc:ctx", []string{"prod", "dev"})
+	require.NoError(t, err)
+	require.Len(t, rebuilt, 1, "unchanged scope must not rebuild")
+
+	// Same set, different order: scope semantics unchanged, no rebuild.
+	_, err = app.SetClusterAllowedNamespaces("kc:ctx", []string{"dev", "prod"})
+	require.NoError(t, err)
+	require.Len(t, rebuilt, 1, "reordered scope must not rebuild")
+
+	// Removing a namespace is a change.
+	_, err = app.SetClusterAllowedNamespaces("kc:ctx", []string{"dev"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"kc:ctx", "kc:ctx"}, rebuilt)
+
+	// A failed set must not rebuild.
+	_, err = app.SetClusterAllowedNamespaces("kc:ctx", []string{"Bad!"})
+	require.Error(t, err)
+	require.Len(t, rebuilt, 2)
+}
+
+func TestAllowedNamespacesForClusterReadsPersistedScope(t *testing.T) {
+	setTestConfigEnv(t)
+	app := newTestAppWithDefaults(t)
+
+	require.Empty(t, app.allowedNamespacesForCluster("kc:ctx"))
+
+	_, err := app.SetClusterAllowedNamespaces("kc:ctx", []string{"prod", "dev"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"prod", "dev"}, app.allowedNamespacesForCluster("kc:ctx"))
+	require.Empty(t, app.allowedNamespacesForCluster("kc:other"))
+}

--- a/backend/app_object_catalog.go
+++ b/backend/app_object_catalog.go
@@ -194,6 +194,9 @@ func (a *App) startObjectCatalogForTarget(target catalogTarget) error {
 		Now:         time.Now,
 		ClusterID:   target.meta.ID,
 		ClusterName: target.meta.Name,
+		// The cluster's namespace scope (docs/plans/namespace-scope.md):
+		// namespaced collection fans out per configured namespace.
+		AllowedNamespaces: a.allowedNamespacesForCluster(target.meta.ID),
 		// The catalog waits for informer caches INSIDE sync, between the RBAC
 		// preflight and the collect, so discovery + preflight overlap the factory's
 		// initial sync instead of running after it (see Dependencies.WaitForCaches).
@@ -382,6 +385,13 @@ func (a *App) catalogNamespaceGroups() []snapshot.CatalogNamespaceGroup {
 			continue
 		}
 		namespaces := entry.service.Namespaces()
+		// A scoped cluster's namespace list is synthesized from the
+		// configured scope (docs/plans/namespace-scope.md) so Browse agrees
+		// with the sidebar even before anything is catalogued.
+		if scope := a.allowedNamespacesForCluster(entry.meta.ID); len(scope) > 0 {
+			namespaces = append([]string(nil), scope...)
+			sort.Strings(namespaces)
+		}
 		if len(namespaces) == 0 {
 			continue
 		}

--- a/backend/app_object_catalog_test.go
+++ b/backend/app_object_catalog_test.go
@@ -539,3 +539,32 @@ func setCatalogServiceItems(
 	}
 	reflect.NewAt(value.Type(), unsafe.Pointer(value.UnsafeAddr())).Elem().Set(reflect.ValueOf(copyItems))
 }
+
+func TestCatalogNamespaceGroupsServesConfiguredScope(t *testing.T) {
+	// Scoped cluster (docs/plans/namespace-scope.md): Browse's namespace
+	// list is synthesized from the configured scope — it must not depend on
+	// the catalog having discovered objects (a restricted identity may have
+	// nothing catalogued yet), and it must agree with the sidebar.
+	setTestConfigEnv(t)
+	app := NewApp()
+	_, err := app.SetClusterAllowedNamespaces("cluster-a", []string{"prod", "dev"})
+	if err != nil {
+		t.Fatalf("set scope: %v", err)
+	}
+
+	app.objectCatalogEntries = map[string]*objectCatalogEntry{
+		"cluster-a": {
+			service: objectcatalog.NewService(objectcatalog.Dependencies{}, nil),
+			meta:    ClusterMeta{ID: "cluster-a", Name: "Cluster A"},
+		},
+	}
+
+	groups := app.catalogNamespaceGroups()
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 namespace group, got %d", len(groups))
+	}
+	got := groups[0].Namespaces
+	if len(got) != 2 || got[0] != "dev" || got[1] != "prod" {
+		t.Fatalf("expected sorted configured scope [dev prod], got %#v", got)
+	}
+}

--- a/backend/app_refresh_setup.go
+++ b/backend/app_refresh_setup.go
@@ -226,6 +226,7 @@ func (a *App) buildRefreshSubsystemForSelection(
 		ContainerLogsTargetLimiter: a.sharedContainerLogsTargetLimiter(),
 		ClusterID:                  clusterMeta.ID,
 		ClusterName:                clusterMeta.Name,
+		AllowedNamespaces:          a.allowedNamespacesForCluster(clusterMeta.ID),
 	}
 
 	cfg.ObjectCatalogService = func() *objectcatalog.Service {

--- a/backend/app_settings.go
+++ b/backend/app_settings.go
@@ -66,11 +66,22 @@ const (
 
 // settingsFile captures the persisted application settings stored in settings.json.
 type settingsFile struct {
-	SchemaVersion int                 `json:"schemaVersion"`
-	UpdatedAt     time.Time           `json:"updatedAt"`
-	Preferences   settingsPreferences `json:"preferences"`
-	Kubeconfig    settingsKubeconfig  `json:"kubeconfig"`
-	UI            settingsUI          `json:"ui"`
+	SchemaVersion int                               `json:"schemaVersion"`
+	UpdatedAt     time.Time                         `json:"updatedAt"`
+	Preferences   settingsPreferences               `json:"preferences"`
+	Kubeconfig    settingsKubeconfig                `json:"kubeconfig"`
+	UI            settingsUI                        `json:"ui"`
+	Clusters      map[string]settingsClusterSection `json:"clusters,omitempty"`
+}
+
+// settingsClusterSection captures per-cluster persisted settings, keyed by
+// clusterId (kubeconfigName:context — the same identity favorites and cluster
+// tabs use).
+type settingsClusterSection struct {
+	// AllowedNamespaces is the cluster's namespace scope
+	// (docs/plans/namespace-scope.md). Empty means no scope: every namespaced
+	// data path runs cluster-wide.
+	AllowedNamespaces []string `json:"allowedNamespaces,omitempty"`
 }
 
 // settingsPreferences captures user-configurable preferences.

--- a/backend/kind/objectmapnode/collector.go
+++ b/backend/kind/objectmapnode/collector.go
@@ -36,7 +36,10 @@ type Collector struct {
 type GatewayCollector struct {
 	Identity resourcekind.Identity
 	// List returns the kind's objects via a live LIST through the Gateway-API client.
-	List func(ctx context.Context, client gatewayversioned.Interface) ([]metav1.Object, error)
+	// List lists the kind in one namespace ("" = all namespaces; ignored by
+	// cluster-scoped kinds). Under a namespace scope the object map calls it
+	// once per configured namespace (docs/plans/namespace-scope.md).
+	List func(ctx context.Context, client gatewayversioned.Interface, namespace string) ([]metav1.Object, error)
 	// Status projects an object into its graph-node status.
 	Status func(clusterID string, obj metav1.Object) *objectmap.Status
 }

--- a/backend/objectcatalog/collect.go
+++ b/backend/objectcatalog/collect.go
@@ -149,6 +149,25 @@ func (s *Service) listResource(ctx context.Context, index int, desc resourceDesc
 	return s.listResourceSequential(ctx, index, namespaceable, desc, targets, agg)
 }
 
+// scopeNamespaces returns the cluster's configured namespace scope for
+// collection (docs/plans/namespace-scope.md); nil means cluster-wide.
+func (s *Service) scopeNamespaces() []string {
+	if s == nil {
+		return nil
+	}
+	return s.deps.AllowedNamespaces
+}
+
+// skipForbiddenNamespaceTarget reports whether a per-target list error is a
+// Forbidden for one REAL namespace target — in which case that namespace is
+// skipped instead of blanking the kind's other namespaces (a scoped identity
+// may legitimately hold grants in only a subset of the configured scope).
+// Cluster-wide targets keep propagating Forbidden so permission denial still
+// surfaces where the whole kind is unreadable.
+func skipForbiddenNamespaceTarget(target string, err error) bool {
+	return target != "" && target != metav1.NamespaceAll && apierrors.IsForbidden(err)
+}
+
 func (s *Service) listResourceSequential(ctx context.Context, index int, namespaceable dynamic.NamespaceableResourceInterface, desc resourceDescriptor, targets []string, agg *streamingAggregator) ([]Summary, error) {
 	results := make([]Summary, 0)
 	for _, target := range targets {
@@ -160,6 +179,9 @@ func (s *Service) listResourceSequential(ctx context.Context, index int, namespa
 		resourceInterface := resourceInterfaceForTarget(namespaceable, desc.Namespaced, target)
 		items, err := s.listNamespaceItems(ctx, index, desc, resourceInterface, agg)
 		if err != nil {
+			if skipForbiddenNamespaceTarget(target, err) {
+				continue
+			}
 			return nil, err
 		}
 		if len(items) > 0 {
@@ -177,6 +199,9 @@ func (s *Service) listResourceNamespacedParallel(ctx context.Context, index int,
 		resourceInterface := resourceInterfaceForTarget(namespaceable, true, target)
 		items, err := s.listNamespaceItems(taskCtx, index, desc, resourceInterface, agg)
 		if err != nil {
+			if skipForbiddenNamespaceTarget(target, err) {
+				return nil
+			}
 			return err
 		}
 		if len(items) == 0 {
@@ -301,7 +326,7 @@ func (s *Service) maybePromote(desc resourceDescriptor, itemCount int) {
 	}
 	gvk := schema.GroupVersionKind{Group: desc.Group, Version: desc.Version, Kind: desc.Kind}
 	project := func(obj metav1.Object) interface{} { return s.buildSummary(desc, obj) }
-	if !source.RegisterDynamicCatalogReflector(gvr, gvk, project) {
+	if !source.RegisterDynamicCatalogReflector(gvr, gvk, project, desc.Namespaced) {
 		return
 	}
 	source.AddCatalogSink(gvr, ingestCatalogSink{service: s, gvr: gvr})

--- a/backend/objectcatalog/collect_dynamic_ingest_test.go
+++ b/backend/objectcatalog/collect_dynamic_ingest_test.go
@@ -55,7 +55,7 @@ func (f *fakeDynamicIngestSource) registered(gvr schema.GroupVersionResource) bo
 	return ok
 }
 
-func (f *fakeDynamicIngestSource) RegisterDynamicCatalogReflector(gvr schema.GroupVersionResource, _ schema.GroupVersionKind, project ingest.CatalogProjector) bool {
+func (f *fakeDynamicIngestSource) RegisterDynamicCatalogReflector(gvr schema.GroupVersionResource, _ schema.GroupVersionKind, project ingest.CatalogProjector, _ bool) bool {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if _, ok := f.projects[gvr]; ok {

--- a/backend/objectcatalog/collect_test.go
+++ b/backend/objectcatalog/collect_test.go
@@ -8,11 +8,13 @@ package objectcatalog
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/luxury-yacht/app/backend/refresh/ingest"
 	"github.com/luxury-yacht/app/backend/resources/common"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -119,7 +121,7 @@ func (f *fakeCatalogIngestSource) AddCatalogSink(schema.GroupVersionResource, in
 
 // The dynamic-CRD path is not exercised by the static-cut-kind tests below, so these
 // satisfy the IngestSource interface as no-ops.
-func (f *fakeCatalogIngestSource) RegisterDynamicCatalogReflector(schema.GroupVersionResource, schema.GroupVersionKind, ingest.CatalogProjector) bool {
+func (f *fakeCatalogIngestSource) RegisterDynamicCatalogReflector(schema.GroupVersionResource, schema.GroupVersionKind, ingest.CatalogProjector, bool) bool {
 	return false
 }
 
@@ -563,5 +565,62 @@ func TestBuildSummaryClusterScope(t *testing.T) {
 	}
 	if summary.CreationTimestamp != "2023-01-02T03:04:05Z" {
 		t.Fatalf("unexpected creation timestamp %s", summary.CreationTimestamp)
+	}
+}
+
+// Scoped clusters (docs/plans/namespace-scope.md): one forbidden namespace
+// must not blank the other configured namespaces' results — the Lens dual-path
+// pitfall (b) this plan explicitly avoids.
+func TestListResourceSkipsForbiddenNamespaceTargets(t *testing.T) {
+	scheme := runtime.NewScheme()
+	cfgGVK := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+	listKinds := map[schema.GroupVersionResource]string{
+		{Group: "apps", Version: "v1", Resource: "deployments"}: "DeploymentList",
+	}
+
+	objA := &unstructured.Unstructured{}
+	objA.SetGroupVersionKind(cfgGVK)
+	objA.SetNamespace("alpha")
+	objA.SetName("sample-a")
+
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, objA)
+	dyn.PrependReactor("list", "deployments", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if action.GetNamespace() == "beta" {
+			return true, nil, k8serrors.NewForbidden(schema.GroupResource{Group: "apps", Resource: "deployments"}, "", errors.New("denied"))
+		}
+		return false, nil, nil
+	})
+
+	svc := NewService(Dependencies{Common: common.Dependencies{KubernetesClient: kubernetesfake.NewClientset(), DynamicClient: dyn}}, &Options{PageSize: 10})
+
+	desc := resourceDescriptor{
+		GVR:        schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+		Namespaced: true,
+		Kind:       "Deployment",
+		Group:      "apps",
+		Version:    "v1",
+		Resource:   "deployments",
+		Scope:      ScopeNamespace,
+	}
+
+	items, err := svc.listResource(context.Background(), 0, desc, []string{"alpha", "beta"}, nil)
+	if err != nil {
+		t.Fatalf("a forbidden namespace must be skipped, not fail the kind: %v", err)
+	}
+	if len(items) != 1 || items[0].Name != "sample-a" {
+		t.Fatalf("expected only alpha's item, got %#v", items)
+	}
+}
+
+func TestServiceScopeNamespacesComeFromDependencies(t *testing.T) {
+	svc := NewService(Dependencies{AllowedNamespaces: []string{"prod", "dev"}, Common: common.Dependencies{}}, nil)
+	got := svc.scopeNamespaces()
+	if len(got) != 2 || got[0] != "prod" || got[1] != "dev" {
+		t.Fatalf("scopeNamespaces = %#v, want configured scope", got)
+	}
+
+	unscoped := NewService(Dependencies{Common: common.Dependencies{}}, nil)
+	if ns := unscoped.scopeNamespaces(); ns != nil {
+		t.Fatalf("unscoped service must report nil scope, got %#v", ns)
 	}
 }

--- a/backend/objectcatalog/ingest_source_test.go
+++ b/backend/objectcatalog/ingest_source_test.go
@@ -28,7 +28,7 @@ func (r replayIngestSource) AddCatalogSink(gvr schema.GroupVersionResource, sink
 	}
 	return true
 }
-func (r replayIngestSource) RegisterDynamicCatalogReflector(schema.GroupVersionResource, schema.GroupVersionKind, ingest.CatalogProjector) bool {
+func (r replayIngestSource) RegisterDynamicCatalogReflector(schema.GroupVersionResource, schema.GroupVersionKind, ingest.CatalogProjector, bool) bool {
 	return false
 }
 func (r replayIngestSource) StopReflectorFor(schema.GroupVersionResource)  {}

--- a/backend/objectcatalog/sync.go
+++ b/backend/objectcatalog/sync.go
@@ -21,37 +21,70 @@ import (
 	authorizationv1 "k8s.io/api/authorization/v1"
 )
 
-// evaluateDescriptor checks if the given descriptor is allowed by the capabilities service.
+// preflightNamespaces returns the namespaces a descriptor's RBAC preflight
+// asks about: the configured scope for a namespaced kind under a namespace
+// scope (docs/plans/namespace-scope.md), otherwise the single cluster-wide
+// "" ask. The check's scope must match the collection's scope — a scoped
+// identity is typically denied cluster-wide but allowed per namespace, and a
+// cluster-wide-only preflight would skip collection for every kind.
+func (s *Service) preflightNamespaces(desc resourceDescriptor) []string {
+	scope := s.scopeNamespaces()
+	if !desc.Namespaced || len(scope) == 0 {
+		return []string{""}
+	}
+	return scope
+}
+
+// evaluateDescriptor checks if the given descriptor is allowed by the
+// capabilities service: allowed in ANY of its preflight namespaces.
 func (s *Service) evaluateDescriptor(ctx context.Context, svc *capabilities.Service, desc resourceDescriptor) (bool, error) {
 	if svc == nil {
 		return true, nil
 	}
-	reviews := []capabilities.ReviewAttributes{
-		{
-			ID: desc.GVR.String(),
+	targets := s.preflightNamespaces(desc)
+	reviews := make([]capabilities.ReviewAttributes, 0, len(targets))
+	for _, namespace := range targets {
+		reviews = append(reviews, capabilities.ReviewAttributes{
+			ID: desc.GVR.String() + "|" + namespace,
 			Attributes: &authorizationv1.ResourceAttributes{
-				Group:    desc.Group,
-				Version:  desc.Version,
-				Resource: desc.Resource,
-				Verb:     "list",
+				Group:     desc.Group,
+				Version:   desc.Version,
+				Resource:  desc.Resource,
+				Verb:      "list",
+				Namespace: namespace,
 			},
-		},
+		})
 	}
 	results, err := svc.Evaluate(ctx, reviews)
 	if err != nil {
 		return false, err
 	}
-	if len(results) == 0 {
+	var firstErr error
+	answered := false
+	for _, res := range results {
+		switch {
+		case res.Error != "":
+			if firstErr == nil {
+				firstErr = errors.New(res.Error)
+			}
+		case res.EvaluationError != "":
+			if firstErr == nil {
+				firstErr = errors.New(res.EvaluationError)
+			}
+		default:
+			answered = true
+			if res.Allowed {
+				return true, nil
+			}
+		}
+	}
+	if !answered {
+		if firstErr != nil {
+			return false, firstErr
+		}
 		return false, nil
 	}
-	res := results[0]
-	if res.Error != "" {
-		return false, errors.New(res.Error)
-	}
-	if res.EvaluationError != "" {
-		return false, errors.New(res.EvaluationError)
-	}
-	return res.Allowed, nil
+	return false, nil
 }
 
 // evaluateDescriptorsBatch checks if the given descriptors are allowed by the capabilities service.
@@ -68,19 +101,26 @@ func (s *Service) evaluateDescriptorsBatch(ctx context.Context, svc *capabilitie
 		return allowed, nil, nil
 	}
 
+	// One check per (descriptor × preflight namespace): a namespaced kind
+	// under a scope is allowed when ANY configured namespace allows it; a
+	// per-namespace error is ignored when another namespace gave a definitive
+	// answer, so one broken namespace never blanks the kind.
 	checks := make([]capabilities.ReviewAttributes, 0, len(descriptors))
 	indexes := make([]int, 0, len(descriptors))
 	for idx, desc := range descriptors {
-		checks = append(checks, capabilities.ReviewAttributes{
-			ID: desc.GVR.String(),
-			Attributes: &authorizationv1.ResourceAttributes{
-				Group:    desc.Group,
-				Version:  desc.Version,
-				Resource: desc.Resource,
-				Verb:     "list",
-			},
-		})
-		indexes = append(indexes, idx)
+		for _, namespace := range s.preflightNamespaces(desc) {
+			checks = append(checks, capabilities.ReviewAttributes{
+				ID: desc.GVR.String() + "|" + namespace,
+				Attributes: &authorizationv1.ResourceAttributes{
+					Group:     desc.Group,
+					Version:   desc.Version,
+					Resource:  desc.Resource,
+					Verb:      "list",
+					Namespace: namespace,
+				},
+			})
+			indexes = append(indexes, idx)
+		}
 	}
 
 	results, err := svc.Evaluate(ctx, checks)
@@ -89,6 +129,7 @@ func (s *Service) evaluateDescriptorsBatch(ctx context.Context, svc *capabilitie
 	}
 
 	errorsByIndex := make(map[int]error)
+	answered := make(map[int]bool, len(descriptors))
 	for i, res := range results {
 		if i >= len(indexes) {
 			break
@@ -96,12 +137,23 @@ func (s *Service) evaluateDescriptorsBatch(ctx context.Context, svc *capabilitie
 		idx := indexes[i]
 		switch {
 		case res.Error != "":
-			errorsByIndex[idx] = errors.New(res.Error)
+			if _, ok := errorsByIndex[idx]; !ok {
+				errorsByIndex[idx] = errors.New(res.Error)
+			}
 		case res.EvaluationError != "":
-			errorsByIndex[idx] = errors.New(res.EvaluationError)
+			if _, ok := errorsByIndex[idx]; !ok {
+				errorsByIndex[idx] = errors.New(res.EvaluationError)
+			}
 		default:
-			allowed[idx] = res.Allowed
+			answered[idx] = true
+			if res.Allowed {
+				allowed[idx] = true
+			}
 		}
+	}
+	// A definitive per-namespace answer outranks a sibling namespace's error.
+	for idx := range answered {
+		delete(errorsByIndex, idx)
 	}
 
 	allowedCount := 0

--- a/backend/objectcatalog/sync.go
+++ b/backend/objectcatalog/sync.go
@@ -399,7 +399,7 @@ func (s *Service) sync(ctx context.Context) error {
 				return nil
 			}
 
-			summaries, err := s.collectResource(taskCtx, index, desc, nil, agg)
+			summaries, err := s.collectResource(taskCtx, index, desc, s.scopeNamespaces(), agg)
 			if err != nil {
 				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 					return err

--- a/backend/objectcatalog/sync_test.go
+++ b/backend/objectcatalog/sync_test.go
@@ -445,7 +445,7 @@ func (b *blockingIngestSource) AddCatalogSink(schema.GroupVersionResource, inges
 	<-b.release
 	return false
 }
-func (b *blockingIngestSource) RegisterDynamicCatalogReflector(schema.GroupVersionResource, schema.GroupVersionKind, ingest.CatalogProjector) bool {
+func (b *blockingIngestSource) RegisterDynamicCatalogReflector(schema.GroupVersionResource, schema.GroupVersionKind, ingest.CatalogProjector, bool) bool {
 	return false
 }
 func (b *blockingIngestSource) StopReflectorFor(schema.GroupVersionResource)  {}

--- a/backend/objectcatalog/sync_test.go
+++ b/backend/objectcatalog/sync_test.go
@@ -605,3 +605,67 @@ func TestFailedInitialSyncRetriesWhileReactiveRegistrationBlocks(t *testing.T) {
 	}
 	t.Fatalf("no failed-sync retry fired while reactive registration was blocked (sync attempts: %d)", rec.count())
 }
+
+// The user-observed failure (docs/plans/namespace-scope.md): a RoleBindings-only
+// identity gets "catalog RBAC preflight: allowed=0 denied=57" because every
+// preflight check is cluster-scoped, so collection is skipped for every kind
+// and Browse stays empty even though the identity can list in its namespaces.
+// Namespaced kinds must be evaluated per configured scope namespace (any-of);
+// cluster-scoped kinds keep the cluster-wide ask.
+func TestCatalogPreflightEvaluatesNamespacedKindsPerScopeNamespace(t *testing.T) {
+	client := kubernetesfake.NewClientset()
+	client.PrependReactor("create", "selfsubjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		review := action.(k8stesting.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
+		result := review.DeepCopy()
+		// Allowed ONLY inside namespace "prod" — cluster-wide asks denied.
+		result.Status.Allowed = review.Spec.ResourceAttributes.Namespace == "prod"
+		return true, result, nil
+	})
+
+	factory := func() *capabilities.Service {
+		return capabilities.NewService(capabilities.Dependencies{
+			Common: common.Dependencies{
+				KubernetesClient: client,
+				EnsureClient:     func(string) error { return nil },
+			},
+		})
+	}
+
+	svc := NewService(Dependencies{
+		Common: common.Dependencies{
+			KubernetesClient: client,
+			EnsureClient:     func(string) error { return nil },
+		},
+		CapabilityFactory: factory,
+		AllowedNamespaces: []string{"prod", "dev"},
+	}, nil)
+	capSvc := factory()
+
+	deployDesc := resourceDescriptor{
+		Resource: "deployments", Group: "apps", Version: "v1", Namespaced: true,
+		GVR: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+	}
+	nodesDesc := resourceDescriptor{
+		Resource: "nodes", Version: "v1", Namespaced: false,
+		GVR: schema.GroupVersionResource{Version: "v1", Resource: "nodes"},
+	}
+
+	batchAllowed, batchErrors, err := svc.evaluateDescriptorsBatch(context.Background(), capSvc, []resourceDescriptor{deployDesc, nodesDesc})
+	if err != nil || len(batchErrors) != 0 {
+		t.Fatalf("batch evaluation failed: err=%v batchErrors=%+v", err, batchErrors)
+	}
+	if !batchAllowed[0] {
+		t.Fatal("namespaced kind allowed in one scope namespace must pass the preflight")
+	}
+	if batchAllowed[1] {
+		t.Fatal("cluster-scoped kind keeps the cluster-wide ask and stays denied")
+	}
+
+	single, err := svc.evaluateDescriptor(context.Background(), capSvc, deployDesc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !single {
+		t.Fatal("single-descriptor preflight must also fan out over the scope")
+	}
+}

--- a/backend/objectcatalog/types.go
+++ b/backend/objectcatalog/types.go
@@ -134,6 +134,12 @@ type Dependencies struct {
 	// discovery + preflight (pure API calls) overlap the factory's initial sync
 	// instead of running after it. nil skips the wait (tests, no factory).
 	WaitForCaches func(ctx context.Context) error
+	// AllowedNamespaces is the cluster's namespace scope
+	// (docs/plans/namespace-scope.md): when non-empty, collection of
+	// namespaced kinds runs per configured namespace instead of
+	// cluster-wide, and a namespace the identity cannot list is skipped
+	// without blanking the others. Empty means cluster-wide (today).
+	AllowedNamespaces []string
 }
 
 // IngestSource supplies the object-catalog Summaries for ingest-owned (cut) kinds,
@@ -150,7 +156,7 @@ type IngestSource interface {
 	// (CRD-backed) kind, projecting each object to its catalog Summary via project. The
 	// catalog calls it when a CR kind crosses its promotion threshold (maybePromote),
 	// consolidating the former catalog-owned dynamic informer onto the ingest path.
-	RegisterDynamicCatalogReflector(gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, project ingest.CatalogProjector) bool
+	RegisterDynamicCatalogReflector(gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, project ingest.CatalogProjector, namespaced bool) bool
 	// StopReflectorFor stops and evicts the on-demand reflector for gvr, the teardown half
 	// of the dynamic path (stopDynamicReflectors).
 	StopReflectorFor(gvr schema.GroupVersionResource)

--- a/backend/refresh/domain/registry.go
+++ b/backend/refresh/domain/registry.go
@@ -73,6 +73,17 @@ func (r *Registry) IsPermissionDenied(name string) bool {
 	return cfg.PermissionDenied
 }
 
+// IsRuntimePolicyExempt reports whether a domain was registered with its
+// runtime permission policy exempted (its data source needs no cluster
+// permission in this configuration).
+func (r *Registry) IsRuntimePolicyExempt(name string) bool {
+	cfg, ok := r.Get(name)
+	if !ok {
+		return false
+	}
+	return cfg.RuntimePolicyExempt
+}
+
 // Build invokes the domain-specific builder.
 func (r *Registry) Build(ctx context.Context, domain, scope string) (*refresh.Snapshot, error) {
 	cfg, ok := r.Get(domain)

--- a/backend/refresh/domainpermissions/access.go
+++ b/backend/refresh/domainpermissions/access.go
@@ -179,7 +179,15 @@ func runtimePolicyAllows(ctx context.Context, checker *permissions.Checker, poli
 	anyAllowed := false
 	allAllowed := true
 	for _, req := range policy.Runtime {
-		decision, err := checker.Can(ctx, req.Group, req.Resource, req.Verb)
+		var decision permissions.Decision
+		var err error
+		if req.ClusterWide {
+			// The requirement gates a cluster-wide data source; its check
+			// must match that source and bypass any namespace scope.
+			decision, err = checker.CanClusterWide(ctx, req.Group, req.Resource, req.Verb)
+		} else {
+			decision, err = checker.Can(ctx, req.Group, req.Resource, req.Verb)
+		}
 		if err != nil {
 			return nil, false, err
 		}

--- a/backend/refresh/domainpermissions/access_test.go
+++ b/backend/refresh/domainpermissions/access_test.go
@@ -11,7 +11,7 @@ import (
 func TestRuntimeAccessAllowsUnknownDomain(t *testing.T) {
 	access := NewRuntimeAccess()
 	require.False(t, access.IsEmpty())
-	checker := permissions.NewCheckerWithReview("cluster-a", 0, func(ctx context.Context, group, resource, verb string) (bool, error) {
+	checker := permissions.NewCheckerWithReview("cluster-a", 0, func(ctx context.Context, group, resource, verb, _ string) (bool, error) {
 		t.Fatalf("unexpected permission review for unknown domain")
 		return false, nil
 	})
@@ -40,7 +40,7 @@ func TestRuntimeAccessDeniedReason(t *testing.T) {
 
 func TestRuntimeAccessRequiresAllPolicyRequirements(t *testing.T) {
 	access := NewRuntimeAccess()
-	checker := permissions.NewCheckerWithReview("cluster-a", 0, func(ctx context.Context, group, resource, verb string) (bool, error) {
+	checker := permissions.NewCheckerWithReview("cluster-a", 0, func(ctx context.Context, group, resource, verb, _ string) (bool, error) {
 		return !(group == "" && resource == "namespaces" && verb == "list"), nil
 	})
 
@@ -52,7 +52,7 @@ func TestRuntimeAccessRequiresAllPolicyRequirements(t *testing.T) {
 
 func TestRuntimeAccessAllowsAnyPolicyRequirement(t *testing.T) {
 	access := NewRuntimeAccess()
-	checker := permissions.NewCheckerWithReview("cluster-a", 0, func(ctx context.Context, group, resource, verb string) (bool, error) {
+	checker := permissions.NewCheckerWithReview("cluster-a", 0, func(ctx context.Context, group, resource, verb, _ string) (bool, error) {
 		return resource == "secrets" && verb == "list", nil
 	})
 
@@ -63,7 +63,7 @@ func TestRuntimeAccessAllowsAnyPolicyRequirement(t *testing.T) {
 
 func TestRuntimeAccessDeniesAnyPolicyWhenNoRequirementsAllowed(t *testing.T) {
 	access := NewRuntimeAccess()
-	checker := permissions.NewCheckerWithReview("cluster-a", 0, func(ctx context.Context, group, resource, verb string) (bool, error) {
+	checker := permissions.NewCheckerWithReview("cluster-a", 0, func(ctx context.Context, group, resource, verb, _ string) (bool, error) {
 		return false, nil
 	})
 
@@ -71,4 +71,29 @@ func TestRuntimeAccessDeniesAnyPolicyWhenNoRequirementsAllowed(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, decision.Allowed)
 	require.Equal(t, "core/configmaps,secrets", decision.DeniedReason)
+}
+
+// The namespace-helm domain reads from the CLUSTER-WIDE helm-storage factory,
+// so its runtime policy must stay a cluster-wide check under a namespace
+// scope (docs/plans/namespace-scope.md): a per-namespace secrets grant must
+// not register a domain whose source can only 403.
+func TestRuntimeAccessHelmPolicyStaysClusterWideUnderScope(t *testing.T) {
+	access := NewRuntimeAccess()
+	checker := permissions.NewCheckerWithReview("cluster-a", 0, func(_ context.Context, _, _, _, namespace string) (bool, error) {
+		// Allowed per-namespace, denied cluster-wide.
+		return namespace != "", nil
+	})
+	checker.SetScope([]string{"prod"}, func(_, resource string) bool {
+		return resource == "secrets" || resource == "configmaps"
+	})
+
+	decision, err := access.Check(context.Background(), "namespace-helm", checker)
+	require.NoError(t, err)
+	require.False(t, decision.Allowed, "cluster-wide helm source denied ⇒ domain denied, even with per-namespace grants")
+
+	// A domain whose source IS scoped (ingest-owned kinds) registers on the
+	// strength of the per-namespace grant.
+	decision, err = access.Check(context.Background(), "namespace-config", checker)
+	require.NoError(t, err)
+	require.True(t, decision.Allowed)
 }

--- a/backend/refresh/domainpermissions/spec.go
+++ b/backend/refresh/domainpermissions/spec.go
@@ -91,6 +91,11 @@ type policySpec struct {
 	Reason  string
 	Runtime []Resource
 	Stream  []Resource
+	// RuntimeClusterWide marks the domain's runtime data source as
+	// cluster-wide regardless of any namespace scope
+	// (docs/plans/namespace-scope.md): its runtime checks bypass the scope so
+	// the gate matches the source.
+	RuntimeClusterWide bool
 }
 
 // Compositions returns the shared resource composition for refresh domains.
@@ -209,11 +214,17 @@ func PreflightRequirements() []permissions.ResourceRequirement {
 func buildPolicies() []Policy {
 	result := make([]Policy, 0, len(policySpecs))
 	for _, spec := range policySpecs {
+		runtime := listRequirements(spec.Runtime)
+		if spec.RuntimeClusterWide {
+			for i := range runtime {
+				runtime[i].ClusterWide = true
+			}
+		}
 		result = append(result, Policy{
 			Domain:  spec.Domain,
 			Mode:    spec.Mode,
 			Reason:  spec.Reason,
-			Runtime: listRequirements(spec.Runtime),
+			Runtime: runtime,
 			Stream:  listWatchRequirements(spec.Stream),
 		})
 	}
@@ -400,6 +411,10 @@ var policySpecs = []policySpec{
 		// storage path. Streams also watch ConfigMaps so configmap-backed Helm
 		// release storage can trigger namespace-level resyncs when permitted.
 		Stream: []Resource{fromIdentity(secretpkg.Identity), fromIdentity(configmap.Identity)},
+		// Helm releases are read from the label-filtered CLUSTER-WIDE
+		// helm-storage informer factory, not from per-namespace ingest — the
+		// gate must match that source under a namespace scope.
+		RuntimeClusterWide: true,
 	},
 	{
 		Domain:  "namespace-events",

--- a/backend/refresh/informer/factory_test.go
+++ b/backend/refresh/informer/factory_test.go
@@ -36,7 +36,7 @@ func brokenInformer(err error) cache.SharedIndexInformer {
 
 func newStartedFactory(t *testing.T) *Factory {
 	t.Helper()
-	checker := permissions.NewCheckerWithReview("test", time.Minute, func(_ context.Context, _, _, _ string) (bool, error) {
+	checker := permissions.NewCheckerWithReview("test", time.Minute, func(_ context.Context, _, _, _, _ string) (bool, error) {
 		return true, nil
 	})
 	return New(fake.NewClientset(), nil, time.Minute, checker)
@@ -193,7 +193,7 @@ func TestResourcesSettledFalseAfterShutdown(t *testing.T) {
 // projector resolves owners through it), so this asserts the cut is precise.
 func TestNewFactoryDoesNotRegisterPodInformer(t *testing.T) {
 	client := fake.NewClientset()
-	checker := permissions.NewCheckerWithReview("test", time.Minute, func(_ context.Context, _, _, _ string) (bool, error) {
+	checker := permissions.NewCheckerWithReview("test", time.Minute, func(_ context.Context, _, _, _, _ string) (bool, error) {
 		return true, nil
 	})
 	factory := New(client, nil, time.Minute, checker)
@@ -220,7 +220,7 @@ func TestNewFactoryDoesNotRegisterPodInformer(t *testing.T) {
 // it and the pod stream re-broadcasts pods on RS changes).
 func TestNewFactoryDoesNotRegisterWorkloadInformers(t *testing.T) {
 	client := fake.NewClientset()
-	checker := permissions.NewCheckerWithReview("test", time.Minute, func(_ context.Context, _, _, _ string) (bool, error) {
+	checker := permissions.NewCheckerWithReview("test", time.Minute, func(_ context.Context, _, _, _, _ string) (bool, error) {
 		return true, nil
 	})
 	factory := New(client, nil, time.Minute, checker)
@@ -251,7 +251,7 @@ func TestNewFactoryDoesNotRegisterWorkloadInformers(t *testing.T) {
 // catalog, object-map, and notify all come from the ingest reflectors instead.
 func TestNewFactoryDoesNotRegisterNetworkInformers(t *testing.T) {
 	client := fake.NewClientset()
-	checker := permissions.NewCheckerWithReview("test", time.Minute, func(_ context.Context, _, _, _ string) (bool, error) {
+	checker := permissions.NewCheckerWithReview("test", time.Minute, func(_ context.Context, _, _, _, _ string) (bool, error) {
 		return true, nil
 	})
 	factory := New(client, nil, time.Minute, checker)
@@ -282,7 +282,7 @@ func TestNewFactoryDoesNotRegisterNetworkInformers(t *testing.T) {
 // no consumer reads and the projection drops.
 func TestNewFactoryDoesNotRegisterNodeInformer(t *testing.T) {
 	client := fake.NewClientset()
-	checker := permissions.NewCheckerWithReview("test", time.Minute, func(_ context.Context, _, _, _ string) (bool, error) {
+	checker := permissions.NewCheckerWithReview("test", time.Minute, func(_ context.Context, _, _, _, _ string) (bool, error) {
 		return true, nil
 	})
 	factory := New(client, nil, time.Minute, checker)
@@ -301,7 +301,7 @@ func TestNewFactoryDoesNotRegisterNodeInformer(t *testing.T) {
 
 func TestCanListResourceCachesResults(t *testing.T) {
 	var sarCalls atomic.Int32
-	checker := permissions.NewCheckerWithReview("test", time.Minute, func(_ context.Context, _, _, _ string) (bool, error) {
+	checker := permissions.NewCheckerWithReview("test", time.Minute, func(_ context.Context, _, _, _, _ string) (bool, error) {
 		sarCalls.Add(1)
 		return true, nil
 	})
@@ -334,7 +334,7 @@ func TestCanListResourceCachesResults(t *testing.T) {
 
 func TestPrimePermissionsDeduplicatesRequests(t *testing.T) {
 	var sarCalls atomic.Int32
-	checker := permissions.NewCheckerWithReview("test", time.Minute, func(_ context.Context, _, _, _ string) (bool, error) {
+	checker := permissions.NewCheckerWithReview("test", time.Minute, func(_ context.Context, _, _, _, _ string) (bool, error) {
 		sarCalls.Add(1)
 		return true, nil
 	})
@@ -361,7 +361,7 @@ func TestPrimePermissionsDeduplicatesRequests(t *testing.T) {
 
 func TestProcessPendingClusterInformersSkipsWithoutPermissions(t *testing.T) {
 	// Deny everything via the Checker.
-	checker := permissions.NewCheckerWithReview("test", time.Minute, func(_ context.Context, _, _, _ string) (bool, error) {
+	checker := permissions.NewCheckerWithReview("test", time.Minute, func(_ context.Context, _, _, _, _ string) (bool, error) {
 		return false, nil
 	})
 
@@ -417,7 +417,7 @@ func TestIsTerminalWatchError(t *testing.T) {
 
 func TestNewFactoryRegistersHelmStorageNotFullConfigInformers(t *testing.T) {
 	client := fake.NewClientset()
-	checker := permissions.NewCheckerWithReview("test", time.Minute, func(_ context.Context, _, _, _ string) (bool, error) {
+	checker := permissions.NewCheckerWithReview("test", time.Minute, func(_ context.Context, _, _, _, _ string) (bool, error) {
 		return true, nil
 	})
 	factory := New(client, nil, time.Minute, checker)
@@ -466,7 +466,7 @@ func TestNewFactoryRegistersHelmStorageNotFullConfigInformers(t *testing.T) {
 // never opens a watch — and reports synced so the helm builder serves empty.
 func TestHelmStorageSourceSkipsDeniedKinds(t *testing.T) {
 	client := fake.NewClientset()
-	checker := permissions.NewCheckerWithReview("test", time.Minute, func(_ context.Context, _, resource, _ string) (bool, error) {
+	checker := permissions.NewCheckerWithReview("test", time.Minute, func(_ context.Context, _, resource, _, _ string) (bool, error) {
 		return resource != "secrets", nil
 	})
 	factory := New(client, nil, time.Minute, checker)

--- a/backend/refresh/informer/helm_storage.go
+++ b/backend/refresh/informer/helm_storage.go
@@ -21,6 +21,8 @@
 package informer
 
 import (
+	"context"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/informers"
@@ -126,16 +128,19 @@ func (f *Factory) newHelmStorageSource() *HelmStorageSource {
 }
 
 // canListWatchHelmStorage reports whether the identity may list AND watch the
-// resource — the precondition for creating a filtered informer over it. It reuses
-// the Factory's permission checks so the helm-storage gate matches every other
-// informer's gate.
+// resource CLUSTER-WIDE — the precondition for creating a filtered informer
+// over it. The helm-storage factory LISTs/WATCHes across all namespaces, so
+// its gate deliberately bypasses any configured namespace scope
+// (docs/plans/namespace-scope.md): a per-namespace grant must not create an
+// informer whose cluster-wide watch would only 403.
 func (f *Factory) canListWatchHelmStorage(group, resource string) bool {
-	listAllowed, listErr := f.CanListResource(group, resource)
-	if listErr != nil || !listAllowed {
+	ctx := context.Background()
+	listDecision, listErr := f.runtimePermissions.CanClusterWide(ctx, group, resource, "list")
+	if listErr != nil || !listDecision.Allowed {
 		return false
 	}
-	watchAllowed, watchErr := f.CanWatchResource(group, resource)
-	if watchErr != nil || !watchAllowed {
+	watchDecision, watchErr := f.runtimePermissions.CanClusterWide(ctx, group, resource, "watch")
+	if watchErr != nil || !watchDecision.Allowed {
 		return false
 	}
 	return true

--- a/backend/refresh/informer/helm_storage_scope_test.go
+++ b/backend/refresh/informer/helm_storage_scope_test.go
@@ -1,0 +1,32 @@
+package informer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/luxury-yacht/app/backend/refresh/permissions"
+)
+
+// The helm-storage factory LISTs/WATCHes secrets+configmaps cluster-wide, so
+// its gate must be the cluster-wide check even under a namespace scope
+// (docs/plans/namespace-scope.md): per-namespace grants must not create
+// informers that would only 403.
+func TestHelmStorageGateIsClusterWideUnderNamespaceScope(t *testing.T) {
+	checker := permissions.NewCheckerWithReview("test", time.Minute, func(_ context.Context, _, _, _, namespace string) (bool, error) {
+		// Allowed in configured namespaces, denied cluster-wide.
+		return namespace != "", nil
+	})
+	checker.SetScope([]string{"prod"}, func(_, resource string) bool {
+		return resource == "secrets" || resource == "configmaps"
+	})
+
+	factory := New(fake.NewSimpleClientset(), nil, time.Minute, checker)
+	helm := factory.HelmStorage()
+	require.NotNil(t, helm)
+	require.Nil(t, helm.SecretInformer(), "per-namespace grant must not create the cluster-wide helm secret informer")
+	require.Nil(t, helm.ConfigMapInformer(), "per-namespace grant must not create the cluster-wide helm configmap informer")
+}

--- a/backend/refresh/ingest/bundle_spill_test.go
+++ b/backend/refresh/ingest/bundle_spill_test.go
@@ -69,7 +69,7 @@ func TestSpillRestoreBundlesRoundTrip(t *testing.T) {
 	require.NoError(t, orig.SpillBundles(path))
 
 	restored := bundleProjectingStore(false)
-	rv, err := restored.RestoreBundles(path)
+	rv, _, err := restored.RestoreBundles(path)
 	require.NoError(t, err)
 	require.Equal(t, "12", rv, "RestoreBundles returns the persisted RV for the resume")
 	require.Equal(t, "12", restored.LastStoreSyncResourceVersion())
@@ -99,7 +99,7 @@ func TestSpillRestoreBundlesRetainsTableHalf(t *testing.T) {
 	require.NoError(t, orig.SpillBundles(path))
 
 	restored := bundleProjectingStore(true)
-	_, err := restored.RestoreBundles(path)
+	_, _, err := restored.RestoreBundles(path)
 	require.NoError(t, err)
 
 	got := map[string]int{}
@@ -114,7 +114,7 @@ func TestSpillRestoreBundlesRetainsTableHalf(t *testing.T) {
 // file — the caller treats the error as "skip → full sync".
 func TestRestoreBundlesMissingFileErrors(t *testing.T) {
 	store := bundleProjectingStore(false)
-	_, err := store.RestoreBundles(filepath.Join(t.TempDir(), "does-not-exist.bundles"))
+	_, _, err := store.RestoreBundles(filepath.Join(t.TempDir(), "does-not-exist.bundles"))
 	require.Error(t, err)
 	require.False(t, store.HasSynced(), "a failed restore leaves the store unsynced (it will full-sync)")
 }
@@ -140,10 +140,11 @@ func TestSpillRestoreStoresSetsResumeRV(t *testing.T) {
 
 	storeB := bundleProjectingStore(false)
 	dstEntry := &entry{store: storeB, example: resumeCM("ex", "0")}
+	dstEntry.parts = []*ingestPart{{namespace: "", view: storeB.PartitionView("")}}
 	dst := &IngestManager{entries: map[schema.GroupVersionResource]*entry{cmGVR(): dstEntry}}
 	dst.RestoreStores(dir)
 
-	require.Equal(t, "11", dstEntry.resumeRV, "restore sets resumeRV from the persisted store RV")
+	require.Equal(t, "11", dstEntry.parts[0].resumeRV, "restore sets resumeRV from the persisted store RV")
 	require.Equal(t, 2, len(storeB.List()), "restore repopulates the store full")
 	require.True(t, storeB.HasSynced())
 }
@@ -153,10 +154,11 @@ func TestSpillRestoreStoresSetsResumeRV(t *testing.T) {
 func TestRestoreStoresNoFileLeavesResumeUnset(t *testing.T) {
 	store := bundleProjectingStore(false)
 	e := &entry{store: store, example: resumeCM("ex", "0")}
+	e.parts = []*ingestPart{{namespace: "", view: store.PartitionView("")}}
 	dst := &IngestManager{entries: map[schema.GroupVersionResource]*entry{cmGVR(): e}}
 
 	dst.RestoreStores(t.TempDir()) // empty dir — no spill file
 
-	require.Equal(t, "", e.resumeRV, "no spill file → resumeRV stays empty → full sync")
+	require.Equal(t, "", e.parts[0].resumeRV, "no spill file → resumeRV stays empty → full sync")
 	require.False(t, store.HasSynced())
 }

--- a/backend/refresh/ingest/manager.go
+++ b/backend/refresh/ingest/manager.go
@@ -72,19 +72,15 @@ type ObjectMapProjector func(obj metav1.Object) interface{}
 // entry is one ingested kind: the reflector that drives intake and the store
 // that holds its projected rows.
 type entry struct {
-	desc      streamspec.Descriptor
-	store     *ProjectingStore
-	reflector *ProjectingReflector
+	desc  streamspec.Descriptor
+	store *ProjectingStore
 
-	// lw is the reflector's ListerWatcher, retained so the stage-3 resume path can issue a
-	// delta WATCH from a persisted resourceVersion through the same source the reflector uses.
-	lw cache.ListerWatcher
-
-	// resumeRV, when set (SetResumeResourceVersion / RestoreStores, before Start), makes Start
-	// attempt a delta resume from this resourceVersion before the reflector's full sync — the
-	// cold-start "resume from persisted RV" path. Empty (the default) launches the reflector
-	// directly, unchanged. It is only set once the store was restored full from disk.
-	resumeRV string
+	// parts are the kind's reflectors: one per configured scope namespace for
+	// a namespaced kind under a namespace scope (docs/plans/namespace-scope.md),
+	// or a single cluster-wide "" part otherwise — the unscoped path is the
+	// same code with a one-element list. All parts feed the ONE shared store
+	// through per-namespace partition views.
+	parts []*ingestPart
 
 	// example is the empty typed object for this kind, retained so registerGobTypes can
 	// project it through the store's projection to discover (and gob.Register) the concrete
@@ -109,13 +105,6 @@ type entry struct {
 	// background, so the store still delivers data if it later syncs.
 	degraded atomic.Bool
 
-	// skipped latches true when Start declines to launch this kind's reflector because
-	// the permission filter reports the identity cannot list/watch it. A skipped kind is
-	// settled immediately (excluded from readiness, empty store) rather than 403-retrying
-	// for the whole sync deadline — mirroring the factory's permission-skip
-	// (informer/factory.go CanListWatch gate).
-	skipped atomic.Bool
-
 	// onDemand marks a reflector added lazily AFTER Start for a dynamic (CRD-backed) kind
 	// the catalog promoted on demand (RegisterDynamicCatalogReflector). On-demand entries
 	// are EXCLUDED from the whole-manager HasSynced gate — they are added once the cluster
@@ -124,11 +113,48 @@ type entry struct {
 	// sync so the catalog can serve-when-synced-else-LIST.
 	onDemand atomic.Bool
 
-	// cancel stops just this entry's reflector. It is set only for on-demand reflectors,
+	// cancel stops just this entry's reflectors. It is set only for on-demand reflectors,
 	// which launch on a context derived from the manager's run context so StopReflectorFor
 	// can tear one down without stopping the rest. Descriptor reflectors run directly on
 	// the run context and leave this nil.
 	cancel context.CancelFunc
+}
+
+// ingestPart is one reflector of an entry: the cluster-wide "" part, or one
+// configured namespace's part under a namespace scope. Each part writes the
+// shared store through its own partition view, so its relists fully define
+// only its own partition.
+type ingestPart struct {
+	namespace string
+	lw        cache.ListerWatcher
+	reflector *ProjectingReflector
+	view      *StorePartitionView
+
+	// resumeRV, when set (RestoreStores, before Start), makes Start attempt a
+	// delta resume of THIS part's watch from the persisted resourceVersion
+	// before the reflector's full sync. Empty launches the reflector directly.
+	resumeRV string
+
+	// skipped latches true when Start declines to launch this part because the
+	// permission filter reports the identity cannot list/watch the kind in the
+	// part's namespace. A skipped part is excluded from the store's expected
+	// partitions, so one denied namespace never blanks or blocks the others.
+	skipped atomic.Bool
+}
+
+// allPartsSkipped reports whether every part of the entry was
+// permission-skipped — the per-kind "permanently empty for this identity"
+// state PermissionSkippedFor exposes.
+func (e *entry) allPartsSkipped() bool {
+	if len(e.parts) == 0 {
+		return false
+	}
+	for _, part := range e.parts {
+		if !part.skipped.Load() {
+			return false
+		}
+	}
+	return true
 }
 
 // IngestManager owns one ProjectingStore + ProjectingReflector per built-in
@@ -164,12 +190,20 @@ type IngestManager struct {
 	startedAtMu  sync.Mutex
 	startedAt    time.Time
 
-	// permissionFilter, when set, reports whether the identity may list+watch a kind.
-	// Start skips (does not launch) the reflector for any kind it returns false for, so
-	// a denied cut kind is excluded from readiness immediately rather than 403-retrying
+	// permissionFilter, when set, reports whether the identity may list+watch a kind
+	// in the given namespace ("" = cluster-wide). Start skips (does not launch) any
+	// part it returns false for, so a denied kind — or a single denied namespace of a
+	// scoped kind — is excluded from readiness immediately rather than 403-retrying
 	// for the whole sync deadline. nil leaves every reflector enabled (the default for
 	// tests and any caller that does not gate on permissions).
-	permissionFilter func(group, resource string) bool
+	permissionFilter func(group, resource, namespace string) bool
+
+	// scope is the cluster's configured namespace scope
+	// (docs/plans/namespace-scope.md); empty means cluster-wide reflectors.
+	scope []string
+	// namespacedGVR reports which registry kinds are namespaced, so only those
+	// fan out over the scope; cluster-scoped kinds always keep one "" part.
+	namespacedGVR map[schema.GroupVersionResource]bool
 }
 
 // NewIngestManager builds an IngestManager for the cluster identified by meta,
@@ -183,20 +217,37 @@ func NewIngestManager(
 	kube kubernetes.Interface,
 	apiext apiextensionsclientset.Interface,
 	gateway gatewayversioned.Interface,
+	allowedNamespaces ...string,
 ) *IngestManager {
+	namespaced := make(map[schema.GroupVersionResource]bool)
+	for _, d := range kindregistry.All {
+		namespaced[d.Identity.GVR()] = d.Identity.Namespaced
+	}
 	m := &IngestManager{
-		meta:         meta,
-		kube:         kube,
-		apiext:       apiext,
-		gateway:      gateway,
-		entries:      make(map[schema.GroupVersionResource]*entry),
-		syncDeadline: config.RefreshInformerSyncDeadline,
-		now:          time.Now,
+		meta:          meta,
+		kube:          kube,
+		apiext:        apiext,
+		gateway:       gateway,
+		entries:       make(map[schema.GroupVersionResource]*entry),
+		syncDeadline:  config.RefreshInformerSyncDeadline,
+		now:           time.Now,
+		scope:         append([]string(nil), allowedNamespaces...),
+		namespacedGVR: namespaced,
 	}
 	for _, desc := range kindregistry.StreamDescriptors() {
 		m.addDescriptor(desc)
 	}
 	return m
+}
+
+// partitionNamespaces returns the namespaces gvr's reflectors run in: the
+// configured scope for a namespaced kind under a namespace scope, otherwise
+// the single cluster-wide "" — the unscoped degenerate of the same loop.
+func (m *IngestManager) partitionNamespaces(gvr schema.GroupVersionResource) []string {
+	if len(m.scope) == 0 || !m.namespacedGVR[gvr] {
+		return []string{""}
+	}
+	return append([]string(nil), m.scope...)
 }
 
 // addDescriptor builds the reflector + projecting store for one streamed kind.
@@ -223,20 +274,34 @@ func (m *IngestManager) addDescriptor(desc streamspec.Descriptor) {
 	m.installReflector(e, gvr, gvk, restClient, example)
 }
 
-// installReflector wires the ListWatch + reflector for an already-built entry whose
-// store is set, then registers the entry under gvr. It is the shared tail of both the
-// generic descriptor path (addDescriptor) and the bespoke-projector path
-// (RegisterReflector), so the ListWatch/WatchList wiring lives in exactly one place.
+// installReflector wires the per-namespace ListWatches + reflectors for an
+// already-built entry whose store is set, then registers the entry under gvr.
+// It is the shared tail of both the generic descriptor path (addDescriptor)
+// and the bespoke-projector path (RegisterReflector), so the ListWatch/
+// WatchList wiring lives in exactly one place. Unscoped (or cluster-scoped
+// kinds) build a single cluster-wide part; a namespace scope fans one part
+// per configured namespace, each writing its own store partition.
 func (m *IngestManager) installReflector(e *entry, gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, restClient rest.Interface, example apiruntime.Object) {
-	lw := cache.NewListWatchFromClient(restClient, gvr.Resource, metav1.NamespaceAll, fields.Everything())
-	// ToListWatcherWithWatchListSemantics lets the reflector use WatchList when the
-	// client advertises support and fall back to LIST+WATCH otherwise — exactly as
-	// the generated informers do. The client argument is the typed group client so
-	// its WatchList capability is detected.
-	wrapped := cache.ToListWatcherWithWatchListSemantics(lw, restClient)
-	e.lw = wrapped
 	e.example = example
-	e.reflector = NewProjectingReflector(gvk.String(), wrapped, example, e.store, resyncDisabled)
+	for _, namespace := range m.partitionNamespaces(gvr) {
+		lw := cache.NewListWatchFromClient(restClient, gvr.Resource, namespace, fields.Everything())
+		// ToListWatcherWithWatchListSemantics lets the reflector use WatchList when the
+		// client advertises support and fall back to LIST+WATCH otherwise — exactly as
+		// the generated informers do. The client argument is the typed group client so
+		// its WatchList capability is detected.
+		wrapped := cache.ToListWatcherWithWatchListSemantics(lw, restClient)
+		name := gvk.String()
+		if namespace != "" {
+			name += " ns=" + namespace
+		}
+		view := e.store.PartitionView(namespace)
+		e.parts = append(e.parts, &ingestPart{
+			namespace: namespace,
+			lw:        wrapped,
+			reflector: NewProjectingReflector(name, wrapped, example, view, resyncDisabled),
+			view:      view,
+		})
+	}
 	m.entries[gvr] = e
 }
 
@@ -285,7 +350,7 @@ func (m *IngestManager) RegisterReflector(gvr schema.GroupVersionResource, gvk s
 // (it is registered after Start) and is EXCLUDED from the whole-manager readiness gate
 // (see entry.onDemand). It returns false when no dynamic client is set, the manager is not
 // started, or an entry for gvr already exists.
-func (m *IngestManager) RegisterDynamicCatalogReflector(gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, project CatalogProjector) bool {
+func (m *IngestManager) RegisterDynamicCatalogReflector(gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, project CatalogProjector, namespaced bool) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.dynamic == nil || m.runCtx == nil {
@@ -298,11 +363,33 @@ func (m *IngestManager) RegisterDynamicCatalogReflector(gvr schema.GroupVersionR
 	e.onDemand.Store(true)
 	example := &unstructuredv1.Unstructured{}
 	example.SetGroupVersionKind(gvk)
-	e.reflector = NewProjectingReflector(gvk.String(), dynamicListWatch(m.dynamic, gvr), example, e.store, resyncDisabled)
+	// A CRD-backed kind is not in the built-in registry, so its scope
+	// fan-out is decided by the caller-supplied namespaced flag.
+	namespaces := []string{""}
+	if namespaced && len(m.scope) > 0 {
+		namespaces = append([]string(nil), m.scope...)
+	}
+	for _, namespace := range namespaces {
+		name := gvk.String()
+		if namespace != "" {
+			name += " ns=" + namespace
+		}
+		view := e.store.PartitionView(namespace)
+		lw := dynamicListWatch(m.dynamic, gvr, namespace)
+		e.parts = append(e.parts, &ingestPart{
+			namespace: namespace,
+			lw:        lw,
+			reflector: NewProjectingReflector(name, lw, example, view, resyncDisabled),
+			view:      view,
+		})
+	}
+	e.store.SetExpectedPartitions(namespaces)
 	m.entries[gvr] = e
 	ctx, cancel := context.WithCancel(m.runCtx)
 	e.cancel = cancel
-	go e.reflector.Run(ctx)
+	for _, part := range e.parts {
+		go part.reflector.Run(ctx)
+	}
 	return true
 }
 
@@ -322,14 +409,18 @@ func (m *IngestManager) StopReflectorFor(gvr schema.GroupVersionResource) {
 	}
 }
 
-// dynamicListWatch builds a ListerWatcher over the dynamic client for gvr across all
-// namespaces — the on-demand dynamic-CRD equivalent of the typed ListWatch
-// NewListWatchFromClient builds in installReflector. The reflector decodes results as
-// *unstructured.Unstructured, which the catalog projection consumes as a metav1.Object.
-// context.Background mirrors NewListWatchFromClient: the reflector stops the returned
-// watch.Interface on ctx-cancel, so the watch is wound down without a per-call context.
-func dynamicListWatch(client dynamic.Interface, gvr schema.GroupVersionResource) cache.ListerWatcher {
-	resource := client.Resource(gvr).Namespace(metav1.NamespaceAll)
+// dynamicListWatch builds a ListerWatcher over the dynamic client for gvr in
+// namespace ("" = all namespaces) — the on-demand dynamic-CRD equivalent of the
+// typed ListWatch NewListWatchFromClient builds in installReflector. The
+// reflector decodes results as *unstructured.Unstructured, which the catalog
+// projection consumes as a metav1.Object. context.Background mirrors
+// NewListWatchFromClient: the reflector stops the returned watch.Interface on
+// ctx-cancel, so the watch is wound down without a per-call context.
+func dynamicListWatch(client dynamic.Interface, gvr schema.GroupVersionResource, namespace string) cache.ListerWatcher {
+	if namespace == "" {
+		namespace = metav1.NamespaceAll
+	}
+	resource := client.Resource(gvr).Namespace(namespace)
 	return &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (apiruntime.Object, error) {
 			return resource.List(context.Background(), options)
@@ -458,9 +549,9 @@ func exampleObjectFor(gvk schema.GroupVersionKind) (apiruntime.Object, bool) {
 }
 
 // SetPermissionFilter installs the predicate Start uses to decide whether to launch
-// each kind's reflector. It must be called before Start. A nil filter (the default)
-// launches every reflector. See permissionFilter.
-func (m *IngestManager) SetPermissionFilter(fn func(group, resource string) bool) {
+// each part's reflector (namespace "" = cluster-wide). It must be called before
+// Start. A nil filter (the default) launches every reflector. See permissionFilter.
+func (m *IngestManager) SetPermissionFilter(fn func(group, resource, namespace string) bool) {
 	m.mu.Lock()
 	m.permissionFilter = fn
 	m.mu.Unlock()
@@ -509,19 +600,38 @@ func (m *IngestManager) Start(ctx context.Context) {
 
 	for _, le := range entries {
 		le := le
-		// Permission-skip: a kind the identity cannot list/watch never launches a
-		// reflector (which would only 403-retry); it is settled-as-skipped so it does
-		// not block readiness and its store stays empty (the domain serves degraded for
-		// that kind), mirroring the factory excluding a denied informer.
-		if filter != nil && !filter(le.gvr.Group, le.gvr.Resource) {
-			le.e.skipped.Store(true)
-			klog.V(2).Infof("ingest: skipping %s — identity cannot list/watch it (logged once)", le.gvr)
-			continue
+		// Permission-skip per part: a kind (or a single scoped namespace of a
+		// kind) the identity cannot list/watch never launches its reflector
+		// (which would only 403-retry); it is excluded from the store's
+		// expected partitions so it does not block readiness — one denied
+		// namespace never blanks or blocks the others, mirroring the factory
+		// excluding a denied informer.
+		launched := make([]string, 0, len(le.e.parts))
+		for _, part := range le.e.parts {
+			if filter != nil && !filter(le.gvr.Group, le.gvr.Resource, part.namespace) {
+				part.skipped.Store(true)
+				if part.namespace == "" {
+					klog.V(2).Infof("ingest: skipping %s — identity cannot list/watch it (logged once)", le.gvr)
+				} else {
+					klog.V(2).Infof("ingest: skipping %s in %q — identity cannot list/watch it there (logged once)", le.gvr, part.namespace)
+				}
+				continue
+			}
+			launched = append(launched, part.namespace)
 		}
-		e := le.e
-		// Resume from a persisted resourceVersion when one was set (the store was restored
-		// full from disk); otherwise — the default — this is exactly e.reflector.Run.
-		go runWithResume(runCtx, e.lw, e.store, e.resumeRV, func() { e.reflector.Run(runCtx) })
+		// Expected partitions must be declared BEFORE any reflector of the
+		// entry runs, so the store's sync gate counts exactly the launched set.
+		le.e.store.SetExpectedPartitions(launched)
+		for _, part := range le.e.parts {
+			if part.skipped.Load() {
+				continue
+			}
+			part := part
+			// Resume from a persisted resourceVersion when one was set (the store was
+			// restored full from disk); otherwise — the default — this is exactly
+			// part.reflector.Run.
+			go runWithResume(runCtx, part.lw, part.view, part.resumeRV, func() { part.reflector.Run(runCtx) })
+		}
 	}
 
 	// One log line when the initial syncs settle, naming the slowest kinds — the
@@ -544,8 +654,15 @@ func (m *IngestManager) SetResumeResourceVersion(gvr schema.GroupVersionResource
 	if !ok {
 		return false
 	}
-	e.resumeRV = rv
-	return true
+	// The legacy single-RV resume applies to the cluster-wide part; scoped
+	// parts resume from their per-partition RVs (RestoreStores).
+	for _, part := range e.parts {
+		if part.namespace == "" {
+			part.resumeRV = rv
+			return true
+		}
+	}
+	return false
 }
 
 // registerGobTypes gob-registers the concrete Bundle-half types every entry projects, by
@@ -639,9 +756,19 @@ func (m *IngestManager) RestoreStores(dir string) {
 		if e.onDemand.Load() {
 			continue
 		}
-		rv, err := e.store.RestoreBundles(filepath.Join(dir, ingestSpillFileName(gvr)))
-		if err == nil && rv != "" {
-			e.resumeRV = rv
+		rv, partitionRVs, err := e.store.RestoreBundles(filepath.Join(dir, ingestSpillFileName(gvr)))
+		if err != nil {
+			continue
+		}
+		for _, part := range e.parts {
+			if part.namespace == "" {
+				// Legacy cluster-wide resume: the store-level RV.
+				part.resumeRV = rv
+				continue
+			}
+			// A scoped part resumes only from ITS namespace's persisted RV; a
+			// missing entry (scope changed since the spill) means full sync.
+			part.resumeRV = partitionRVs[part.namespace]
 		}
 	}
 }
@@ -702,7 +829,7 @@ func (m *IngestManager) HasSynced() bool {
 // LIST+WATCH in the background, so HasSynced still reflects a later real sync — the
 // degrade only stops it BLOCKING the initial gate.
 func (m *IngestManager) entrySettled(e *entry) bool {
-	if e.skipped.Load() {
+	if e.allPartsSkipped() {
 		// Permission-skipped: reflector never launched, store stays empty; settled so it
 		// does not block readiness (the domain serves degraded for this kind).
 		return true
@@ -975,7 +1102,7 @@ func (m *IngestManager) PermissionSkippedFor(gvr schema.GroupVersionResource) bo
 	if !ok {
 		return false
 	}
-	return e.skipped.Load()
+	return e.allPartsSkipped()
 }
 
 // resyncDisabled documents that ingest reflectors run with no periodic resync:

--- a/backend/refresh/ingest/manager_dynamic_test.go
+++ b/backend/refresh/ingest/manager_dynamic_test.go
@@ -89,9 +89,9 @@ func TestRegisterDynamicCatalogReflectorServesCatalogRows(t *testing.T) {
 	project := func(o metav1.Object) interface{} {
 		return dynCatRow{Namespace: o.GetNamespace(), Name: o.GetName()}
 	}
-	require.True(t, m.RegisterDynamicCatalogReflector(gvr, gvk, project),
+	require.True(t, m.RegisterDynamicCatalogReflector(gvr, gvk, project, true),
 		"first registration of a dynamic reflector should succeed")
-	require.False(t, m.RegisterDynamicCatalogReflector(gvr, gvk, project),
+	require.False(t, m.RegisterDynamicCatalogReflector(gvr, gvk, project, true),
 		"re-registering the same gvr should be a no-op")
 
 	require.Eventually(t, func() bool { return m.HasSyncedFor(gvr) }, 2*time.Second, 10*time.Millisecond,
@@ -150,7 +150,7 @@ func TestStopReflectorForEvicts(t *testing.T) {
 
 	m := newStartedDynamicManager(ctx, dyn)
 	project := func(o metav1.Object) interface{} { return dynCatRow{Namespace: o.GetNamespace(), Name: o.GetName()} }
-	require.True(t, m.RegisterDynamicCatalogReflector(gvr, gvk, project))
+	require.True(t, m.RegisterDynamicCatalogReflector(gvr, gvk, project, true))
 	require.Eventually(t, func() bool { return m.HasSyncedFor(gvr) }, 2*time.Second, 10*time.Millisecond)
 
 	m.StopReflectorFor(gvr)

--- a/backend/refresh/ingest/manager_readiness_test.go
+++ b/backend/refresh/ingest/manager_readiness_test.go
@@ -78,7 +78,7 @@ func TestIngestManagerSkipsDeniedKindsAtStart(t *testing.T) {
 		t.Fatal("need at least two entries to exercise deny-one/allow-one")
 	}
 	// Deny exactly one kind; allow everything else.
-	mgr.SetPermissionFilter(func(group, resource string) bool {
+	mgr.SetPermissionFilter(func(group, resource, _ string) bool {
 		return !(group == deniedGVR.Group && resource == deniedGVR.Resource)
 	})
 	mgr.now = func() time.Time { return time.Unix(1_700_000_000, 0) }
@@ -115,7 +115,7 @@ func TestIngestManagerPermissionSkippedFor(t *testing.T) {
 	if deniedGVR.Resource == "" || allowedGVR.Resource == "" {
 		t.Fatal("need at least two entries to exercise deny-one/allow-one")
 	}
-	mgr.SetPermissionFilter(func(group, resource string) bool {
+	mgr.SetPermissionFilter(func(group, resource, _ string) bool {
 		return !(group == deniedGVR.Group && resource == deniedGVR.Resource)
 	})
 	mgr.now = func() time.Time { return time.Unix(1_700_000_000, 0) }

--- a/backend/refresh/ingest/manager_scope_test.go
+++ b/backend/refresh/ingest/manager_scope_test.go
@@ -1,0 +1,85 @@
+package ingest
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var clusterRoleGVR = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"}
+
+// Namespace-scoped ingestion end-to-end (docs/plans/namespace-scope.md): a
+// scoped manager runs one reflector per configured namespace through the
+// production LIST/WATCH path and converges each kind's shared store on
+// exactly the scope's objects.
+
+func TestScopedIngestManagerFansReflectorsPerNamespace(t *testing.T) {
+	server := newTrackerAPIServer(t)
+	server.add(t, newCM("prod", "in-prod"), configMapGVK)
+	server.add(t, newCM("dev", "in-dev"), configMapGVK)
+	server.add(t, newCM("other", "outside-scope"), configMapGVK)
+
+	httpSrv := httptest.NewServer(server)
+	defer httpSrv.Close()
+	kube := newKubeClientFor(t, httpSrv)
+
+	mgr := NewIngestManager(testMeta, kube, nil, nil, "prod", "dev")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mgr.Start(ctx)
+	waitForManagerSynced(t, mgr)
+
+	cmStore := mgr.StoreFor(configMapGVR)
+	require.NotNil(t, cmStore)
+	got := waitForNames(t, cmStore, []string{"dev/in-dev", "prod/in-prod"})
+	require.ElementsMatch(t, []string{"dev/in-dev", "prod/in-prod"}, got,
+		"scoped store must hold exactly the configured namespaces' objects")
+}
+
+func TestScopedIngestPartitionNamespaces(t *testing.T) {
+	server := newTrackerAPIServer(t)
+	httpSrv := httptest.NewServer(server)
+	defer httpSrv.Close()
+	kube := newKubeClientFor(t, httpSrv)
+
+	mgr := NewIngestManager(testMeta, kube, nil, nil, "prod", "dev")
+
+	require.Equal(t, []string{"prod", "dev"}, mgr.partitionNamespaces(configMapGVR),
+		"namespaced kinds fan out over the scope")
+	require.Equal(t, []string{""}, mgr.partitionNamespaces(clusterRoleGVR),
+		"cluster-scoped kinds keep the single cluster-wide reflector")
+
+	unscoped := NewIngestManager(testMeta, kube, nil, nil)
+	require.Equal(t, []string{""}, unscoped.partitionNamespaces(configMapGVR),
+		"no scope degenerates to today's single reflector")
+}
+
+func TestScopedIngestPermissionSkipsOnlyDeniedNamespaces(t *testing.T) {
+	server := newTrackerAPIServer(t)
+	server.add(t, newCM("prod", "in-prod"), configMapGVK)
+	server.add(t, newCM("dev", "in-dev"), configMapGVK)
+
+	httpSrv := httptest.NewServer(server)
+	defer httpSrv.Close()
+	kube := newKubeClientFor(t, httpSrv)
+
+	mgr := NewIngestManager(testMeta, kube, nil, nil, "prod", "dev")
+	mgr.SetPermissionFilter(func(_, _, namespace string) bool {
+		return namespace != "prod" // prod denied, dev (and cluster-wide "") allowed
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mgr.Start(ctx)
+	waitForManagerSynced(t, mgr)
+
+	cmStore := mgr.StoreFor(configMapGVR)
+	require.NotNil(t, cmStore)
+	got := waitForNames(t, cmStore, []string{"dev/in-dev"})
+	require.ElementsMatch(t, []string{"dev/in-dev"}, got,
+		"one denied namespace must not blank the allowed ones")
+	require.False(t, mgr.PermissionSkippedFor(configMapGVR),
+		"a kind with at least one running partition is not permission-skipped")
+}

--- a/backend/refresh/ingest/partition.go
+++ b/backend/refresh/ingest/partition.go
@@ -1,0 +1,207 @@
+package ingest
+
+import (
+	"strings"
+
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+// Namespace-partitioned ingestion (docs/plans/namespace-scope.md): a scoped
+// cluster runs one reflector per configured namespace against ONE shared
+// ProjectingStore. Each reflector writes through a partition view, so
+// client-go's "Replace fully defines the store" contract holds per
+// PARTITION: a relist in one namespace drops only that namespace's vanished
+// keys and can never wipe sibling namespaces' rows (the multi-kind unscoped
+// BundleSink wipe class, one level deeper). The unscoped path is the same
+// code with a single "" partition, which degenerates to the classic
+// full-store Replace — one code path, scope as a value.
+
+// SetExpectedPartitions declares the namespaces whose reflectors feed this
+// store. Once set, HasSynced reports true only when EVERY expected partition
+// has completed its initial relist (or was marked synced by a resume) — the
+// per-partition equivalent of "the initial relist landed". Call before the
+// reflectors start. Unset (nil) keeps the classic single-source behavior.
+func (s *ProjectingStore) SetExpectedPartitions(namespaces []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.expectedPartitions = append([]string(nil), namespaces...)
+	if s.syncedPartitions == nil {
+		s.syncedPartitions = make(map[string]struct{}, len(namespaces))
+	}
+}
+
+// PartitionView returns the cache.Store a single namespace's reflector writes
+// through. namespace "" is the cluster-wide view (classic Replace semantics).
+func (s *ProjectingStore) PartitionView(namespace string) *StorePartitionView {
+	return &StorePartitionView{store: s, namespace: namespace}
+}
+
+// ReplacePartition is Replace scoped to one namespace partition: the supplied
+// list fully defines that namespace's rows; every other namespace's rows are
+// untouched. Sinks receive the partition's vanished keys as deletes and its
+// new set as per-row upserts — never a bulk kind-wide Replace, because the
+// bulk sink contract ("full state for the kind") would make the consumer drop
+// sibling namespaces' rows. namespace "" delegates to the classic Replace.
+func (s *ProjectingStore) ReplacePartition(namespace string, list []interface{}, resourceVersion string) error {
+	if namespace == "" {
+		if err := s.Replace(list, resourceVersion); err != nil {
+			return err
+		}
+		s.mu.Lock()
+		s.markPartitionSyncedLocked("")
+		s.mu.Unlock()
+		return nil
+	}
+
+	next := make(map[string]interface{}, len(list))
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, obj := range list {
+		key, err := keyOf(obj)
+		if err != nil {
+			return cache.KeyError{Obj: obj, Err: err}
+		}
+		projected, err := s.project(obj)
+		if err != nil {
+			if !s.projectErrLogged {
+				s.projectErrLogged = true
+				klog.V(2).Infof("ingest: projection failed for %q during partition replace, skipping (logged once): %v", key, err)
+			}
+			continue
+		}
+		next[key] = projected
+	}
+
+	prefix := namespace + "/"
+	if s.hasSinks() {
+		// Deletes first (vanished keys fan the PREVIOUS stored bundle, whose
+		// Catalog half is retained, so catalog-keyed consumers evict ghosts),
+		// then per-row upserts — feedSinksReplace minus the bulk path.
+		for key, stored := range s.rows {
+			if !strings.HasPrefix(key, prefix) {
+				continue
+			}
+			if _, kept := next[key]; kept {
+				continue
+			}
+			s.emitDelete(stored)
+		}
+		for _, projected := range next {
+			s.emitUpsert(projected)
+		}
+	}
+
+	for key := range s.rows {
+		if strings.HasPrefix(key, prefix) {
+			delete(s.rows, key)
+		}
+	}
+	for key, projected := range next {
+		s.rows[key] = s.storedValue(projected)
+	}
+	if s.partitionRVs == nil {
+		s.partitionRVs = make(map[string]string)
+	}
+	s.partitionRVs[namespace] = resourceVersion
+	s.rv = resourceVersion
+	s.markPartitionSyncedLocked(namespace)
+	s.rebuildIndexesLocked()
+	return nil
+}
+
+// MarkPartitionSynced is MarkSynced for one partition — the stage-3 resume
+// path of a scoped reflector whose baseline came from a restored spill.
+func (s *ProjectingStore) MarkPartitionSynced(namespace string) {
+	s.mu.Lock()
+	s.markPartitionSyncedLocked(namespace)
+	s.mu.Unlock()
+}
+
+// markPartitionSyncedLocked records the partition's initial sync and, once
+// every expected partition has landed, latches the store-level synced flag
+// (stamping syncedAt exactly once). Callers hold the write lock.
+func (s *ProjectingStore) markPartitionSyncedLocked(namespace string) {
+	if s.syncedPartitions == nil {
+		s.syncedPartitions = make(map[string]struct{})
+	}
+	s.syncedPartitions[namespace] = struct{}{}
+	if len(s.expectedPartitions) == 0 {
+		// No declared partitions: store-level sync is owned by the classic
+		// Replace/MarkSynced path.
+		return
+	}
+	for _, expected := range s.expectedPartitions {
+		if _, ok := s.syncedPartitions[expected]; !ok {
+			return
+		}
+	}
+	s.markSyncedLocked()
+}
+
+// BookmarkPartition records a watch bookmark for one partition's resume
+// bookkeeping (and advances the store-level RV like Bookmark).
+func (s *ProjectingStore) BookmarkPartition(namespace, rv string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.partitionRVs == nil {
+		s.partitionRVs = make(map[string]string)
+	}
+	s.partitionRVs[namespace] = rv
+	s.rv = rv
+}
+
+// PartitionResourceVersions returns the latest per-partition resource
+// versions (spill/resume bookkeeping for scoped reflectors).
+func (s *ProjectingStore) PartitionResourceVersions() map[string]string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make(map[string]string, len(s.partitionRVs))
+	for ns, rv := range s.partitionRVs {
+		out[ns] = rv
+	}
+	return out
+}
+
+// StorePartitionView is the cache.Store one scoped reflector writes through:
+// per-object mutations pass straight to the shared store; Replace, MarkSynced,
+// and Bookmark are scoped to the view's namespace partition.
+type StorePartitionView struct {
+	store     *ProjectingStore
+	namespace string
+}
+
+var _ cache.Store = (*StorePartitionView)(nil)
+
+func (v *StorePartitionView) Add(obj interface{}) error    { return v.store.Add(obj) }
+func (v *StorePartitionView) Update(obj interface{}) error { return v.store.Update(obj) }
+func (v *StorePartitionView) Delete(obj interface{}) error { return v.store.Delete(obj) }
+func (v *StorePartitionView) List() []interface{}          { return v.store.List() }
+func (v *StorePartitionView) ListKeys() []string           { return v.store.ListKeys() }
+func (v *StorePartitionView) Get(obj interface{}) (interface{}, bool, error) {
+	return v.store.Get(obj)
+}
+func (v *StorePartitionView) GetByKey(key string) (interface{}, bool, error) {
+	return v.store.GetByKey(key)
+}
+func (v *StorePartitionView) Resync() error { return v.store.Resync() }
+
+func (v *StorePartitionView) Replace(list []interface{}, resourceVersion string) error {
+	return v.store.ReplacePartition(v.namespace, list, resourceVersion)
+}
+
+func (v *StorePartitionView) MarkSynced() {
+	v.store.MarkPartitionSynced(v.namespace)
+}
+
+func (v *StorePartitionView) Bookmark(rv string) {
+	v.store.BookmarkPartition(v.namespace, rv)
+}
+
+// LastStoreSyncResourceVersion reports the view's partition RV so a reflector
+// relist resumes from ITS namespace's version, not a sibling's.
+func (v *StorePartitionView) LastStoreSyncResourceVersion() string {
+	v.store.mu.RLock()
+	defer v.store.mu.RUnlock()
+	return v.store.partitionRVs[v.namespace]
+}

--- a/backend/refresh/ingest/partition_test.go
+++ b/backend/refresh/ingest/partition_test.go
@@ -1,0 +1,117 @@
+package ingest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Namespace-scoped ingest (docs/plans/namespace-scope.md) runs one reflector
+// per configured namespace against ONE shared store. Each reflector writes
+// through a partition view, so client-go's "Replace = full state" contract
+// holds per partition: a relist in one namespace must never wipe sibling
+// namespaces' rows — the same bug class as the multi-kind unscoped
+// BundleSink wipe, one level deeper.
+
+func projectBundle(obj interface{}) (interface{}, error) {
+	projected, err := projectConfigMap(obj)
+	if err != nil {
+		return nil, err
+	}
+	return Bundle{Table: projected, Catalog: projected}, nil
+}
+
+// partitionRecordingSink implements both the incremental and the bulk-replace
+// sink contracts, so a test can prove which path a partition replace used.
+type partitionRecordingSink struct {
+	upserts  []Bundle
+	deletes  []Bundle
+	replaces [][]Bundle
+}
+
+func (s *partitionRecordingSink) UpsertBundle(b Bundle)        { s.upserts = append(s.upserts, b) }
+func (s *partitionRecordingSink) DeleteBundle(b Bundle)        { s.deletes = append(s.deletes, b) }
+func (s *partitionRecordingSink) ReplaceBundles(rows []Bundle) { s.replaces = append(s.replaces, rows) }
+
+func TestReplacePartitionDoesNotWipeSiblingNamespaces(t *testing.T) {
+	store := NewProjectingStore(projectConfigMap)
+	store.SetExpectedPartitions([]string{"prod", "dev"})
+	prod := store.PartitionView("prod")
+	dev := store.PartitionView("dev")
+
+	require.NoError(t, prod.Replace([]interface{}{configMap("prod", "a")}, "10"))
+	require.False(t, store.HasSynced(), "one of two partitions synced must not report store synced")
+	require.NoError(t, dev.Replace([]interface{}{configMap("dev", "b")}, "12"))
+	require.True(t, store.HasSynced())
+	require.ElementsMatch(t, []string{"prod/a", "dev/b"}, store.ListKeys())
+
+	// The wipe-class case: a relist in prod fully defines PROD ONLY.
+	require.NoError(t, prod.Replace([]interface{}{configMap("prod", "c")}, "15"))
+	require.ElementsMatch(t, []string{"prod/c", "dev/b"}, store.ListKeys(),
+		"prod relist must drop prod/a but never touch dev rows")
+}
+
+func TestReplacePartitionEmitsPerRowSinkEventsNotBulkReplace(t *testing.T) {
+	store := NewProjectingStore(projectBundle)
+	store.SetExpectedPartitions([]string{"prod", "dev"})
+	prod := store.PartitionView("prod")
+	dev := store.PartitionView("dev")
+	require.NoError(t, prod.Replace([]interface{}{configMap("prod", "a")}, "10"))
+	require.NoError(t, dev.Replace([]interface{}{configMap("dev", "b")}, "11"))
+
+	sink := &partitionRecordingSink{}
+	store.AddBundleSink(sink)
+	sink.upserts = nil
+	sink.replaces = nil
+
+	// prod relist: a vanishes, c appears. The bulk ReplaceBundles contract is
+	// "full state for the kind" — a partition must never use it, or the sink
+	// (maintained store) would drop dev's rows.
+	require.NoError(t, prod.Replace([]interface{}{configMap("prod", "c")}, "15"))
+
+	require.Empty(t, sink.replaces, "partition replace must not emit a bulk kind-wide Replace")
+	require.Len(t, sink.deletes, 1)
+	// Deletes fan the PREVIOUS stored bundle: its Table half was dropped at
+	// store time (retainTable=false), its Catalog half is retained so
+	// catalog-keyed consumers can evict the ghost.
+	require.Equal(t, row{NS: "prod", Name: "a"}, sink.deletes[0].Catalog)
+	require.Len(t, sink.upserts, 1)
+	require.Equal(t, row{NS: "prod", Name: "c"}, sink.upserts[0].Table, "upserts fan the FULL projected value")
+}
+
+func TestPartitionViewMarkSyncedMarksOnlyItsPartition(t *testing.T) {
+	store := NewProjectingStore(projectConfigMap)
+	store.SetExpectedPartitions([]string{"prod", "dev"})
+
+	store.PartitionView("prod").MarkSynced()
+	require.False(t, store.HasSynced())
+	store.PartitionView("dev").MarkSynced()
+	require.True(t, store.HasSynced())
+}
+
+func TestClusterWidePartitionViewKeepsBulkReplaceSemantics(t *testing.T) {
+	// The unscoped path is the same code with a single "" partition: full
+	// Replace semantics, including the bulk sink fan-out.
+	store := NewProjectingStore(projectBundle)
+	view := store.PartitionView("")
+	require.NoError(t, view.Replace([]interface{}{configMap("prod", "a")}, "10"))
+
+	sink := &partitionRecordingSink{}
+	store.AddBundleSink(sink)
+	sink.replaces = nil
+
+	require.NoError(t, view.Replace([]interface{}{configMap("dev", "b")}, "12"))
+	require.Len(t, sink.replaces, 1, "cluster-wide replace keeps the bulk sink path")
+	require.True(t, store.HasSynced())
+	require.ElementsMatch(t, []string{"dev/b"}, store.ListKeys(), "cluster-wide replace fully defines the store")
+}
+
+func TestPartitionResourceVersionsTrackPerPartition(t *testing.T) {
+	store := NewProjectingStore(projectConfigMap)
+	store.SetExpectedPartitions([]string{"prod", "dev"})
+	require.NoError(t, store.PartitionView("prod").Replace([]interface{}{configMap("prod", "a")}, "10"))
+	require.NoError(t, store.PartitionView("dev").Replace([]interface{}{configMap("dev", "b")}, "12"))
+
+	rvs := store.PartitionResourceVersions()
+	require.Equal(t, map[string]string{"prod": "10", "dev": "12"}, rvs)
+}

--- a/backend/refresh/ingest/projecting_reflector.go
+++ b/backend/refresh/ingest/projecting_reflector.go
@@ -15,7 +15,7 @@ import (
 // landing in a typed indexer.
 type ProjectingReflector struct {
 	reflector *cache.Reflector
-	store     *ProjectingStore
+	store     cache.Store
 }
 
 // NewProjectingReflector wraps cache.NewNamedReflector over lw, feeding the
@@ -23,7 +23,9 @@ type ProjectingReflector struct {
 // &corev1.ConfigMap{}); resync is the relist period (0 disables periodic
 // resync). It stays thin: no event handling or projection lives here — the
 // store performs the projection on every Add/Update/Replace the reflector makes.
-func NewProjectingReflector(name string, lw cache.ListerWatcher, exampleObject apiruntime.Object, store *ProjectingStore, resync time.Duration) *ProjectingReflector {
+// store is the cache.Store the reflector feeds: a ProjectingStore, or one
+// namespace's StorePartitionView under a namespace scope.
+func NewProjectingReflector(name string, lw cache.ListerWatcher, exampleObject apiruntime.Object, store cache.Store, resync time.Duration) *ProjectingReflector {
 	return &ProjectingReflector{
 		reflector: cache.NewNamedReflector(name, lw, exampleObject, store, resync),
 		store:     store,
@@ -37,8 +39,8 @@ func (r *ProjectingReflector) Run(ctx context.Context) {
 	r.reflector.Run(ctx.Done())
 }
 
-// Store returns the ProjectingStore the reflector feeds. Consumers read the
+// Store returns the cache.Store the reflector feeds. Consumers read the
 // projected rows from it; they never see the source objects.
-func (r *ProjectingReflector) Store() *ProjectingStore {
+func (r *ProjectingReflector) Store() cache.Store {
 	return r.store
 }

--- a/backend/refresh/ingest/projecting_store.go
+++ b/backend/refresh/ingest/projecting_store.go
@@ -31,6 +31,11 @@ import (
 type spilledBundles struct {
 	Rows map[string]Bundle
 	RV   string
+	// PartitionRVs are the per-namespace resource versions of a scoped
+	// store's partitions (docs/plans/namespace-scope.md), so each scoped
+	// reflector resumes from ITS namespace's persisted RV. Empty for
+	// unscoped spills; gob ignores it when absent from old files.
+	PartitionRVs map[string]string
 }
 
 // ProjectFunc maps a Kubernetes object to its projected row (any type). It is
@@ -149,6 +154,14 @@ type ProjectingStore struct {
 	// projectErrLogged ensures a recurring projection failure is logged once,
 	// matching the repo rule that recurring identical errors log exactly once.
 	projectErrLogged bool
+
+	// expectedPartitions/syncedPartitions/partitionRVs support the
+	// namespace-partitioned scoped ingest path (partition.go,
+	// docs/plans/namespace-scope.md). Unset for the classic single-reflector
+	// store — every field's zero value preserves pre-scope behavior.
+	expectedPartitions []string
+	syncedPartitions   map[string]struct{}
+	partitionRVs       map[string]string
 
 	// retainTable keeps the Bundle's Table half in the STORED row when true; when false
 	// (the default) the Table half is dropped from the stored bundle after it has been
@@ -819,6 +832,12 @@ func (s *ProjectingStore) HasSynced() bool {
 func (s *ProjectingStore) SpillBundles(path string) error {
 	s.mu.RLock()
 	snap := spilledBundles{Rows: make(map[string]Bundle, len(s.rows)), RV: s.rv}
+	if len(s.partitionRVs) > 0 {
+		snap.PartitionRVs = make(map[string]string, len(s.partitionRVs))
+		for ns, rv := range s.partitionRVs {
+			snap.PartitionRVs[ns] = rv
+		}
+	}
 	for key, row := range s.rows {
 		if b, ok := row.(Bundle); ok {
 			snap.Rows[key] = b
@@ -854,15 +873,15 @@ func (s *ProjectingStore) SpillBundles(path string) error {
 // fine, but a sink consumer that needs the FULL baseline and has no independent restore must
 // seed itself from the store's rows once it observes sync — see NamespaceWorkloadTracker,
 // which would otherwise miss every restored workload and wrongly dim active namespaces.
-func (s *ProjectingStore) RestoreBundles(path string) (string, error) {
+func (s *ProjectingStore) RestoreBundles(path string) (string, map[string]string, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return "", fmt.Errorf("ingest: restore open %q: %w", path, err)
+		return "", nil, fmt.Errorf("ingest: restore open %q: %w", path, err)
 	}
 	defer f.Close()
 	var snap spilledBundles
 	if err := gob.NewDecoder(bufio.NewReader(f)).Decode(&snap); err != nil {
-		return "", fmt.Errorf("ingest: restore decode %q: %w", path, err)
+		return "", nil, fmt.Errorf("ingest: restore decode %q: %w", path, err)
 	}
 
 	s.mu.Lock()
@@ -872,9 +891,15 @@ func (s *ProjectingStore) RestoreBundles(path string) (string, error) {
 	}
 	s.rebuildIndexesLocked()
 	s.rv = snap.RV
+	if len(snap.PartitionRVs) > 0 {
+		s.partitionRVs = make(map[string]string, len(snap.PartitionRVs))
+		for ns, rv := range snap.PartitionRVs {
+			s.partitionRVs[ns] = rv
+		}
+	}
 	s.markSyncedLocked()
 	s.mu.Unlock()
-	return snap.RV, nil
+	return snap.RV, snap.PartitionRVs, nil
 }
 
 // MarkSynced flips the store's synced flag without a Replace, for the stage-3 resume path:

--- a/backend/refresh/ingest/resume.go
+++ b/backend/refresh/ingest/resume.go
@@ -39,7 +39,7 @@ const (
 // readiness). A 410/expired at watch-start, a closed watch, or a watch Error event returns
 // resumeNeedsFullSync WITHOUT having relied on the baseline being current; ctx cancellation
 // returns resumeContextDone.
-func resumeFromResourceVersion(ctx context.Context, lw cache.ListerWatcher, store *ProjectingStore, startRV string) resumeOutcome {
+func resumeFromResourceVersion(ctx context.Context, lw cache.ListerWatcher, store resumeTarget, startRV string) resumeOutcome {
 	w, err := cache.ToListerWatcherWithContext(lw).WatchWithContext(ctx, metav1.ListOptions{
 		ResourceVersion:     startRV,
 		AllowWatchBookmarks: true,
@@ -89,7 +89,17 @@ func resumeFromResourceVersion(ctx context.Context, lw cache.ListerWatcher, stor
 // watch), it falls back to fullSync — the reflector's full LIST+WATCH, which also reconciles
 // anything a stale baseline still held (stage 4). With resumeRV == "" this is exactly the
 // reflector's normal launch, so the default (no persisted RV yet) path is unchanged.
-func runWithResume(ctx context.Context, lw cache.ListerWatcher, store *ProjectingStore, resumeRV string, fullSync func()) {
+// resumeTarget is the store surface the resume path writes: the classic
+// *ProjectingStore, or one namespace's StorePartitionView under a scope —
+// MarkSynced/Bookmark then apply to that partition only.
+type resumeTarget interface {
+	Add(obj interface{}) error
+	Delete(obj interface{}) error
+	Bookmark(rv string)
+	MarkSynced()
+}
+
+func runWithResume(ctx context.Context, lw cache.ListerWatcher, store resumeTarget, resumeRV string, fullSync func()) {
 	if resumeRV != "" && lw != nil {
 		if resumeFromResourceVersion(ctx, lw, store, resumeRV) == resumeContextDone {
 			return

--- a/backend/refresh/metrics/poller.go
+++ b/backend/refresh/metrics/poller.go
@@ -121,6 +121,14 @@ type Poller struct {
 
 	nodeLister func(context.Context, *metricsclient.Clientset) (*metricsv1beta1.NodeMetricsList, error)
 	podLister  func(context.Context, *metricsclient.Clientset) (*metricsv1beta1.PodMetricsList, error)
+	// podNamespaceLister lists one namespace's pod metrics ("" = cluster-wide);
+	// podLister fans it over the configured scope (injectable in tests).
+	podNamespaceLister func(context.Context, *metricsclient.Clientset, string) (*metricsv1beta1.PodMetricsList, error)
+	// allowedNamespaces is the cluster's namespace scope
+	// (docs/plans/namespace-scope.md): non-empty makes the pod-metrics list
+	// run per configured namespace, with one failing namespace skipped
+	// instead of blanking the others. Node metrics stay cluster-scoped.
+	allowedNamespaces []string
 
 	// observerMu guards collectionObserver. The observer is notified after every
 	// SUCCESSFUL collection (the metric doorbell rides it); failures do not
@@ -183,8 +191,51 @@ func NewPoller(client *metricsclient.Clientset, restConfig *rest.Config, interva
 		telemetry:    recorder,
 	}
 	p.nodeLister = p.listNodeMetricsWithRetry
-	p.podLister = p.listPodMetricsWithRetry
+	p.podNamespaceLister = p.listPodMetricsInNamespaceWithRetry
+	p.podLister = p.listPodMetricsScoped
 	return p
+}
+
+// SetAllowedNamespaces configures the cluster's namespace scope
+// (docs/plans/namespace-scope.md). Call before Start.
+func (p *Poller) SetAllowedNamespaces(namespaces []string) {
+	if p == nil {
+		return
+	}
+	p.allowedNamespaces = append([]string(nil), namespaces...)
+}
+
+// listPodMetricsScoped fans the pod-metrics list over the configured scope
+// (one per-namespace list each), merging the successes: a namespace the
+// identity cannot read is logged and skipped, never blanking the others. The
+// unscoped path is the same loop with a single cluster-wide "" entry. It
+// fails only when EVERY namespace fails, so the poller's failure accounting
+// still fires when nothing at all is readable.
+func (p *Poller) listPodMetricsScoped(ctx context.Context, client *metricsclient.Clientset) (*metricsv1beta1.PodMetricsList, error) {
+	namespaces := []string{""}
+	if len(p.allowedNamespaces) > 0 {
+		namespaces = p.allowedNamespaces
+	}
+	merged := &metricsv1beta1.PodMetricsList{}
+	var firstErr error
+	succeeded := false
+	for _, namespace := range namespaces {
+		resp, err := p.podNamespaceLister(ctx, client, namespace)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		succeeded = true
+		if resp != nil {
+			merged.Items = append(merged.Items, resp.Items...)
+		}
+	}
+	if !succeeded {
+		return nil, firstErr
+	}
+	return merged, nil
 }
 
 // LatestNodeUsage returns a copy of the most recent node usage map.
@@ -397,7 +448,7 @@ func (p *Poller) listNodeMetricsWithRetry(ctx context.Context, client *metricscl
 	}
 }
 
-func (p *Poller) listPodMetricsWithRetry(ctx context.Context, client *metricsclient.Clientset) (*metricsv1beta1.PodMetricsList, error) {
+func (p *Poller) listPodMetricsInNamespaceWithRetry(ctx context.Context, client *metricsclient.Clientset, namespace string) (*metricsv1beta1.PodMetricsList, error) {
 	var attempt int
 	backoff := config.MetricsInitialBackoff
 
@@ -406,7 +457,7 @@ func (p *Poller) listPodMetricsWithRetry(ctx context.Context, client *metricscli
 			return nil, ctx.Err()
 		}
 
-		resp, err := client.MetricsV1beta1().PodMetricses("").List(ctx, metav1.ListOptions{})
+		resp, err := client.MetricsV1beta1().PodMetricses(namespace).List(ctx, metav1.ListOptions{})
 		if err == nil {
 			return resp, nil
 		}

--- a/backend/refresh/metrics/poller_test.go
+++ b/backend/refresh/metrics/poller_test.go
@@ -403,3 +403,50 @@ func TestDisabledPollerMetadata(t *testing.T) {
 	custom := NewDisabledPoller(nil, "cluster has no metrics API")
 	require.Equal(t, "cluster has no metrics API", custom.Metadata().LastError)
 }
+
+// Scoped clusters (docs/plans/namespace-scope.md): pod metrics are listed per
+// configured namespace — a scoped identity cannot list metrics cluster-wide —
+// and one failing namespace must not blank the others' usage.
+func TestScopedPollerListsPodMetricsPerNamespace(t *testing.T) {
+	poller := NewPoller(nil, nil, time.Hour, nil)
+	poller.SetAllowedNamespaces([]string{"prod", "dev"})
+
+	var listed []string
+	poller.podNamespaceLister = func(_ context.Context, _ *metricsclient.Clientset, namespace string) (*metricsv1beta1.PodMetricsList, error) {
+		listed = append(listed, namespace)
+		if namespace == "dev" {
+			return nil, errors.New("forbidden")
+		}
+		return &metricsv1beta1.PodMetricsList{Items: []metricsv1beta1.PodMetrics{{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "pod-a"},
+		}}}, nil
+	}
+
+	resp, err := poller.podLister(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("one failing namespace must not fail the scoped pod-metrics list: %v", err)
+	}
+	if len(listed) != 2 || listed[0] != "prod" || listed[1] != "dev" {
+		t.Fatalf("expected per-namespace lists over the scope, got %v", listed)
+	}
+	if len(resp.Items) != 1 || resp.Items[0].Namespace != "prod" {
+		t.Fatalf("expected the successful namespace's items, got %#v", resp.Items)
+	}
+}
+
+func TestUnscopedPollerKeepsClusterWidePodList(t *testing.T) {
+	poller := NewPoller(nil, nil, time.Hour, nil)
+
+	var namespaces []string
+	poller.podNamespaceLister = func(_ context.Context, _ *metricsclient.Clientset, namespace string) (*metricsv1beta1.PodMetricsList, error) {
+		namespaces = append(namespaces, namespace)
+		return &metricsv1beta1.PodMetricsList{}, nil
+	}
+
+	if _, err := poller.podLister(context.Background(), nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(namespaces) != 1 || namespaces[0] != "" {
+		t.Fatalf("unscoped poller must issue exactly one cluster-wide list, got %v", namespaces)
+	}
+}

--- a/backend/refresh/permissions/checker.go
+++ b/backend/refresh/permissions/checker.go
@@ -24,8 +24,10 @@ type ListWatchChecker interface {
 	CanListWatch(group, resource string) bool
 }
 
-// AccessReviewFunc issues a SelfSubjectAccessReview for the specified resource verb.
-type AccessReviewFunc func(ctx context.Context, group, resource, verb string) (bool, error)
+// AccessReviewFunc issues a SelfSubjectAccessReview for the specified resource
+// verb. namespace scopes the review to one namespace; empty means
+// cluster-wide (exactly the pre-scope behavior).
+type AccessReviewFunc func(ctx context.Context, group, resource, verb, namespace string) (bool, error)
 
 // DecisionSource describes how a permission decision was obtained.
 type DecisionSource string
@@ -62,6 +64,11 @@ type Checker struct {
 	mu      sync.RWMutex
 	cache   map[string]cacheEntry
 	sfGroup singleflight.Group // deduplicates concurrent SSAR calls for the same key
+
+	// scope + scopeApplies configure the cluster's namespace scope
+	// (docs/plans/namespace-scope.md); see SetScope.
+	scope        []string
+	scopeApplies func(group, resource string) bool
 }
 
 // NewChecker constructs a permission checker backed by the Kubernetes client.
@@ -70,7 +77,7 @@ func NewChecker(client kubernetes.Interface, clusterID string, ttl time.Duration
 		ttl = config.PermissionCacheTTL
 	}
 
-	review := func(ctx context.Context, group, resource, verb string) (bool, error) {
+	review := func(ctx context.Context, group, resource, verb, namespace string) (bool, error) {
 		if client == nil {
 			return false, fmt.Errorf("kubernetes client not initialized")
 		}
@@ -86,9 +93,10 @@ func NewChecker(client kubernetes.Interface, clusterID string, ttl time.Duration
 			req := &authorizationv1.SelfSubjectAccessReview{
 				Spec: authorizationv1.SelfSubjectAccessReviewSpec{
 					ResourceAttributes: &authorizationv1.ResourceAttributes{
-						Group:    group,
-						Resource: resource,
-						Verb:     verb,
+						Group:     group,
+						Resource:  resource,
+						Verb:      verb,
+						Namespace: namespace,
 					},
 				},
 			}
@@ -129,7 +137,7 @@ func NewCheckerWithReview(clusterID string, ttl time.Duration, review AccessRevi
 		ttl = config.PermissionCacheTTL
 	}
 	if review == nil {
-		review = func(context.Context, string, string, string) (bool, error) {
+		review = func(context.Context, string, string, string, string) (bool, error) {
 			return false, fmt.Errorf("permission review function not configured")
 		}
 	}
@@ -143,12 +151,106 @@ func NewCheckerWithReview(clusterID string, ttl time.Duration, review AccessRevi
 	}
 }
 
+// SetScope configures the cluster's namespace scope
+// (docs/plans/namespace-scope.md). scopeApplies reports whether a resource's
+// DATA PATH is namespace-scoped in this build — Can fans out over the scope
+// only for those resources; every other resource keeps cluster-wide checks so
+// a domain can never register against a cluster-wide source it cannot read.
+// Call before the checker is shared across goroutines (subsystem build time).
+func (c *Checker) SetScope(namespaces []string, scopeApplies func(group, resource string) bool) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	c.scope = append([]string(nil), namespaces...)
+	c.scopeApplies = scopeApplies
+	c.mu.Unlock()
+}
+
+// scopeFor returns the namespaces Can must fan out over for the resource:
+// nil for a single cluster-wide check.
+func (c *Checker) scopeFor(group, resource string) []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if len(c.scope) == 0 || c.scopeApplies == nil || !c.scopeApplies(group, resource) {
+		return nil
+	}
+	return c.scope
+}
+
 // Can checks a resource verb and caches the decision per cluster selection.
+// Under a namespace scope, resources whose data path is scoped are allowed
+// when ANY configured namespace allows the verb; the per-namespace results
+// are cached individually so per-namespace consumers reuse them.
 func (c *Checker) Can(ctx context.Context, group, resource, verb string) (Decision, error) {
 	if c == nil {
 		return Decision{}, fmt.Errorf("permission checker not initialized")
 	}
-	key, err := c.cacheKey(group, resource, verb)
+	scope := c.scopeFor(group, resource)
+	if len(scope) == 0 {
+		return c.canInNamespace(ctx, group, resource, verb, "")
+	}
+
+	type outcome struct {
+		decision Decision
+		err      error
+	}
+	outcomes := make([]outcome, len(scope))
+	var wg sync.WaitGroup
+	for i, namespace := range scope {
+		wg.Add(1)
+		go func(i int, namespace string) {
+			defer wg.Done()
+			decision, err := c.canInNamespace(ctx, group, resource, verb, namespace)
+			outcomes[i] = outcome{decision: decision, err: err}
+		}(i, namespace)
+	}
+	wg.Wait()
+
+	var firstErr error
+	denied := Decision{}
+	deniedSeen := false
+	for _, o := range outcomes {
+		if o.err != nil {
+			if firstErr == nil {
+				firstErr = o.err
+			}
+			continue
+		}
+		if o.decision.Allowed {
+			return o.decision, nil
+		}
+		denied = o.decision
+		deniedSeen = true
+	}
+	if deniedSeen {
+		return denied, nil
+	}
+	return Decision{}, firstErr
+}
+
+// CanInNamespace checks a resource verb in one namespace (empty =
+// cluster-wide), bypassing the scope fan-out. Per-namespace surfaces use it
+// directly; results share Can's cache.
+func (c *Checker) CanInNamespace(ctx context.Context, group, resource, verb, namespace string) (Decision, error) {
+	if c == nil {
+		return Decision{}, fmt.Errorf("permission checker not initialized")
+	}
+	return c.canInNamespace(ctx, group, resource, verb, namespace)
+}
+
+// CanClusterWide checks a resource verb cluster-wide regardless of any
+// configured scope. For callers whose DATA SOURCE is cluster-wide (e.g. the
+// helm-storage informer factory) — their gate must match their source.
+func (c *Checker) CanClusterWide(ctx context.Context, group, resource, verb string) (Decision, error) {
+	if c == nil {
+		return Decision{}, fmt.Errorf("permission checker not initialized")
+	}
+	return c.canInNamespace(ctx, group, resource, verb, "")
+}
+
+func (c *Checker) canInNamespace(ctx context.Context, group, resource, verb, namespace string) (Decision, error) {
+	key, err := c.cacheKey(group, resource, verb, namespace)
 	if err != nil {
 		return Decision{}, err
 	}
@@ -167,7 +269,7 @@ func (c *Checker) Can(ctx context.Context, group, resource, verb string) (Decisi
 	// Stale-while-revalidate: if the entry is expired but within the grace window,
 	// return the stale value immediately and trigger a background refresh.
 	if ok && c.staleGrace > 0 && !now.After(entry.expiresAt.Add(c.staleGrace)) {
-		c.triggerBackgroundRefresh(ctx, key, group, resource, verb)
+		c.triggerBackgroundRefresh(ctx, key, group, resource, verb, namespace)
 		return Decision{
 			Allowed:   entry.allowed,
 			Source:    DecisionSourceStale,
@@ -182,7 +284,7 @@ func (c *Checker) Can(ctx context.Context, group, resource, verb string) (Decisi
 		err     error
 	}
 	val, _, _ := c.sfGroup.Do(key, func() (interface{}, error) {
-		allowed, err := c.review(ctx, strings.TrimSpace(group), strings.TrimSpace(resource), strings.TrimSpace(verb))
+		allowed, err := c.review(ctx, strings.TrimSpace(group), strings.TrimSpace(resource), strings.TrimSpace(verb), strings.TrimSpace(namespace))
 		return sfResult{allowed: allowed, err: err}, nil
 	})
 	result := val.(sfResult)
@@ -212,7 +314,7 @@ func (c *Checker) Can(ctx context.Context, group, resource, verb string) (Decisi
 
 // triggerBackgroundRefresh fires an async SSAR call (deduplicated via singleflight)
 // to refresh an expired cache entry without blocking the caller.
-func (c *Checker) triggerBackgroundRefresh(ctx context.Context, key, group, resource, verb string) {
+func (c *Checker) triggerBackgroundRefresh(ctx context.Context, key, group, resource, verb, namespace string) {
 	// Use a detached context so the background call outlives the request.
 	bgCtx := context.Background()
 	if _, hasDeadline := ctx.Deadline(); hasDeadline {
@@ -221,21 +323,21 @@ func (c *Checker) triggerBackgroundRefresh(ctx context.Context, key, group, reso
 		// cancel is invoked after the goroutine completes.
 		go func() {
 			defer cancel()
-			c.doBackgroundRefresh(bgCtx, key, group, resource, verb)
+			c.doBackgroundRefresh(bgCtx, key, group, resource, verb, namespace)
 		}()
 		return
 	}
-	go c.doBackgroundRefresh(bgCtx, key, group, resource, verb)
+	go c.doBackgroundRefresh(bgCtx, key, group, resource, verb, namespace)
 }
 
 // doBackgroundRefresh executes the SSAR call and stores the result via singleflight.
-func (c *Checker) doBackgroundRefresh(ctx context.Context, key, group, resource, verb string) {
+func (c *Checker) doBackgroundRefresh(ctx context.Context, key, group, resource, verb, namespace string) {
 	type sfResult struct {
 		allowed bool
 		err     error
 	}
 	val, _, _ := c.sfGroup.Do(key, func() (interface{}, error) {
-		allowed, err := c.review(ctx, strings.TrimSpace(group), strings.TrimSpace(resource), strings.TrimSpace(verb))
+		allowed, err := c.review(ctx, strings.TrimSpace(group), strings.TrimSpace(resource), strings.TrimSpace(verb), strings.TrimSpace(namespace))
 		return sfResult{allowed: allowed, err: err}, nil
 	})
 	result := val.(sfResult)
@@ -244,14 +346,19 @@ func (c *Checker) doBackgroundRefresh(ctx context.Context, key, group, resource,
 	}
 }
 
-func (c *Checker) cacheKey(group, resource, verb string) (string, error) {
+func (c *Checker) cacheKey(group, resource, verb, namespace string) (string, error) {
 	resource = strings.TrimSpace(resource)
 	verb = strings.TrimSpace(verb)
 	group = strings.TrimSpace(group)
+	namespace = strings.TrimSpace(namespace)
 	if resource == "" || verb == "" {
 		return "", fmt.Errorf("permission key requires resource and verb")
 	}
 	key := fmt.Sprintf("%s/%s/%s", group, resource, verb)
+	if namespace != "" {
+		// Cluster-wide checks keep the pre-scope key shape.
+		key = fmt.Sprintf("%s|ns=%s", key, namespace)
+	}
 	if c.clusterID == "" {
 		return key, nil
 	}

--- a/backend/refresh/permissions/checker_test.go
+++ b/backend/refresh/permissions/checker_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestCheckerUsesCacheUntilExpiry(t *testing.T) {
 	callCount := 0
-	checker := NewCheckerWithReview("cluster-a", time.Minute, func(context.Context, string, string, string) (bool, error) {
+	checker := NewCheckerWithReview("cluster-a", time.Minute, func(context.Context, string, string, string, string) (bool, error) {
 		callCount++
 		return true, nil
 	})
@@ -45,7 +45,7 @@ func TestCheckerUsesCacheUntilExpiry(t *testing.T) {
 
 func TestCheckerFallsBackOnTransientError(t *testing.T) {
 	callCount := 0
-	checker := NewCheckerWithReview("cluster-a", time.Minute, func(context.Context, string, string, string) (bool, error) {
+	checker := NewCheckerWithReview("cluster-a", time.Minute, func(context.Context, string, string, string, string) (bool, error) {
 		callCount++
 		if callCount == 1 {
 			return true, nil
@@ -68,7 +68,7 @@ func TestCheckerFallsBackOnTransientError(t *testing.T) {
 }
 
 func TestCheckerReturnsErrorWithoutCacheOnTransient(t *testing.T) {
-	checker := NewCheckerWithReview("cluster-a", time.Minute, func(context.Context, string, string, string) (bool, error) {
+	checker := NewCheckerWithReview("cluster-a", time.Minute, func(context.Context, string, string, string, string) (bool, error) {
 		return false, context.DeadlineExceeded
 	})
 
@@ -98,13 +98,17 @@ func TestCheckerRetriesTransientAuthorizationError(t *testing.T) {
 }
 
 func TestCheckerCacheKeyIncludesClusterID(t *testing.T) {
-	checker := NewCheckerWithReview("cluster-a", time.Minute, func(context.Context, string, string, string) (bool, error) {
+	checker := NewCheckerWithReview("cluster-a", time.Minute, func(context.Context, string, string, string, string) (bool, error) {
 		return true, nil
 	})
 
-	key, err := checker.cacheKey("", "pods", "list")
+	key, err := checker.cacheKey("", "pods", "list", "")
 	require.NoError(t, err)
 	require.Equal(t, "cluster-a|/pods/list", key)
+
+	key, err = checker.cacheKey("", "pods", "list", "prod")
+	require.NoError(t, err)
+	require.Equal(t, "cluster-a|/pods/list|ns=prod", key)
 }
 
 func TestCheckerDeduplicatesConcurrentCalls(t *testing.T) {
@@ -113,7 +117,7 @@ func TestCheckerDeduplicatesConcurrentCalls(t *testing.T) {
 	// Use a barrier to ensure all goroutines call Can() concurrently.
 	ready := make(chan struct{})
 
-	checker := NewCheckerWithReview("cluster-b", time.Minute, func(ctx context.Context, group, resource, verb string) (bool, error) {
+	checker := NewCheckerWithReview("cluster-b", time.Minute, func(ctx context.Context, group, resource, verb, _ string) (bool, error) {
 		atomic.AddInt64(&reviewCalls, 1)
 		// Small delay to widen the singleflight window.
 		time.Sleep(50 * time.Millisecond)
@@ -148,7 +152,7 @@ func TestCheckerDeduplicatesConcurrentCalls(t *testing.T) {
 
 func TestCheckerStaleWhileRevalidate(t *testing.T) {
 	var callCount int64
-	checker := NewCheckerWithReview("cluster-a", time.Minute, func(context.Context, string, string, string) (bool, error) {
+	checker := NewCheckerWithReview("cluster-a", time.Minute, func(context.Context, string, string, string, string) (bool, error) {
 		atomic.AddInt64(&callCount, 1)
 		return true, nil
 	})
@@ -181,7 +185,7 @@ func TestCheckerStaleWhileRevalidate(t *testing.T) {
 
 func TestCheckerStaleGracePeriodExpired(t *testing.T) {
 	callCount := 0
-	checker := NewCheckerWithReview("cluster-a", time.Minute, func(context.Context, string, string, string) (bool, error) {
+	checker := NewCheckerWithReview("cluster-a", time.Minute, func(context.Context, string, string, string, string) (bool, error) {
 		callCount++
 		return true, nil
 	})
@@ -205,14 +209,14 @@ func TestCheckerStaleGracePeriodExpired(t *testing.T) {
 
 func TestCheckerCanListWatch(t *testing.T) {
 	t.Run("both allowed", func(t *testing.T) {
-		checker := NewCheckerWithReview("cluster-c", time.Minute, func(_ context.Context, _, _, verb string) (bool, error) {
+		checker := NewCheckerWithReview("cluster-c", time.Minute, func(_ context.Context, _, _, verb, _ string) (bool, error) {
 			return true, nil
 		})
 		require.True(t, checker.CanListWatch("", "pods"))
 	})
 
 	t.Run("list denied", func(t *testing.T) {
-		checker := NewCheckerWithReview("cluster-c", time.Minute, func(_ context.Context, _, _, verb string) (bool, error) {
+		checker := NewCheckerWithReview("cluster-c", time.Minute, func(_ context.Context, _, _, verb, _ string) (bool, error) {
 			if verb == "list" {
 				return false, nil
 			}
@@ -222,7 +226,7 @@ func TestCheckerCanListWatch(t *testing.T) {
 	})
 
 	t.Run("watch denied", func(t *testing.T) {
-		checker := NewCheckerWithReview("cluster-c", time.Minute, func(_ context.Context, _, _, verb string) (bool, error) {
+		checker := NewCheckerWithReview("cluster-c", time.Minute, func(_ context.Context, _, _, verb, _ string) (bool, error) {
 			if verb == "watch" {
 				return false, nil
 			}
@@ -232,7 +236,7 @@ func TestCheckerCanListWatch(t *testing.T) {
 	})
 
 	t.Run("list error", func(t *testing.T) {
-		checker := NewCheckerWithReview("cluster-c", time.Minute, func(_ context.Context, _, _, verb string) (bool, error) {
+		checker := NewCheckerWithReview("cluster-c", time.Minute, func(_ context.Context, _, _, verb, _ string) (bool, error) {
 			if verb == "list" {
 				return false, fmt.Errorf("connection refused")
 			}
@@ -245,4 +249,114 @@ func TestCheckerCanListWatch(t *testing.T) {
 		var checker *Checker
 		require.False(t, checker.CanListWatch("", "pods"))
 	})
+}
+
+// --- Namespace scope (docs/plans/namespace-scope.md) ---
+
+func scopeAppliesToPods(group, resource string) bool {
+	return group == "" && resource == "pods"
+}
+
+func TestCheckerScopedAllowsWhenAnyNamespaceAllows(t *testing.T) {
+	var mu sync.Mutex
+	seen := map[string]bool{}
+	checker := NewCheckerWithReview("cluster-a", time.Minute, func(_ context.Context, _, _, _ string, namespace string) (bool, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		seen[namespace] = true
+		return namespace == "dev", nil
+	})
+	checker.SetScope([]string{"prod", "dev"}, scopeAppliesToPods)
+
+	decision, err := checker.Can(context.Background(), "", "pods", "list")
+	require.NoError(t, err)
+	require.True(t, decision.Allowed)
+	mu.Lock()
+	defer mu.Unlock()
+	require.True(t, seen["prod"] && seen["dev"], "both scope namespaces must be checked (and cached), got %v", seen)
+	require.False(t, seen[""], "no cluster-wide SSAR for a scoped resource")
+}
+
+func TestCheckerScopedDeniesWhenAllNamespacesDeny(t *testing.T) {
+	checker := NewCheckerWithReview("cluster-a", time.Minute, func(_ context.Context, _, _, _ string, _ string) (bool, error) {
+		return false, nil
+	})
+	checker.SetScope([]string{"prod", "dev"}, scopeAppliesToPods)
+
+	decision, err := checker.Can(context.Background(), "", "pods", "list")
+	require.NoError(t, err)
+	require.False(t, decision.Allowed)
+}
+
+func TestCheckerScopeOnlyAppliesToPredicateResources(t *testing.T) {
+	var namespaces []string
+	var mu sync.Mutex
+	checker := NewCheckerWithReview("cluster-a", time.Minute, func(_ context.Context, _, _, _ string, namespace string) (bool, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		namespaces = append(namespaces, namespace)
+		return true, nil
+	})
+	checker.SetScope([]string{"prod"}, scopeAppliesToPods)
+
+	// events is not covered by the predicate: its data source is
+	// cluster-wide, so the check must stay cluster-wide.
+	_, err := checker.Can(context.Background(), "", "events", "list")
+	require.NoError(t, err)
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, []string{""}, namespaces)
+}
+
+func TestCheckerCanClusterWideBypassesScope(t *testing.T) {
+	var namespaces []string
+	var mu sync.Mutex
+	checker := NewCheckerWithReview("cluster-a", time.Minute, func(_ context.Context, _, _, _ string, namespace string) (bool, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		namespaces = append(namespaces, namespace)
+		return true, nil
+	})
+	checker.SetScope([]string{"prod"}, scopeAppliesToPods)
+
+	decision, err := checker.CanClusterWide(context.Background(), "", "pods", "list")
+	require.NoError(t, err)
+	require.True(t, decision.Allowed)
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, []string{""}, namespaces)
+}
+
+func TestCheckerCanInNamespaceCachesPerNamespace(t *testing.T) {
+	callCount := 0
+	checker := NewCheckerWithReview("cluster-a", time.Minute, func(_ context.Context, _, _, _ string, _ string) (bool, error) {
+		callCount++
+		return true, nil
+	})
+	now := time.Date(2024, 5, 1, 10, 0, 0, 0, time.UTC)
+	checker.now = func() time.Time { return now }
+
+	_, err := checker.CanInNamespace(context.Background(), "", "pods", "list", "prod")
+	require.NoError(t, err)
+	_, err = checker.CanInNamespace(context.Background(), "", "pods", "list", "dev")
+	require.NoError(t, err)
+	require.Equal(t, 2, callCount, "distinct namespaces are distinct cache entries")
+
+	_, err = checker.CanInNamespace(context.Background(), "", "pods", "list", "prod")
+	require.NoError(t, err)
+	require.Equal(t, 2, callCount, "repeat per-namespace check must hit the cache")
+}
+
+func TestCheckerScopedFanOutUsesSuccessesDespitePartialErrors(t *testing.T) {
+	checker := NewCheckerWithReview("cluster-a", time.Minute, func(_ context.Context, _, _, _ string, namespace string) (bool, error) {
+		if namespace == "prod" {
+			return false, context.DeadlineExceeded
+		}
+		return true, nil
+	})
+	checker.SetScope([]string{"prod", "dev"}, scopeAppliesToPods)
+
+	decision, err := checker.Can(context.Background(), "", "pods", "list")
+	require.NoError(t, err)
+	require.True(t, decision.Allowed, "one namespace erroring must not mask another namespace's allow")
 }

--- a/backend/refresh/permissions/resource_requirement.go
+++ b/backend/refresh/permissions/resource_requirement.go
@@ -10,6 +10,11 @@ type ResourceRequirement struct {
 	Group    string
 	Resource string
 	Verb     string
+	// ClusterWide forces the check to bypass any configured namespace scope
+	// (docs/plans/namespace-scope.md). Set when the requirement gates a data
+	// source that reads cluster-wide regardless of scope (e.g. the
+	// helm-storage informer factory), so the gate matches the source.
+	ClusterWide bool
 }
 
 // ListRequirement creates a list permission requirement.

--- a/backend/refresh/resourcestream/manager.go
+++ b/backend/refresh/resourcestream/manager.go
@@ -158,12 +158,15 @@ func (s *subscription) markResyncing() bool {
 }
 
 type customResourceInformer struct {
-	gvr      schema.GroupVersionResource
-	kind     string
-	domain   string
-	informer cache.SharedIndexInformer
-	stopCh   chan struct{}
-	stopOnce sync.Once
+	gvr    schema.GroupVersionResource
+	kind   string
+	domain string
+	// informers are the CRD's dynamic informers: one cluster-wide (or one
+	// per configured scope namespace for a namespaced CRD under a namespace
+	// scope, docs/plans/namespace-scope.md). All share stopCh.
+	informers []cache.SharedIndexInformer
+	stopCh    chan struct{}
+	stopOnce  sync.Once
 }
 
 func (c *customResourceInformer) stop() {
@@ -205,6 +208,11 @@ type Manager struct {
 	jobLister        batchlisters.JobLister
 	cronJobLister    batchlisters.CronJobLister
 
+	// allowedNamespaces is the cluster's namespace scope
+	// (docs/plans/namespace-scope.md); namespaced custom-resource informers
+	// fan out over it instead of watching cluster-wide.
+	allowedNamespaces []string
+
 	customInformerMu sync.Mutex
 	customInformers  map[string]*customResourceInformer
 	// stopped is set once Stop() runs. It is terminal: a torn-down manager is
@@ -237,21 +245,23 @@ func NewManager(
 	meta snapshot.ClusterMeta,
 	dynamicClient dynamic.Interface,
 	ingestManager *ingest.IngestManager,
+	allowedNamespaces ...string,
 ) *Manager {
 	if logger == nil {
 		logger = applog.Noop
 	}
 	mgr := &Manager{
-		clusterMeta:     meta,
-		metrics:         provider,
-		logger:          logger,
-		telemetry:       recorder,
-		permissions:     factory,
-		dynamicClient:   dynamicClient,
-		customInformers: make(map[string]*customResourceInformer),
-		subscribers:     make(map[string]map[string]map[uint64]*subscription),
-		buffers:         make(map[string]*updateBuffer),
-		sequences:       make(map[string]uint64),
+		clusterMeta:       meta,
+		metrics:           provider,
+		logger:            logger,
+		telemetry:         recorder,
+		permissions:       factory,
+		dynamicClient:     dynamicClient,
+		allowedNamespaces: append([]string(nil), allowedNamespaces...),
+		customInformers:   make(map[string]*customResourceInformer),
+		subscribers:       make(map[string]map[string]map[uint64]*subscription),
+		buffers:           make(map[string]*updateBuffer),
+		sequences:         make(map[string]uint64),
 	}
 	if ingestManager != nil {
 		mgr.podIngest = ingestManager
@@ -500,32 +510,43 @@ func (m *Manager) ensureCustomInformer(crd *apiextensionsv1.CustomResourceDefini
 		delete(m.customInformers, crd.Name)
 	}
 
-	// Use a dynamic informer per CRD to stream custom resource updates.
-	dynamicInformer := dynamicinformer.NewFilteredDynamicInformer(
-		m.dynamicClient,
-		gvr,
-		namespace,
-		0,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
-		nil,
-	)
-	informer := dynamicInformer.Informer()
-	info := &customResourceInformer{
-		gvr:      gvr,
-		kind:     kind,
-		domain:   customDomain,
-		informer: informer,
-		stopCh:   make(chan struct{}),
+	// One dynamic informer per CRD streams custom resource updates. Under a
+	// namespace scope a namespaced CRD fans out one informer per configured
+	// namespace (the scoped identity typically cannot watch cluster-wide);
+	// the unscoped path is the same loop with a single all-namespaces entry.
+	namespaces := []string{namespace}
+	if customDomain == domainNamespaceCustom && len(m.allowedNamespaces) > 0 {
+		namespaces = append([]string(nil), m.allowedNamespaces...)
 	}
-	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { m.handleCustomResource(obj, MessageTypeAdded, info) },
-		UpdateFunc: func(_, newObj interface{}) { m.handleCustomResource(newObj, MessageTypeModified, info) },
-		DeleteFunc: func(obj interface{}) { m.handleCustomResource(obj, MessageTypeDeleted, info) },
-	})
+	info := &customResourceInformer{
+		gvr:    gvr,
+		kind:   kind,
+		domain: customDomain,
+		stopCh: make(chan struct{}),
+	}
+	for _, ns := range namespaces {
+		dynamicInformer := dynamicinformer.NewFilteredDynamicInformer(
+			m.dynamicClient,
+			gvr,
+			ns,
+			0,
+			cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+			nil,
+		)
+		informer := dynamicInformer.Informer()
+		informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc:    func(obj interface{}) { m.handleCustomResource(obj, MessageTypeAdded, info) },
+			UpdateFunc: func(_, newObj interface{}) { m.handleCustomResource(newObj, MessageTypeModified, info) },
+			DeleteFunc: func(obj interface{}) { m.handleCustomResource(obj, MessageTypeDeleted, info) },
+		})
+		info.informers = append(info.informers, informer)
+	}
 	m.customInformers[crd.Name] = info
 	m.customInformerMu.Unlock()
 
-	go informer.Run(info.stopCh)
+	for _, informer := range info.informers {
+		go informer.Run(info.stopCh)
+	}
 }
 
 func (m *Manager) removeCustomInformer(crdName string) {

--- a/backend/refresh/snapshot/namespace_custom.go
+++ b/backend/refresh/snapshot/namespace_custom.go
@@ -10,6 +10,7 @@ import (
 	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	apiextensionslisters "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -34,6 +35,10 @@ type NamespaceCustomBuilder struct {
 	dynamic   dynamic.Interface
 	crdLister apiextensionslisters.CustomResourceDefinitionLister
 	logger    containerlogsstream.Logger
+	// scope is the cluster's namespace scope (docs/plans/namespace-scope.md):
+	// the all-namespaces view fans the per-CRD LIST over these namespaces
+	// instead of one cluster-wide LIST. Empty means cluster-wide (today).
+	scope []string
 }
 
 // NamespaceCustomSnapshot is returned to clients.
@@ -62,6 +67,7 @@ func RegisterNamespaceCustomDomain(
 	apiextFactory apiextensionsinformers.SharedInformerFactory,
 	dynamicClient dynamic.Interface,
 	logger containerlogsstream.Logger,
+	allowedNamespaces []string,
 ) error {
 	if apiextFactory == nil {
 		return fmt.Errorf("apiextensions informer factory is nil")
@@ -74,6 +80,7 @@ func RegisterNamespaceCustomDomain(
 		dynamic:   dynamicClient,
 		crdLister: apiextFactory.Apiextensions().V1().CustomResourceDefinitions().Lister(),
 		logger:    logger,
+		scope:     append([]string(nil), allowedNamespaces...),
 	}
 
 	return reg.Register(refresh.DomainConfig{
@@ -162,15 +169,35 @@ func (b *NamespaceCustomBuilder) Build(ctx context.Context, scope string) (*refr
 				Resource: crdCopy.Spec.Names.Plural,
 			}
 
-			listNamespace := parsedScope.Namespace
+			// The all-namespaces view under a scope fans out over the
+			// configured namespaces; the unscoped path is the same loop with
+			// a single all-namespaces target.
+			listTargets := []string{parsedScope.Namespace}
 			if parsedScope.AllNamespaces {
-				listNamespace = metav1.NamespaceAll
-			}
-			resourceList, err := b.dynamic.Resource(gvr).Namespace(listNamespace).List(ctx, metav1.ListOptions{})
-			if err != nil {
-				if shouldSkipError(err) {
-					return nil
+				listTargets = []string{metav1.NamespaceAll}
+				if len(b.scope) > 0 {
+					listTargets = b.scope
 				}
+			}
+			var listed []unstructured.Unstructured
+			var listErr error
+			for _, listNamespace := range listTargets {
+				resourceList, err := b.dynamic.Resource(gvr).Namespace(listNamespace).List(ctx, metav1.ListOptions{})
+				if err != nil {
+					// Per-target skip: one forbidden/absent namespace must not
+					// blank the others.
+					if shouldSkipError(err) {
+						continue
+					}
+					listErr = err
+					break
+				}
+				if resourceList != nil {
+					listed = append(listed, resourceList.Items...)
+				}
+			}
+			resourceList := &unstructured.UnstructuredList{Items: listed}
+			if err := listErr; err != nil {
 				applog.Warn(b.logger, fmt.Sprintf("namespace-custom: list %s failed: %v", gvr.String(), err), logsources.Refresh)
 				mu.Lock()
 				warning := fmt.Sprintf("Failed to list %s: %v", gvr.String(), err)

--- a/backend/refresh/snapshot/namespace_custom_test.go
+++ b/backend/refresh/snapshot/namespace_custom_test.go
@@ -154,3 +154,62 @@ func registerDBClusterTypes(t testing.TB, scheme *runtime.Scheme) {
 	scheme.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
 	scheme.AddKnownTypeWithName(gvk.GroupVersion().WithKind("DBClusterList"), &unstructured.UnstructuredList{})
 }
+
+// Scoped clusters (docs/plans/namespace-scope.md): the all-namespaces view
+// fans the per-CRD LIST over the configured scope instead of one cluster-wide
+// LIST the identity cannot perform. A namespace outside the scope must never
+// be listed.
+func TestNamespaceCustomBuilderAllNamespacesFansOutOverScope(t *testing.T) {
+	now := time.Now()
+	widgetCRD := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "widgets.acme.test"},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "acme.test",
+			Scope: apiextensionsv1.NamespaceScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{Plural: "widgets", Kind: "Widget"},
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{
+				Name: "v1", Served: true, Storage: true,
+			}},
+		},
+	}
+
+	makeWidget := func(namespace, name string) *unstructured.Unstructured {
+		return &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "acme.test/v1",
+				"kind":       "Widget",
+				"metadata": map[string]any{
+					"name":              name,
+					"namespace":         namespace,
+					"resourceVersion":   "10",
+					"creationTimestamp": metav1.NewTime(now.Add(-time.Hour)).Format(time.RFC3339),
+				},
+			},
+		}
+	}
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, apiextensionsscheme.AddToScheme(scheme))
+	registerWidgetTypes(t, scheme)
+
+	builder := &NamespaceCustomBuilder{
+		dynamic:   testsupport.NewDynamicClient(t, scheme, makeWidget("team-a", "wa"), makeWidget("team-c", "wc")),
+		crdLister: testsupport.NewCRDLister(t, widgetCRD),
+		logger:    applog.Noop,
+		scope:     []string{"team-a", "team-b"},
+	}
+
+	snapshot, err := builder.Build(context.Background(), "cluster-a|namespace:all")
+	require.NoError(t, err)
+	payload, ok := snapshot.Payload.(NamespaceCustomSnapshot)
+	require.True(t, ok)
+
+	require.Equal(t, []string{"Widget"}, payload.Kinds, "CRD discovery must still work under scope")
+
+	var names []string
+	for _, item := range payload.Resources {
+		names = append(names, item.Namespace+"/"+item.Name)
+	}
+	require.Equal(t, []string{"team-a/wa"}, names,
+		"scope namespaces listed, out-of-scope namespaces excluded")
+}

--- a/backend/refresh/snapshot/namespaces.go
+++ b/backend/refresh/snapshot/namespaces.go
@@ -11,6 +11,7 @@ import (
 	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	informers "k8s.io/client-go/informers"
@@ -33,6 +34,11 @@ type NamespaceBuilder struct {
 	namespaces corelisters.NamespaceLister
 	ingest     namespacePodIngestSource
 	tracker    *NamespaceWorkloadTracker
+	// scope is the cluster's configured namespace scope
+	// (docs/plans/namespace-scope.md). Non-empty means the rows are
+	// synthesized from these names instead of read from the (cluster-wide,
+	// permission-gated) namespace lister; empty means today's lister path.
+	scope []string
 }
 
 // namespacePodIngestSource is the ingest surface the namespace domain reads: the per-kind sync
@@ -84,27 +90,34 @@ type NamespaceSummary struct {
 // informer events and workload/pod ingest events feed it (handlers/sinks registered HERE,
 // before the informer factory and ingest manager start), and the subsystem wires its
 // broadcast to the resource-stream doorbell once the stream manager exists.
-func RegisterNamespaceDomain(reg *domain.Registry, factory informers.SharedInformerFactory, ingestManager namespacePodIngestSource) (*NamespaceChangeNotifier, error) {
+func RegisterNamespaceDomain(reg *domain.Registry, factory informers.SharedInformerFactory, ingestManager namespacePodIngestSource, allowedNamespaces []string) (*NamespaceChangeNotifier, error) {
 	tracker := NewNamespaceWorkloadTracker(ingestManager)
 	builder := &NamespaceBuilder{
-		namespaces: factory.Core().V1().Namespaces().Lister(),
-		ingest:     ingestManager,
-		tracker:    tracker,
+		ingest:  ingestManager,
+		tracker: tracker,
+		scope:   append([]string(nil), allowedNamespaces...),
 	}
 	notifier := NewNamespaceChangeNotifier(ingestManager, tracker)
-	if _, err := factory.Core().V1().Namespaces().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(interface{}) { notifier.NamespaceChanged() },
-		UpdateFunc: func(oldObj, newObj interface{}) {
-			// Informer resyncs re-deliver every namespace with an unchanged
-			// ResourceVersion; only real updates ring the doorbell.
-			if namespaceUpdateIsEcho(oldObj, newObj) {
-				return
-			}
-			notifier.NamespaceChanged()
-		},
-		DeleteFunc: func(interface{}) { notifier.NamespaceChanged() },
-	}); err != nil {
-		return nil, fmt.Errorf("namespaces: register namespace handler: %w", err)
+	// Scoped clusters synthesize rows from the configured names: the
+	// (cluster-scoped, typically denied) namespaces informer is never
+	// instantiated, and namespace add/delete events cannot occur — the row
+	// set only changes through a settings-triggered subsystem rebuild.
+	if len(builder.scope) == 0 {
+		builder.namespaces = factory.Core().V1().Namespaces().Lister()
+		if _, err := factory.Core().V1().Namespaces().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc: func(interface{}) { notifier.NamespaceChanged() },
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				// Informer resyncs re-deliver every namespace with an unchanged
+				// ResourceVersion; only real updates ring the doorbell.
+				if namespaceUpdateIsEcho(oldObj, newObj) {
+					return
+				}
+				notifier.NamespaceChanged()
+			},
+			DeleteFunc: func(interface{}) { notifier.NamespaceChanged() },
+		}); err != nil {
+			return nil, fmt.Errorf("namespaces: register namespace handler: %w", err)
+		}
 	}
 	// Bundle sinks fire on every Upsert/Delete/Replace for their GVR, which is all
 	// the notifier needs: the flush decides via the presence signature whether the
@@ -160,7 +173,20 @@ func (b *NamespaceBuilder) Build(ctx context.Context, scope string) (*refresh.Sn
 		err        error
 	)
 
-	if strings.TrimSpace(scopeValue) != "" {
+	switch {
+	case len(b.scope) > 0:
+		// Scoped cluster: synthesize name-only rows from the configured
+		// scope (the identity typically cannot read namespace objects).
+		// Per-namespace GET enrichment is a later plan phase.
+		for _, name := range b.scope {
+			if strings.TrimSpace(scopeValue) != "" && name != scopeValue {
+				continue
+			}
+			namespaces = append(namespaces, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: name},
+			})
+		}
+	case strings.TrimSpace(scopeValue) != "":
 		var ns *corev1.Namespace
 		ns, err = b.namespaces.Get(scopeValue)
 		if err != nil {
@@ -173,7 +199,7 @@ func (b *NamespaceBuilder) Build(ctx context.Context, scope string) (*refresh.Sn
 		} else {
 			namespaces = []*corev1.Namespace{ns}
 		}
-	} else {
+	default:
 		namespaces, err = b.namespaces.List(labels.Everything())
 		if err != nil {
 			return nil, err
@@ -201,7 +227,11 @@ func (b *NamespaceBuilder) Build(ctx context.Context, scope string) (*refresh.Sn
 	var version uint64
 	for _, ns := range namespaces {
 		_, hasWorkloads := workloadNamespaces[ns.Name]
-		workloadsKnown := hasWorkloads || trackerReady
+		// In scoped mode a tracker that latched synced because NOTHING is
+		// tracked (every workload kind permission-skipped) means presence is
+		// genuinely unknown — reporting it as authoritative would dim every
+		// configured namespace. Unscoped behavior is unchanged.
+		workloadsKnown := hasWorkloads || (trackerReady && (len(b.scope) == 0 || b.tracksAnyWorkloadKind()))
 		model := namespacepkg.BuildResourceModel(meta.ClusterID, ns, hasWorkloads, workloadsKnown, nil, nil)
 		facts := namespacepkg.BuildFacts(meta.ClusterID, ns, hasWorkloads, workloadsKnown, nil, nil, resourcemodel.ResourceModelBuildOptions{})
 		items = append(items, NamespaceSummary{
@@ -269,6 +299,25 @@ func workloadPresenceSignature(set map[string]struct{}, ready bool) string {
 	return strconv.FormatUint(h.Sum64(), 16)
 }
 
+// tracksAnyWorkloadKind reports whether the ingest manager runs a reflector for
+// at least one workload/pod kind — i.e. whether workload presence is knowable
+// at all for this identity. False when every workload kind was
+// permission-skipped (or there is no ingest), which in scoped mode must read
+// as "unknown", never as "authoritatively empty".
+func (b *NamespaceBuilder) tracksAnyWorkloadKind() bool {
+	if b.ingest == nil {
+		return false
+	}
+	for _, gvr := range []schema.GroupVersionResource{
+		DeploymentGVR, StatefulSetGVR, DaemonSetGVR, JobGVR, CronJobGVR, PodGVR,
+	} {
+		if b.ingest.Tracks(gvr) {
+			return true
+		}
+	}
+	return false
+}
+
 // namespacesWithWorkloads returns the set of namespaces that have at least one workload, read
 // directly from the ingest stores in a single pass: the five cut workload kinds' projected
 // Catalog rows (Deployment/StatefulSet/DaemonSet/Job/CronJob) plus the pod aggregate rows. It
@@ -312,6 +361,11 @@ func parseResourceVersion(obj *corev1.Namespace) uint64 {
 		if parsed, err := strconv.ParseUint(rv, 10, 64); err == nil {
 			return parsed
 		}
+	}
+	// Synthesized scoped rows carry neither RV nor creation time; a zero
+	// timestamp must not wrap into a huge bogus version.
+	if obj.CreationTimestamp.IsZero() {
+		return 0
 	}
 	return uint64(obj.CreationTimestamp.UnixNano())
 }

--- a/backend/refresh/snapshot/namespaces.go
+++ b/backend/refresh/snapshot/namespaces.go
@@ -136,6 +136,10 @@ func RegisterNamespaceDomain(reg *domain.Registry, factory informers.SharedInfor
 	if err := reg.Register(refresh.DomainConfig{
 		Name:          "namespaces",
 		BuildSnapshot: builder.Build,
+		// Scoped rows are synthesized from configuration: no cluster
+		// permission is needed, so BOTH permission gates (registration-time
+		// and the snapshot service's per-request check) must stand down.
+		RuntimePolicyExempt: len(builder.scope) > 0,
 	}); err != nil {
 		return nil, err
 	}

--- a/backend/refresh/snapshot/namespaces.go
+++ b/backend/refresh/snapshot/namespaces.go
@@ -7,6 +7,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
 
@@ -15,9 +17,11 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	informers "k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/luxury-yacht/app/backend/internal/config"
 	"github.com/luxury-yacht/app/backend/kind/streamrows"
 	"github.com/luxury-yacht/app/backend/objectcatalog"
 	"github.com/luxury-yacht/app/backend/refresh"
@@ -39,6 +43,105 @@ type NamespaceBuilder struct {
 	// synthesized from these names instead of read from the (cluster-wide,
 	// permission-gated) namespace lister; empty means today's lister path.
 	scope []string
+
+	// client backs the scoped-mode per-namespace GET probe that enriches
+	// rows and flags configured names the identity cannot reach. nil (the
+	// unscoped path, unit tests) disables probing.
+	client kubernetes.Interface
+	// now/probeTTL are injectable for tests; zero values mean time.Now and
+	// the permission-cache TTL.
+	now      func() time.Time
+	probeTTL time.Duration
+
+	probeMu sync.Mutex
+	probes  map[string]namespaceProbe
+}
+
+// Scope-probe outcomes surfaced on NamespaceSummary.ScopeStatus. A permitted
+// GET returning 404 is definitive ("not-found"); a 403 stays honest — a
+// restricted identity cannot distinguish a missing namespace from a denied
+// one ("no-access").
+const (
+	scopeStatusNotFound = "not-found"
+	scopeStatusNoAccess = "no-access"
+)
+
+// namespaceProbe caches one configured name's GET outcome: the real object
+// when it exists and is readable, else the flag; checkedAt drives the TTL.
+type namespaceProbe struct {
+	ns        *corev1.Namespace
+	status    string
+	checkedAt time.Time
+}
+
+// probeScopedNamespace resolves one configured name: the real namespace
+// object (row enrichment) or a flag. Results are TTL-cached so builds do not
+// issue one GET per name per refresh tick; a transient error serves the
+// previous result (or nothing) rather than flapping a flag.
+func (b *NamespaceBuilder) probeScopedNamespace(ctx context.Context, name string) (*corev1.Namespace, string) {
+	if b.client == nil {
+		return nil, ""
+	}
+	nowFn := b.now
+	if nowFn == nil {
+		nowFn = time.Now
+	}
+	ttl := b.probeTTL
+	if ttl <= 0 {
+		ttl = config.PermissionCacheTTL
+	}
+	b.probeMu.Lock()
+	if probe, ok := b.probes[name]; ok && nowFn().Sub(probe.checkedAt) < ttl {
+		b.probeMu.Unlock()
+		return probe.ns, probe.status
+	}
+	b.probeMu.Unlock()
+
+	got, err := b.client.CoreV1().Namespaces().Get(ctx, name, metav1.GetOptions{})
+	var probe namespaceProbe
+	switch {
+	case err == nil:
+		probe = namespaceProbe{ns: got}
+	case apimachineryerrors.IsNotFound(err):
+		probe = namespaceProbe{status: scopeStatusNotFound}
+	case apimachineryerrors.IsForbidden(err):
+		probe = namespaceProbe{status: scopeStatusNoAccess}
+	default:
+		b.probeMu.Lock()
+		previous, ok := b.probes[name]
+		b.probeMu.Unlock()
+		if ok {
+			return previous.ns, previous.status
+		}
+		return nil, ""
+	}
+	probe.checkedAt = nowFn()
+	b.probeMu.Lock()
+	if b.probes == nil {
+		b.probes = make(map[string]namespaceProbe)
+	}
+	b.probes[name] = probe
+	b.probeMu.Unlock()
+	return probe.ns, probe.status
+}
+
+// scopeProbeSignature fingerprints the per-name probe flags so a flag
+// transition (a namespace created, deleted, or newly accessible) changes the
+// snapshot's cache validator — synthesized rows carry no RV clock to do it.
+func scopeProbeSignature(statuses map[string]string) string {
+	names := make([]string, 0, len(statuses))
+	for name := range statuses {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	h := fnv.New64a()
+	for _, name := range names {
+		_, _ = h.Write([]byte(name))
+		_, _ = h.Write([]byte{'='})
+		_, _ = h.Write([]byte(statuses[name]))
+		_, _ = h.Write([]byte{0})
+	}
+	return strconv.FormatUint(h.Sum64(), 16)
 }
 
 // namespacePodIngestSource is the ingest surface the namespace domain reads: the per-kind sync
@@ -79,6 +182,10 @@ type NamespaceSummary struct {
 	CreationUnix       int64                     `json:"creationTimestamp"`
 	HasWorkloads       bool                      `json:"hasWorkloads"`
 	WorkloadsUnknown   bool                      `json:"workloadsUnknown,omitempty"`
+	// ScopeStatus flags a configured scope entry the identity cannot reach:
+	// "not-found" (definitive) or "no-access" (may not exist). Empty for
+	// reachable namespaces and for every unscoped row.
+	ScopeStatus string `json:"scopeStatus,omitempty"`
 }
 
 // RegisterNamespaceDomain registers the namespace domain with the registry. The cut workload +
@@ -90,12 +197,17 @@ type NamespaceSummary struct {
 // informer events and workload/pod ingest events feed it (handlers/sinks registered HERE,
 // before the informer factory and ingest manager start), and the subsystem wires its
 // broadcast to the resource-stream doorbell once the stream manager exists.
-func RegisterNamespaceDomain(reg *domain.Registry, factory informers.SharedInformerFactory, ingestManager namespacePodIngestSource, allowedNamespaces []string) (*NamespaceChangeNotifier, error) {
+func RegisterNamespaceDomain(reg *domain.Registry, factory informers.SharedInformerFactory, ingestManager namespacePodIngestSource, allowedNamespaces []string, client kubernetes.Interface) (*NamespaceChangeNotifier, error) {
 	tracker := NewNamespaceWorkloadTracker(ingestManager)
 	builder := &NamespaceBuilder{
 		ingest:  ingestManager,
 		tracker: tracker,
 		scope:   append([]string(nil), allowedNamespaces...),
+	}
+	if len(builder.scope) > 0 {
+		// The probe client is scoped-mode only: unscoped rows come from the
+		// lister and must not issue per-name GETs.
+		builder.client = client
 	}
 	notifier := NewNamespaceChangeNotifier(ingestManager, tracker)
 	// Scoped clusters synthesize rows from the configured names: the
@@ -177,13 +289,22 @@ func (b *NamespaceBuilder) Build(ctx context.Context, scope string) (*refresh.Sn
 		err        error
 	)
 
+	scopeStatuses := make(map[string]string)
 	switch {
 	case len(b.scope) > 0:
-		// Scoped cluster: synthesize name-only rows from the configured
-		// scope (the identity typically cannot read namespace objects).
-		// Per-namespace GET enrichment is a later plan phase.
+		// Scoped cluster: rows come from the configured scope. A
+		// per-namespace GET probe enriches each row from the real object
+		// where permitted and flags names the identity cannot reach
+		// (not-found / no-access); without a probe result the row stays
+		// name-only.
 		for _, name := range b.scope {
 			if strings.TrimSpace(scopeValue) != "" && name != scopeValue {
+				continue
+			}
+			probed, status := b.probeScopedNamespace(ctx, name)
+			scopeStatuses[name] = status
+			if probed != nil {
+				namespaces = append(namespaces, probed)
 				continue
 			}
 			namespaces = append(namespaces, &corev1.Namespace{
@@ -251,6 +372,7 @@ func (b *NamespaceBuilder) Build(ctx context.Context, scope string) (*refresh.Sn
 			CreationUnix:       model.Metadata.CreationTimestamp.Unix(),
 			HasWorkloads:       facts.HasWorkloads,
 			WorkloadsUnknown:   !facts.WorkloadsKnown,
+			ScopeStatus:        scopeStatuses[ns.Name],
 		})
 		if v := parseResourceVersion(ns); v > version {
 			version = v
@@ -275,6 +397,12 @@ func (b *NamespaceBuilder) Build(ctx context.Context, scope string) (*refresh.Sn
 		SourceVersions: map[string]string{
 			"workloads": workloadPresenceSignature(workloadNamespaces, trackerReady),
 		},
+	}
+	if len(b.scope) > 0 {
+		// Probe flags are content the namespace RV clock cannot carry (a
+		// flagged row has no RV at all) — publish them as their own source
+		// clock so transitions are delivered instead of 304'd.
+		snap.SourceVersions["scope-probe"] = scopeProbeSignature(scopeStatuses)
 	}
 	return snap, nil
 }

--- a/backend/refresh/snapshot/namespaces_test.go
+++ b/backend/refresh/snapshot/namespaces_test.go
@@ -2,12 +2,18 @@ package snapshot
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
 
 	"github.com/luxury-yacht/app/backend/refresh/domain"
 	"github.com/luxury-yacht/app/backend/testsupport"
@@ -432,7 +438,96 @@ func TestRegisterNamespaceDomainScopedDoesNotTouchNamespaceInformer(t *testing.T
 	// the scoped registration must never instantiate the namespaces informer.
 	// Passing a nil factory proves it: any touch would panic.
 	reg := domain.New()
-	notifier, err := RegisterNamespaceDomain(reg, nil, nil, []string{"prod"})
+	notifier, err := RegisterNamespaceDomain(reg, nil, nil, []string{"prod"}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, notifier)
+}
+
+// Scoped rows are enriched by a per-namespace GET probe
+// (docs/plans/namespace-scope.md, Phase 5): a real namespace serves its full
+// row; a 404 flags "not-found" (definitive — the GET was permitted); a 403
+// flags "no-access" (a restricted identity cannot distinguish absence from
+// denial, so the label stays honest).
+func TestNamespaceBuilderScopedProbesEnrichAndFlagRows(t *testing.T) {
+	created := time.Unix(1700000000, 0).UTC()
+	realNs := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "prod",
+			ResourceVersion:   "42",
+			CreationTimestamp: metav1.NewTime(created),
+		},
+		Status: corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
+	}
+	client := k8sfake.NewClientset(realNs)
+	client.PrependReactor("get", "namespaces", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		if action.(clienttesting.GetAction).GetName() == "locked" {
+			return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "namespaces"}, "locked", errors.New("denied"))
+		}
+		return false, nil, nil
+	})
+
+	builder := &NamespaceBuilder{
+		scope:  []string{"prod", "ghost", "locked"},
+		client: client,
+	}
+
+	snap, err := builder.Build(context.Background(), "")
+	require.NoError(t, err)
+	payload := snap.Payload.(NamespaceSnapshot)
+	require.Len(t, payload.Namespaces, 3)
+
+	byName := map[string]NamespaceSummary{}
+	for _, ns := range payload.Namespaces {
+		byName[ns.Name] = ns
+	}
+
+	prod := byName["prod"]
+	require.Empty(t, prod.ScopeStatus, "an existing accessible namespace carries no flag")
+	require.Equal(t, "Active", prod.Phase, "probe enriches the row from the real object")
+	require.Equal(t, "42", prod.ResourceVersion)
+	require.Equal(t, created.Unix(), prod.CreationUnix)
+
+	require.Equal(t, "not-found", byName["ghost"].ScopeStatus,
+		"a permitted GET returning 404 is definitive")
+	require.Equal(t, "no-access", byName["locked"].ScopeStatus,
+		"403 is honest: may not exist or may be denied")
+}
+
+func TestNamespaceBuilderScopedProbeCacheAndValidator(t *testing.T) {
+	gets := 0
+	client := k8sfake.NewClientset()
+	client.PrependReactor("get", "namespaces", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		gets++
+		return false, nil, nil
+	})
+
+	now := time.Unix(1700000000, 0)
+	builder := &NamespaceBuilder{
+		scope:  []string{"ghost"},
+		client: client,
+		now:    func() time.Time { return now },
+	}
+
+	snapA, err := builder.Build(context.Background(), "")
+	require.NoError(t, err)
+	require.Equal(t, 1, gets)
+	_, err = builder.Build(context.Background(), "")
+	require.NoError(t, err)
+	require.Equal(t, 1, gets, "within the TTL the probe result is cached")
+
+	// The namespace is created; past the TTL the probe re-asks and the
+	// snapshot's cache validator must change (the row content changed with
+	// no namespace-RV clock to carry it).
+	require.NoError(t, client.Tracker().Add(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "ghost", ResourceVersion: "7"},
+		Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
+	}))
+	now = now.Add(time.Hour)
+
+	snapB, err := builder.Build(context.Background(), "")
+	require.NoError(t, err)
+	require.Equal(t, 2, gets, "past the TTL the probe re-asks")
+	require.Empty(t, snapB.Payload.(NamespaceSnapshot).Namespaces[0].ScopeStatus)
+	require.NotEqual(t, snapA.SourceVersions["scope-probe"], snapB.SourceVersions["scope-probe"],
+		"probe transitions must change the cache validator or the client keeps the stale flag")
 }

--- a/backend/refresh/snapshot/namespaces_test.go
+++ b/backend/refresh/snapshot/namespaces_test.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/luxury-yacht/app/backend/refresh/domain"
 	"github.com/luxury-yacht/app/backend/testsupport"
 	"github.com/stretchr/testify/require"
 )
@@ -352,4 +353,86 @@ func TestNamespaceBuilderWorkloadSyncReadinessChangesSourceVersion(t *testing.T)
 	if notReady == ready {
 		t.Fatalf("workload sync readiness did not change the workloads source version (%q)", ready)
 	}
+}
+
+// --- Scoped ("accessible namespaces") mode, docs/plans/namespace-scope.md ---
+
+func TestNamespaceBuilderScopedSynthesizesConfiguredNames(t *testing.T) {
+	// Pre-Phase-4 restricted cluster: no lister (cluster-wide list denied), no
+	// ingest data at all. Rows come from the configured scope; workload
+	// presence is genuinely unknown, so nothing may render as
+	// authoritatively-empty (dimmed).
+	builder := &NamespaceBuilder{scope: []string{"prod", "dev"}}
+
+	ctx := WithClusterMeta(context.Background(), ClusterMeta{ClusterID: "cluster-a", ClusterName: "prod-cluster"})
+	snap, err := builder.Build(ctx, "")
+	require.NoError(t, err)
+
+	payload, ok := snap.Payload.(NamespaceSnapshot)
+	require.True(t, ok)
+	require.True(t, payload.WorkloadsReady, "scoped snapshot must satisfy the lifecycle Ready gate")
+	require.Len(t, payload.Namespaces, 2)
+	require.Equal(t, "dev", payload.Namespaces[0].Name)
+	require.Equal(t, "prod", payload.Namespaces[1].Name)
+
+	for _, ns := range payload.Namespaces {
+		require.False(t, ns.HasWorkloads)
+		require.True(t, ns.WorkloadsUnknown, "no tracked workload kind: presence must be unknown, not authoritatively empty")
+		require.Equal(t, "Namespace", ns.Ref.Kind)
+		require.Equal(t, "namespaces", ns.Ref.Resource)
+		require.Equal(t, ns.Name, ns.Ref.Name)
+		require.Equal(t, "cluster-a", ns.Ref.ClusterID)
+	}
+}
+
+func TestNamespaceBuilderScopedReportsPresenceOnceIngestTracksWorkloads(t *testing.T) {
+	// Post-Phase-4 scoped cluster: ingest tracks workload kinds and has rows
+	// for one configured namespace. Presence becomes known for every row.
+	tracker := newNamespaceWorkloadTracker()
+	tracker.synced.Store(true)
+
+	builder := &NamespaceBuilder{
+		scope:   []string{"prod", "dev"},
+		ingest:  fakePodAggregateSource{}.withWorkloadCatalog(DeploymentGVR, "prod", 1),
+		tracker: tracker,
+	}
+
+	snap, err := builder.Build(context.Background(), "")
+	require.NoError(t, err)
+	payload := snap.Payload.(NamespaceSnapshot)
+	require.Len(t, payload.Namespaces, 2)
+
+	byName := map[string]NamespaceSummary{}
+	for _, ns := range payload.Namespaces {
+		byName[ns.Name] = ns
+	}
+	require.True(t, byName["prod"].HasWorkloads)
+	require.False(t, byName["prod"].WorkloadsUnknown)
+	require.False(t, byName["dev"].HasWorkloads)
+	require.False(t, byName["dev"].WorkloadsUnknown, "tracked ingest makes absence authoritative")
+}
+
+func TestNamespaceBuilderScopedViewScopeFiltersToConfiguredNames(t *testing.T) {
+	builder := &NamespaceBuilder{scope: []string{"prod", "dev"}}
+
+	snap, err := builder.Build(context.Background(), "cluster-a|prod")
+	require.NoError(t, err)
+	payload := snap.Payload.(NamespaceSnapshot)
+	require.Len(t, payload.Namespaces, 1)
+	require.Equal(t, "prod", payload.Namespaces[0].Name)
+
+	snap, err = builder.Build(context.Background(), "cluster-a|not-configured")
+	require.NoError(t, err)
+	payload = snap.Payload.(NamespaceSnapshot)
+	require.Empty(t, payload.Namespaces)
+}
+
+func TestRegisterNamespaceDomainScopedDoesNotTouchNamespaceInformer(t *testing.T) {
+	// A scoped identity typically cannot list/watch namespaces cluster-wide;
+	// the scoped registration must never instantiate the namespaces informer.
+	// Passing a nil factory proves it: any touch would panic.
+	reg := domain.New()
+	notifier, err := RegisterNamespaceDomain(reg, nil, nil, []string{"prod"})
+	require.NoError(t, err)
+	require.NotNil(t, notifier)
 }

--- a/backend/refresh/snapshot/object_map.go
+++ b/backend/refresh/snapshot/object_map.go
@@ -137,6 +137,9 @@ type objectMapBuilder struct {
 	// ingest supplies projected object-map nodes for ingest-owned (cut) kinds. nil
 	// when no kind in the build is ingest-owned (e.g. a unit test with no cut kinds).
 	ingest objectMapIngestSource
+	// allowedNamespaces is the cluster's namespace scope
+	// (docs/plans/namespace-scope.md) for the live-LIST collectors.
+	allowedNamespaces []string
 }
 
 // objectMapTypedSource carries everything collectTyped needs for one build: the
@@ -195,7 +198,11 @@ type objectMapRecord struct {
 }
 
 type objectMapIndex struct {
-	meta       ClusterMeta
+	meta ClusterMeta
+	// scope is the cluster's namespace scope (docs/plans/namespace-scope.md):
+	// the live-LIST collectors (gateway kinds, HPA) fan out over it instead
+	// of listing cluster-wide. Empty means cluster-wide.
+	scope      []string
 	records    map[string]*objectMapRecord
 	byUID      map[string]*objectMapRecord
 	byIdent    map[string]*objectMapRecord
@@ -235,6 +242,7 @@ func RegisterObjectMapDomain(
 	gatewayPresence objectMapGatewayPresence,
 	catalogService func() *objectcatalog.Service,
 	ingestSource objectMapIngestSource,
+	allowedNamespaces []string,
 ) error {
 	if client == nil {
 		return fmt.Errorf("kubernetes client is required for object map domain")
@@ -243,13 +251,14 @@ func RegisterObjectMapDomain(
 		return fmt.Errorf("shared informer factory is required for object map domain")
 	}
 	builder := &objectMapBuilder{
-		client:          client,
-		gatewayClient:   gatewayClient,
-		gatewayPresence: gatewayPresence,
-		catalogService:  catalogService,
-		shared:          shared,
-		permissions:     permissions,
-		ingest:          ingestSource,
+		client:            client,
+		gatewayClient:     gatewayClient,
+		gatewayPresence:   gatewayPresence,
+		catalogService:    catalogService,
+		shared:            shared,
+		permissions:       permissions,
+		ingest:            ingestSource,
+		allowedNamespaces: append([]string(nil), allowedNamespaces...),
 	}
 	return reg.Register(refresh.DomainConfig{
 		Name:          objectMapDomain,
@@ -351,9 +360,10 @@ func parseBoundedInt(raw string, fallback, minValue, maxValue int) int {
 	return parsed
 }
 
-func newObjectMapIndex(meta ClusterMeta) *objectMapIndex {
+func newObjectMapIndex(meta ClusterMeta, allowedNamespaces []string) *objectMapIndex {
 	return &objectMapIndex{
 		meta:    meta,
+		scope:   append([]string(nil), allowedNamespaces...),
 		records: make(map[string]*objectMapRecord),
 		byUID:   make(map[string]*objectMapRecord),
 		byIdent: make(map[string]*objectMapRecord),
@@ -481,7 +491,16 @@ func (idx *objectMapIndex) collectGatewayTyped(ctx context.Context, client gatew
 		if !gatewayKindPresent(presence, collector.Identity.Kind) {
 			continue
 		}
-		items, err := collector.List(ctx, client)
+		var items []metav1.Object
+		var err error
+		for _, namespace := range idx.listNamespaces(collector.Identity.Namespaced) {
+			listed, listErr := collector.List(ctx, client, namespace)
+			if listErr != nil {
+				err = listErr
+				break
+			}
+			items = append(items, listed...)
+		}
 		if idx.skipListError(collector.Identity.Resource, err) {
 			if idx.hasListError() {
 				return
@@ -501,6 +520,17 @@ func (idx *objectMapIndex) collectGatewayTyped(ctx context.Context, client gatew
 	}
 }
 
+// listNamespaces returns the namespaces a live-LIST collector runs in: the
+// configured scope for a namespaced kind under a namespace scope, otherwise
+// the single cluster-wide "" — the unscoped degenerate of the same loop. A
+// per-namespace Forbidden is swallowed by skipListError exactly as before.
+func (idx *objectMapIndex) listNamespaces(namespaced bool) []string {
+	if !namespaced || len(idx.scope) == 0 {
+		return []string{""}
+	}
+	return idx.scope
+}
+
 func gatewayKindPresent(presence objectMapGatewayPresence, kind string) bool {
 	return presence == nil || presence.Has(kind)
 }
@@ -513,13 +543,25 @@ func (idx *objectMapIndex) collectHPAs(ctx context.Context, client kubernetes.In
 	if client == nil {
 		return
 	}
-	list, err := client.AutoscalingV2().HorizontalPodAutoscalers(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	var items []autoscalingv2.HorizontalPodAutoscaler
+	var err error
+	for _, namespace := range idx.listNamespaces(true) {
+		if namespace == "" {
+			namespace = metav1.NamespaceAll
+		}
+		list, listErr := client.AutoscalingV2().HorizontalPodAutoscalers(namespace).List(ctx, metav1.ListOptions{})
+		if listErr != nil {
+			err = listErr
+			break
+		}
+		items = append(items, list.Items...)
+	}
 	if idx.skipListError("horizontalpodautoscalers", err) {
 		return
 	}
 	idx.hpaListed = true
-	for i := range list.Items {
-		hpa := list.Items[i]
+	for i := range items {
+		hpa := items[i]
 		idx.addRecord(&objectMapRecord{
 			ref:               refFromObject(&hpa.ObjectMeta, hpapkg.Identity.Group, hpapkg.Identity.Version, hpapkg.Identity.Kind, hpapkg.Identity.Resource, hpa.Namespace),
 			obj:               &hpa,

--- a/backend/refresh/snapshot/object_map_assembler.go
+++ b/backend/refresh/snapshot/object_map_assembler.go
@@ -15,7 +15,7 @@ type objectMapAssembler struct {
 
 func (b *objectMapBuilder) newObjectMapAssembler(ctx context.Context) (*objectMapAssembler, error) {
 	meta := ClusterMetaFromContext(ctx)
-	index := newObjectMapIndex(meta)
+	index := newObjectMapIndex(meta, b.allowedNamespaces)
 	index.addCatalog(b.catalog())
 	index.collectTyped(objectMapTypedSource{
 		ctx:         ctx,

--- a/backend/refresh/snapshot/object_map_test.go
+++ b/backend/refresh/snapshot/object_map_test.go
@@ -3,6 +3,7 @@ package snapshot
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1420,4 +1421,52 @@ func stringPtr(value string) *string {
 func objectNamePtr(value string) *gatewayv1.ObjectName {
 	name := gatewayv1.ObjectName(value)
 	return &name
+}
+
+// Scoped clusters (docs/plans/namespace-scope.md): the object map's live-LIST
+// collectors run once per configured namespace and never cluster-wide — the
+// scoped identity could not perform that LIST. The fake clientset does not
+// enforce server-side namespace filtering, so the assertion is on the
+// namespaces REQUESTED (the contract this code owns).
+func TestObjectMapScopedGatewayCollectionListsOnlyScopeNamespaces(t *testing.T) {
+	client := fake.NewSimpleClientset(serviceFixture("default", "web", "svc-web-uid", nil))
+	gatewayClient := newObjectMapGatewayClient(t)
+
+	var mu sync.Mutex
+	requested := map[string]map[string]bool{}
+	gatewayClient.PrependReactor("list", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		mu.Lock()
+		resource := action.GetResource().Resource
+		if requested[resource] == nil {
+			requested[resource] = map[string]bool{}
+		}
+		requested[resource][action.GetNamespace()] = true
+		mu.Unlock()
+		return false, nil, nil
+	})
+
+	builder := newObjectMapTestBuilder(t, client)
+	builder.gatewayClient = gatewayClient
+	builder.allowedNamespaces = []string{"default", "team-b"}
+	ctx := WithClusterMeta(context.Background(), ClusterMeta{ClusterID: "cluster-a", ClusterName: "Cluster A"})
+	if _, err := builder.Build(ctx, "default:gateway.networking.k8s.io/v1:Gateway:edge?maxDepth=5&maxNodes=100"); err != nil {
+		t.Fatalf("scoped build failed: %v", err)
+	}
+
+	for _, resource := range []string{"gateways", "httproutes", "tlsroutes", "grpcroutes"} {
+		got := requested[resource]
+		if got == nil {
+			t.Fatalf("no list recorded for %s", resource)
+		}
+		if got[""] {
+			t.Fatalf("%s was listed cluster-wide under a namespace scope: %v", resource, got)
+		}
+		if !got["default"] || !got["team-b"] {
+			t.Fatalf("%s must be listed in every scope namespace, got %v", resource, got)
+		}
+	}
+	// Cluster-scoped gateway kinds keep their single cluster-wide list.
+	if got := requested["gatewayclasses"]; got == nil || !got[""] || len(got) != 1 {
+		t.Fatalf("gatewayclasses must keep one cluster-wide list, got %v", got)
+	}
 }

--- a/backend/refresh/snapshot/service.go
+++ b/backend/refresh/snapshot/service.go
@@ -335,6 +335,13 @@ func (s *Service) ensurePermissions(ctx context.Context, domainName, scope strin
 	if s.registry != nil && s.registry.IsPermissionDenied(domainName) {
 		return ctx, "", nil
 	}
+	// A runtime-policy-exempt domain's data source needs no cluster
+	// permission in this configuration (the scoped namespaces domain serves
+	// synthesized names) — the serve-time gate must match the source exactly
+	// as the registration-time gate does (docs/plans/namespace-scope.md).
+	if s.registry != nil && s.registry.IsRuntimePolicyExempt(domainName) {
+		return ctx, "", nil
+	}
 	start := time.Now()
 	decision, err := s.runtimeAccess.Check(ctx, domainName, s.permissionChecker)
 	permissionCacheKey := domainpermissions.AllowedResourcesFingerprint(decision.AllowedResources)

--- a/backend/refresh/snapshot/service_test.go
+++ b/backend/refresh/snapshot/service_test.go
@@ -840,7 +840,7 @@ func TestServiceBuildBlocksPermissionDenied(t *testing.T) {
 	}
 
 	// Deny all resources in the namespace-config domain (configmaps + secrets).
-	checker := permissions.NewCheckerWithReview("cluster-a", 0, func(ctx context.Context, group, resource, verb string) (bool, error) {
+	checker := permissions.NewCheckerWithReview("cluster-a", 0, func(ctx context.Context, group, resource, verb, _ string) (bool, error) {
 		return false, nil
 	})
 	service := NewServiceWithPermissions(reg, nil, testClusterMeta(), checker)
@@ -871,7 +871,7 @@ func TestServiceBuildBlocksNamespacesWithoutListPermission(t *testing.T) {
 		t.Fatalf("register failed: %v", err)
 	}
 
-	checker := permissions.NewCheckerWithReview("cluster-a", 0, func(ctx context.Context, group, resource, verb string) (bool, error) {
+	checker := permissions.NewCheckerWithReview("cluster-a", 0, func(ctx context.Context, group, resource, verb, _ string) (bool, error) {
 		if group == "" && resource == "namespaces" && verb == "list" {
 			return false, nil
 		}
@@ -908,7 +908,7 @@ func TestServiceBuildAllowsPartialPermissions(t *testing.T) {
 	}
 
 	// Deny configmaps but allow secrets.
-	checker := permissions.NewCheckerWithReview("cluster-a", 0, func(ctx context.Context, group, resource, verb string) (bool, error) {
+	checker := permissions.NewCheckerWithReview("cluster-a", 0, func(ctx context.Context, group, resource, verb, _ string) (bool, error) {
 		if resource == "configmaps" && verb == "list" {
 			return false, nil
 		}
@@ -949,7 +949,7 @@ func TestServiceBuildKeysCacheByRuntimeAllowedResources(t *testing.T) {
 		t.Fatalf("register failed: %v", err)
 	}
 
-	checker := permissions.NewCheckerWithReview("cluster-a", 0, func(ctx context.Context, group, resource, verb string) (bool, error) {
+	checker := permissions.NewCheckerWithReview("cluster-a", 0, func(ctx context.Context, group, resource, verb, _ string) (bool, error) {
 		return resource == "configmaps" || resource == "secrets", nil
 	})
 	service := NewServiceWithPermissions(reg, nil, testClusterMeta(), checker)
@@ -963,7 +963,7 @@ func TestServiceBuildKeysCacheByRuntimeAllowedResources(t *testing.T) {
 		t.Fatalf("expected first build to allow both resources, got %#v", firstPayload)
 	}
 
-	service.permissionChecker = permissions.NewCheckerWithReview("cluster-a", 0, func(ctx context.Context, group, resource, verb string) (bool, error) {
+	service.permissionChecker = permissions.NewCheckerWithReview("cluster-a", 0, func(ctx context.Context, group, resource, verb, _ string) (bool, error) {
 		return resource == "secrets", nil
 	})
 	second, err := service.Build(context.Background(), namespaceConfigDomainName, "cluster-a|namespace:default")
@@ -987,7 +987,7 @@ func TestServiceBuildSkipsEnsureForPermissionDeniedDomain(t *testing.T) {
 	}
 
 	reviewCalled := false
-	checker := permissions.NewCheckerWithReview("cluster-a", 0, func(ctx context.Context, group, resource, verb string) (bool, error) {
+	checker := permissions.NewCheckerWithReview("cluster-a", 0, func(ctx context.Context, group, resource, verb, _ string) (bool, error) {
 		reviewCalled = true
 		return false, nil
 	})
@@ -1027,7 +1027,7 @@ func TestServiceBuildAllowsWhenPermissionsSucceed(t *testing.T) {
 		t.Fatalf("register failed: %v", err)
 	}
 
-	checker := permissions.NewCheckerWithReview("cluster-a", 0, func(ctx context.Context, group, resource, verb string) (bool, error) {
+	checker := permissions.NewCheckerWithReview("cluster-a", 0, func(ctx context.Context, group, resource, verb, _ string) (bool, error) {
 		return true, nil
 	})
 	service := NewServiceWithPermissions(reg, nil, testClusterMeta(), checker)

--- a/backend/refresh/snapshot/service_test.go
+++ b/backend/refresh/snapshot/service_test.go
@@ -1039,3 +1039,38 @@ func TestServiceBuildAllowsWhenPermissionsSucceed(t *testing.T) {
 		t.Fatalf("expected snapshot builder to run when permissions allow")
 	}
 }
+
+// The scoped namespaces domain (docs/plans/namespace-scope.md) serves
+// synthesized rows and needs NO cluster permission — the per-request policy
+// gate must honor the registration's exemption. This is the live-observed
+// failure: the scoped domain was registered and serving, but every fetch got
+// a fresh 403 from ensurePermissions, so the sidebar never left the
+// permission-denied state.
+func TestServiceBuildServesRuntimePolicyExemptDomainForDeniedIdentity(t *testing.T) {
+	reg := domain.New()
+	called := false
+	if err := reg.Register(refresh.DomainConfig{
+		Name:                "namespaces",
+		RuntimePolicyExempt: true,
+		BuildSnapshot: func(ctx context.Context, scope string) (*refresh.Snapshot, error) {
+			called = true
+			return &refresh.Snapshot{Domain: "namespaces", Scope: scope}, nil
+		},
+	}); err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+
+	// The restricted persona: every cluster-wide ask denied.
+	checker := permissions.NewCheckerWithReview("cluster-a", 0, func(context.Context, string, string, string, string) (bool, error) {
+		return false, nil
+	})
+	service := NewServiceWithPermissions(reg, nil, testClusterMeta(), checker)
+
+	snap, err := service.Build(context.Background(), "namespaces", "cluster-a|")
+	if err != nil {
+		t.Fatalf("exempt domain must serve despite a fully denied identity: %v", err)
+	}
+	if snap == nil || !called {
+		t.Fatalf("expected the builder to run (called=%v, snap=%v)", called, snap)
+	}
+}

--- a/backend/refresh/system/ingest_hub_test.go
+++ b/backend/refresh/system/ingest_hub_test.go
@@ -82,7 +82,7 @@ func TestIngestInformerHubGlobalReadinessTracksFactoryOnly(t *testing.T) {
 }
 
 func newTestInformerFactory() *informer.Factory {
-	checker := permissions.NewCheckerWithReview("cluster-a", time.Minute, func(context.Context, string, string, string) (bool, error) {
+	checker := permissions.NewCheckerWithReview("cluster-a", time.Minute, func(context.Context, string, string, string, string) (bool, error) {
 		return true, nil
 	})
 	return informer.New(kubernetesfake.NewClientset(), nil, time.Hour, checker)

--- a/backend/refresh/system/ingest_permission_test.go
+++ b/backend/refresh/system/ingest_permission_test.go
@@ -1,8 +1,12 @@
 package system
 
 import (
+	"context"
 	"errors"
 	"testing"
+	"time"
+
+	"github.com/luxury-yacht/app/backend/refresh/permissions"
 )
 
 // TestIngestPermissionFilterConservative pins the conservative gating contract: the
@@ -11,28 +15,51 @@ import (
 // per-kind sync-deadline degrade is the backstop, so a transient permission blip never
 // wrongly excludes a kind with no retry.
 func TestIngestPermissionFilterConservative(t *testing.T) {
-	allow := func(string, string) (bool, error) { return true, nil }
-	deny := func(string, string) (bool, error) { return false, nil }
-	boom := func(string, string) (bool, error) { return false, errors.New("ssar boom") }
-
 	cases := []struct {
-		name              string
-		canList, canWatch func(string, string) (bool, error)
-		wantRun           bool
+		name    string
+		review  func(verb string) (bool, error)
+		wantRun bool
 	}{
-		{"both allowed -> run", allow, allow, true},
-		{"list denied -> skip", deny, allow, false},
-		{"watch denied -> skip", allow, deny, false},
-		{"list errors -> run (deadline backstops)", boom, allow, true},
-		{"watch errors -> run (deadline backstops)", allow, boom, true},
-		{"both error -> run", boom, boom, true},
+		{"both allowed -> run", func(string) (bool, error) { return true, nil }, true},
+		{"list denied -> skip", func(verb string) (bool, error) { return verb != "list", nil }, false},
+		{"watch denied -> skip", func(verb string) (bool, error) { return verb != "watch", nil }, false},
+		{"list errors -> run (deadline backstops)", func(verb string) (bool, error) {
+			if verb == "list" {
+				return false, errors.New("ssar boom")
+			}
+			return true, nil
+		}, true},
+		{"both error -> run", func(string) (bool, error) { return false, errors.New("ssar boom") }, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := ingestPermissionFilter(tc.canList, tc.canWatch)("g", "r")
+			checker := permissions.NewCheckerWithReview("test", time.Minute, func(_ context.Context, _, _, verb, _ string) (bool, error) {
+				return tc.review(verb)
+			})
+			got := ingestPermissionFilter(checker)("g", "r", "")
 			if got != tc.wantRun {
 				t.Fatalf("ingestPermissionFilter run=%v, want %v", got, tc.wantRun)
 			}
 		})
+	}
+}
+
+// TestIngestPermissionFilterChecksThePartNamespace pins the scoped contract
+// (docs/plans/namespace-scope.md): a part's filter decision is made for ITS
+// namespace, so one denied namespace skips one reflector — never the kind.
+func TestIngestPermissionFilterChecksThePartNamespace(t *testing.T) {
+	checker := permissions.NewCheckerWithReview("test", time.Minute, func(_ context.Context, _, _, _, namespace string) (bool, error) {
+		return namespace != "prod", nil
+	})
+	filter := ingestPermissionFilter(checker)
+
+	if filter("g", "r", "prod") {
+		t.Fatal("prod is denied: its part must be skipped")
+	}
+	if !filter("g", "r", "dev") {
+		t.Fatal("dev is allowed: its part must run")
+	}
+	if !filter("g", "r", "") {
+		t.Fatal("cluster-wide part uses the cluster-wide check")
 	}
 }

--- a/backend/refresh/system/manager.go
+++ b/backend/refresh/system/manager.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/luxury-yacht/app/backend/internal/applog"
 	"github.com/luxury-yacht/app/backend/internal/config"
+	"github.com/luxury-yacht/app/backend/kind/kindregistry"
 	"github.com/luxury-yacht/app/backend/kind/streamrows"
 	"github.com/luxury-yacht/app/backend/objectcatalog"
 	"github.com/luxury-yacht/app/backend/refresh"
@@ -72,9 +73,9 @@ type Config struct {
 	ClusterID                  string                                   // stable identifier for cluster-scoped keys
 	ClusterName                string                                   // display name for cluster in payloads
 	// AllowedNamespaces is the cluster's namespace scope
-	// (docs/plans/namespace-scope.md). Empty means cluster-wide. Carried for
-	// subsystem construction; enforcement in the data/permission paths lands
-	// in later plan phases.
+	// (docs/plans/namespace-scope.md). Empty means cluster-wide. Enforced by
+	// the permission checker's scope fan-out, the scoped namespaces domain,
+	// and the ingest manager's per-namespace reflectors.
 	AllowedNamespaces []string
 }
 
@@ -130,10 +131,32 @@ func NewSubsystem(cfg Config) (*refresh.Manager, http.Handler, *telemetry.Record
 		nil
 }
 
+// scopedResourcePredicate reports which resources' permission checks fan out
+// over a configured namespace scope (docs/plans/namespace-scope.md): exactly
+// the namespaced, ingest-owned kinds, because only their data path runs
+// per-namespace. A check's scope must match its data source's scope — scoping
+// the check for a cluster-wide source (events, HPA, replicasets, gateway,
+// helm storage) would register domains that then serve silently-empty data.
+func scopedResourcePredicate() func(group, resource string) bool {
+	scoped := make(map[string]struct{})
+	for _, d := range kindregistry.IngestOwnedDescriptors() {
+		if d.Identity.Namespaced {
+			scoped[d.Identity.Group+"/"+d.Identity.Resource] = struct{}{}
+		}
+	}
+	return func(group, resource string) bool {
+		_, ok := scoped[group+"/"+resource]
+		return ok
+	}
+}
+
 // NewSubsystemWithServices returns a fully wired refresh subsystem.
 func NewSubsystemWithServices(cfg Config) (*Subsystem, error) {
 	registry := domain.New()
 	runtimePerms := permissions.NewChecker(cfg.KubernetesClient, cfg.ClusterID, 0)
+	if len(cfg.AllowedNamespaces) > 0 {
+		runtimePerms.SetScope(cfg.AllowedNamespaces, scopedResourcePredicate())
+	}
 	// Decide once per process whether WatchList is usable, BEFORE the first
 	// informer factory issues a watch (client-go reads the WatchListClient gate
 	// lazily and caches it). If a bookmark-stripping proxy is in front of the
@@ -152,6 +175,7 @@ func NewSubsystemWithServices(cfg Config) (*Subsystem, error) {
 		cfg.KubernetesClient,
 		cfg.APIExtensionsClient,
 		cfg.GatewayClient,
+		cfg.AllowedNamespaces...,
 	)
 	// Dynamic client for the on-demand dynamic (CRD-backed) reflectors the catalog promotes
 	// at runtime (objectcatalog maybePromote → RegisterDynamicCatalogReflector). Set before
@@ -186,8 +210,7 @@ func NewSubsystemWithServices(cfg Config) (*Subsystem, error) {
 	// a true failure, so a transient permission blip never wrongly excludes a kind with
 	// no retry. Permission preflight below primes the same checker before Start, and
 	// cache misses still run the normal SubjectAccessReview path.
-	ingestManager.SetPermissionFilter(ingestPermissionFilter(
-		informerFactory.CanListResource, informerFactory.CanWatchResource))
+	ingestManager.SetPermissionFilter(ingestPermissionFilter(runtimePerms))
 
 	informerHub := newIngestInformerHub(informerFactory, ingestManager)
 
@@ -246,6 +269,7 @@ func NewSubsystemWithServices(cfg Config) (*Subsystem, error) {
 	appendIssue("metrics-poller", "metrics.k8s.io/nodes,pods", metricsErrs...)
 	if len(metricsErrs) == 0 && metricsAllowed {
 		poller := metrics.NewPoller(cfg.MetricsClient, cfg.RestConfig, cfg.MetricsInterval, telemetryRecorder)
+		poller.SetAllowedNamespaces(cfg.AllowedNamespaces)
 		idleTimeout := cfg.MetricsInterval * 3
 		demandPoller := metrics.NewDemandPoller(poller, poller, idleTimeout)
 		metricsPoller = demandPoller
@@ -504,12 +528,16 @@ func eventSignalObserver(resourceManager *resourcestream.Manager) func(scope str
 // sync-deadline degrade is the backstop, so a transient permission blip never wrongly
 // excludes a kind with no retry. canList/canWatch are the factory's CanListResource/
 // CanWatchResource.
-func ingestPermissionFilter(canList, canWatch func(group, resource string) (bool, error)) func(group, resource string) bool {
-	return func(group, resource string) bool {
-		if allowed, err := canList(group, resource); err == nil && !allowed {
+func ingestPermissionFilter(checker *permissions.Checker) func(group, resource, namespace string) bool {
+	return func(group, resource, namespace string) bool {
+		ctx := context.Background()
+		// namespace "" is the cluster-wide part — exactly the pre-scope check.
+		// A scoped part asks about ITS namespace only, so one denied namespace
+		// skips one reflector, never the kind's siblings.
+		if decision, err := checker.CanInNamespace(ctx, group, resource, "list", namespace); err == nil && !decision.Allowed {
 			return false
 		}
-		if allowed, err := canWatch(group, resource); err == nil && !allowed {
+		if decision, err := checker.CanInNamespace(ctx, group, resource, "watch", namespace); err == nil && !decision.Allowed {
 			return false
 		}
 		return true

--- a/backend/refresh/system/manager.go
+++ b/backend/refresh/system/manager.go
@@ -71,6 +71,11 @@ type Config struct {
 	ContainerLogsTargetLimiter *containerlogsstream.GlobalTargetLimiter // Shared global limiter for container logs stream targets.
 	ClusterID                  string                                   // stable identifier for cluster-scoped keys
 	ClusterName                string                                   // display name for cluster in payloads
+	// AllowedNamespaces is the cluster's namespace scope
+	// (docs/plans/namespace-scope.md). Empty means cluster-wide. Carried for
+	// subsystem construction; enforcement in the data/permission paths lands
+	// in later plan phases.
+	AllowedNamespaces []string
 }
 
 // Subsystem bundles the refresh manager and supporting services.

--- a/backend/refresh/system/namespaces_registration_test.go
+++ b/backend/refresh/system/namespaces_registration_test.go
@@ -1,0 +1,32 @@
+package system
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Scoped clusters (docs/plans/namespace-scope.md) register the namespaces
+// domain directly: rows are synthesized from configuration, so neither the
+// cluster-wide list+watch gate nor the runtime policy may apply — both would
+// deny exactly the restricted user the scope exists for.
+func TestNamespacesRegistrationScopedBypassesPermissionGates(t *testing.T) {
+	deps := registrationDeps{cfg: Config{AllowedNamespaces: []string{"prod", "dev"}}}
+
+	reg := namespacesRegistration(deps)
+	require.Equal(t, "namespaces", reg.name)
+	require.NotNil(t, reg.direct, "scoped registration must dispatch directly")
+	require.Nil(t, reg.listWatch)
+	require.True(t, reg.skipRuntimePolicy, "synthesized rows need no cluster permission")
+}
+
+func TestNamespacesRegistrationUnscopedKeepsFailFastGate(t *testing.T) {
+	deps := registrationDeps{cfg: Config{}}
+
+	reg := namespacesRegistration(deps)
+	require.Equal(t, "namespaces", reg.name)
+	require.Nil(t, reg.direct)
+	require.NotNil(t, reg.listWatch)
+	require.False(t, reg.skipRuntimePolicy)
+	require.Equal(t, []listWatchCheck{{group: "", resource: "namespaces"}}, reg.listWatch.checks)
+}

--- a/backend/refresh/system/registrations.go
+++ b/backend/refresh/system/registrations.go
@@ -46,6 +46,12 @@ type domainRegistration struct {
 	direct             func() error           // Direct registration function
 	skipIf             func() bool            // Function to determine if registration should be skipped
 	require            func() error           // Function to determine if registration is required
+	// skipRuntimePolicy exempts the registration from the domain runtime
+	// permission policy. Set ONLY when the domain's data source needs no
+	// cluster permission for this configuration (the scoped namespaces
+	// domain serves synthesized names) — the permission gate must always
+	// match the data source's actual scope.
+	skipRuntimePolicy bool
 }
 
 // domainMeta captures shared metadata for gated registrations that cannot use
@@ -82,7 +88,7 @@ func runDomainRegistrations(ctx context.Context, gate *permissionGate, checker *
 			}
 		}
 
-		if checker != nil {
+		if checker != nil && !registration.skipRuntimePolicy {
 			decision, err := access.Check(ctx, registration.name, checker)
 			if err == nil && !decision.Allowed {
 				if regErr := snapshot.RegisterPermissionDeniedDomain(gate.registry, registration.name, decision.DeniedReason); regErr != nil {
@@ -257,31 +263,16 @@ func domainRegistrations(deps registrationDeps) []domainRegistration {
 	runtimeAccess := domainpermissions.NewRuntimeAccess()
 
 	return []domainRegistration{
-		// Fail fast on missing list permission: a restricted user gets an
-		// explicit permission-denied snapshot (the sidebar renders "You do not
-		// have permission to list namespaces.") instead of an empty list. No
-		// fallback by design — manual namespace entry is future work
-		// (docs/todo.md).
-		listWatchRegistration(listWatchDomainConfig{
-			name:          "namespaces",
-			issueResource: "core/namespaces",
-			logGroup:      "",
-			logResource:   "namespaces",
-			checks: []listWatchCheck{
-				{group: "", resource: "namespaces"},
-			},
-			registerInformer: func() error {
-				notifier, err := snapshot.RegisterNamespaceDomain(deps.registry, deps.informerFactory.SharedInformerFactory(), deps.ingestManager)
-				if err != nil {
-					return err
-				}
-				if deps.noteNamespaceNotifier != nil {
-					deps.noteNamespaceNotifier(notifier)
-				}
-				return nil
-			},
-			deniedReason: "core/namespaces",
-		}),
+		// Unscoped: fail fast on missing list permission — a restricted user
+		// gets an explicit permission-denied snapshot (the sidebar renders
+		// "You do not have permission to list namespaces." plus the scope
+		// editor) instead of an empty list. Scoped
+		// (cfg.AllowedNamespaces non-empty, docs/plans/namespace-scope.md):
+		// rows are synthesized from the configured names, so the domain
+		// needs no cluster permission at all — it registers directly, with
+		// the runtime policy exempted to match its permissionless data
+		// source.
+		namespacesRegistration(deps),
 
 		// Cluster overview degrades per resource (issue #244): the informer path
 		// needs only the namespaces informer — nodes, pods, and the workload
@@ -484,6 +475,7 @@ func domainRegistrations(deps registrationDeps) []domainRegistration {
 					deps.informerFactory.APIExtensionsInformerFactory(),
 					deps.cfg.DynamicClient,
 					deps.cfg.Logger,
+					deps.cfg.AllowedNamespaces,
 				)
 			},
 		}), requireAvailable("dynamic client must be provided for namespace custom resources", func() bool {
@@ -592,6 +584,7 @@ func domainRegistrations(deps registrationDeps) []domainRegistration {
 				deps.cfg.GatewayAPIPresence,
 				deps.cfg.ObjectCatalogService,
 				deps.ingestManager,
+				deps.cfg.AllowedNamespaces,
 			)
 		}),
 		directRegistration("object-maintenance", func() error {
@@ -681,6 +674,47 @@ func listChecksFromRegistrationPlan(plan domainpermissions.RegistrationAccessPla
 		checks = append(checks, listCheck{group: req.Group, resource: req.Resource})
 	}
 	return checks
+}
+
+// namespacesRegistration builds the namespaces-domain registration entry.
+// Scoped clusters (allowedNamespaces set) register directly and exempt the
+// runtime policy: the rows are synthesized from configuration, so requiring
+// the cluster-wide namespaces LIST would deny exactly the restricted user
+// the scope exists for. Unscoped clusters keep the fail-fast list+watch gate.
+func namespacesRegistration(deps registrationDeps) domainRegistration {
+	registerScopedOrUnscoped := func() error {
+		notifier, err := snapshot.RegisterNamespaceDomain(
+			deps.registry,
+			deps.informerFactory.SharedInformerFactory(),
+			deps.ingestManager,
+			deps.cfg.AllowedNamespaces,
+		)
+		if err != nil {
+			return err
+		}
+		if deps.noteNamespaceNotifier != nil {
+			deps.noteNamespaceNotifier(notifier)
+		}
+		return nil
+	}
+	if len(deps.cfg.AllowedNamespaces) > 0 {
+		return domainRegistration{
+			name:              "namespaces",
+			direct:            registerScopedOrUnscoped,
+			skipRuntimePolicy: true,
+		}
+	}
+	return listWatchRegistration(listWatchDomainConfig{
+		name:          "namespaces",
+		issueResource: "core/namespaces",
+		logGroup:      "",
+		logResource:   "namespaces",
+		checks: []listWatchCheck{
+			{group: "", resource: "namespaces"},
+		},
+		registerInformer: registerScopedOrUnscoped,
+		deniedReason:     "core/namespaces",
+	})
 }
 
 func listWatchRegistration(cfg listWatchDomainConfig) domainRegistration {

--- a/backend/refresh/system/registrations.go
+++ b/backend/refresh/system/registrations.go
@@ -688,6 +688,7 @@ func namespacesRegistration(deps registrationDeps) domainRegistration {
 			deps.informerFactory.SharedInformerFactory(),
 			deps.ingestManager,
 			deps.cfg.AllowedNamespaces,
+			deps.cfg.KubernetesClient,
 		)
 		if err != nil {
 			return err

--- a/backend/refresh/system/scoped_permissions_test.go
+++ b/backend/refresh/system/scoped_permissions_test.go
@@ -1,0 +1,26 @@
+package system
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The scope predicate encodes the rule that a permission check's scope must
+// match the data source's scope: only namespaced, ingest-owned kinds are
+// served from per-namespace-capable sources today. Factory-backed kinds
+// (events, HPA, replicasets, gateway) and cluster-scoped kinds stay
+// cluster-wide until their sources are scoped.
+func TestScopedResourcePredicate(t *testing.T) {
+	applies := scopedResourcePredicate()
+
+	require.True(t, applies("apps", "deployments"))
+	require.True(t, applies("", "pods"))
+	require.True(t, applies("", "secrets"))
+	require.False(t, applies("", "events"), "events informer is cluster-wide")
+	require.False(t, applies("autoscaling", "horizontalpodautoscalers"), "HPA informer is cluster-wide")
+	require.False(t, applies("apps", "replicasets"), "RS informer is cluster-wide")
+	require.False(t, applies("", "nodes"), "cluster-scoped kinds never scope")
+	require.False(t, applies("", "namespaces"))
+	require.False(t, applies("gateway.networking.k8s.io", "httproutes"), "gateway informers are cluster-wide")
+}

--- a/backend/refresh/system/streams.go
+++ b/backend/refresh/system/streams.go
@@ -55,6 +55,7 @@ func registerStreamHandlers(mux *http.ServeMux, deps streamDeps) (*eventstream.M
 		deps.clusterMeta,
 		deps.cfg.DynamicClient,
 		deps.ingestManager,
+		deps.cfg.AllowedNamespaces...,
 	)
 	resourceHandler, err := resourcestream.NewHandler(resourceManager, logger, deps.telemetry, deps.clusterMeta)
 	if err != nil {

--- a/backend/refresh/types.go
+++ b/backend/refresh/types.go
@@ -38,6 +38,12 @@ type DomainConfig struct {
 	BuildSnapshot    func(ctx context.Context, scope string) (*Snapshot, error)
 	ManualRefresh    func(ctx context.Context, scope string) (*ManualRefreshResult, error)
 	PermissionDenied bool // Set when domain is registered as a permission-denied placeholder.
+	// RuntimePolicyExempt marks a domain whose data source needs no cluster
+	// permission in this configuration (the scoped namespaces domain serves
+	// synthesized names, docs/plans/namespace-scope.md). The snapshot
+	// service's per-request policy gate skips exempt domains, exactly as the
+	// registration-time gate does — the gate must match the source.
+	RuntimePolicyExempt bool
 }
 
 // InformerHub exposes informer lifecycle hooks used by the refresh manager.

--- a/backend/resources/backendtlspolicy/objectmapnode.go
+++ b/backend/resources/backendtlspolicy/objectmapnode.go
@@ -14,8 +14,11 @@ import (
 // LIST via the Gateway client) and projects each object into a graph node.
 var ObjectMapNode = objectmapnode.GatewayCollector{
 	Identity: Identity,
-	List: func(ctx context.Context, client gatewayversioned.Interface) ([]metav1.Object, error) {
-		list, err := client.GatewayV1().BackendTLSPolicies(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	List: func(ctx context.Context, client gatewayversioned.Interface, namespace string) ([]metav1.Object, error) {
+		if namespace == "" {
+			namespace = metav1.NamespaceAll
+		}
+		list, err := client.GatewayV1().BackendTLSPolicies(namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return nil, err
 		}

--- a/backend/resources/gateway/objectmapnode.go
+++ b/backend/resources/gateway/objectmapnode.go
@@ -14,8 +14,11 @@ import (
 // LIST via the Gateway client) and projects each object into a graph node.
 var ObjectMapNode = objectmapnode.GatewayCollector{
 	Identity: Identity,
-	List: func(ctx context.Context, client gatewayversioned.Interface) ([]metav1.Object, error) {
-		list, err := client.GatewayV1().Gateways(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	List: func(ctx context.Context, client gatewayversioned.Interface, namespace string) ([]metav1.Object, error) {
+		if namespace == "" {
+			namespace = metav1.NamespaceAll
+		}
+		list, err := client.GatewayV1().Gateways(namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return nil, err
 		}

--- a/backend/resources/gatewayclass/objectmapnode.go
+++ b/backend/resources/gatewayclass/objectmapnode.go
@@ -14,7 +14,7 @@ import (
 // LIST via the Gateway client) and projects each object into a graph node.
 var ObjectMapNode = objectmapnode.GatewayCollector{
 	Identity: Identity,
-	List: func(ctx context.Context, client gatewayversioned.Interface) ([]metav1.Object, error) {
+	List: func(ctx context.Context, client gatewayversioned.Interface, _ string) ([]metav1.Object, error) {
 		list, err := client.GatewayV1().GatewayClasses().List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return nil, err

--- a/backend/resources/grpcroute/objectmapnode.go
+++ b/backend/resources/grpcroute/objectmapnode.go
@@ -14,8 +14,11 @@ import (
 // LIST via the Gateway client) and projects each object into a graph node.
 var ObjectMapNode = objectmapnode.GatewayCollector{
 	Identity: Identity,
-	List: func(ctx context.Context, client gatewayversioned.Interface) ([]metav1.Object, error) {
-		list, err := client.GatewayV1().GRPCRoutes(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	List: func(ctx context.Context, client gatewayversioned.Interface, namespace string) ([]metav1.Object, error) {
+		if namespace == "" {
+			namespace = metav1.NamespaceAll
+		}
+		list, err := client.GatewayV1().GRPCRoutes(namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return nil, err
 		}

--- a/backend/resources/httproute/objectmapnode.go
+++ b/backend/resources/httproute/objectmapnode.go
@@ -14,8 +14,11 @@ import (
 // LIST via the Gateway client) and projects each object into a graph node.
 var ObjectMapNode = objectmapnode.GatewayCollector{
 	Identity: Identity,
-	List: func(ctx context.Context, client gatewayversioned.Interface) ([]metav1.Object, error) {
-		list, err := client.GatewayV1().HTTPRoutes(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	List: func(ctx context.Context, client gatewayversioned.Interface, namespace string) ([]metav1.Object, error) {
+		if namespace == "" {
+			namespace = metav1.NamespaceAll
+		}
+		list, err := client.GatewayV1().HTTPRoutes(namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return nil, err
 		}

--- a/backend/resources/listenerset/objectmapnode.go
+++ b/backend/resources/listenerset/objectmapnode.go
@@ -14,8 +14,11 @@ import (
 // LIST via the Gateway client) and projects each object into a graph node.
 var ObjectMapNode = objectmapnode.GatewayCollector{
 	Identity: Identity,
-	List: func(ctx context.Context, client gatewayversioned.Interface) ([]metav1.Object, error) {
-		list, err := client.GatewayV1().ListenerSets(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	List: func(ctx context.Context, client gatewayversioned.Interface, namespace string) ([]metav1.Object, error) {
+		if namespace == "" {
+			namespace = metav1.NamespaceAll
+		}
+		list, err := client.GatewayV1().ListenerSets(namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return nil, err
 		}

--- a/backend/resources/referencegrant/objectmapnode.go
+++ b/backend/resources/referencegrant/objectmapnode.go
@@ -14,8 +14,11 @@ import (
 // LIST via the Gateway client) and projects each object into a graph node.
 var ObjectMapNode = objectmapnode.GatewayCollector{
 	Identity: Identity,
-	List: func(ctx context.Context, client gatewayversioned.Interface) ([]metav1.Object, error) {
-		list, err := client.GatewayV1().ReferenceGrants(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	List: func(ctx context.Context, client gatewayversioned.Interface, namespace string) ([]metav1.Object, error) {
+		if namespace == "" {
+			namespace = metav1.NamespaceAll
+		}
+		list, err := client.GatewayV1().ReferenceGrants(namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return nil, err
 		}

--- a/backend/resources/tlsroute/objectmapnode.go
+++ b/backend/resources/tlsroute/objectmapnode.go
@@ -14,8 +14,11 @@ import (
 // LIST via the Gateway client) and projects each object into a graph node.
 var ObjectMapNode = objectmapnode.GatewayCollector{
 	Identity: Identity,
-	List: func(ctx context.Context, client gatewayversioned.Interface) ([]metav1.Object, error) {
-		list, err := client.GatewayV1().TLSRoutes(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	List: func(ctx context.Context, client gatewayversioned.Interface, namespace string) ([]metav1.Object, error) {
+		if namespace == "" {
+			namespace = metav1.NamespaceAll
+		}
+		list, err := client.GatewayV1().TLSRoutes(namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return nil, err
 		}

--- a/backend/response_cache_invalidation_test.go
+++ b/backend/response_cache_invalidation_test.go
@@ -112,7 +112,7 @@ func TestRegisterHelmCacheInvalidationEvictsViaHelmStorageInformer(t *testing.T)
 	// Build the production helm-storage source from a fake client and register the
 	// Helm cache eviction on it, proving the cut-config path (no shared configmap/
 	// secret informer) still evicts the Helm cache on a release secret change.
-	checker := permissions.NewCheckerWithReview("test", time.Minute, func(_ context.Context, _, _, _ string) (bool, error) {
+	checker := permissions.NewCheckerWithReview("test", time.Minute, func(_ context.Context, _, _, _, _ string) (bool, error) {
 		return true, nil
 	})
 	client := cgofake.NewClientset()

--- a/backend/response_cache_permissions_test.go
+++ b/backend/response_cache_permissions_test.go
@@ -16,7 +16,7 @@ func TestCanServeCachedResponseDeniedEvictsCaches(t *testing.T) {
 	app.responseCache = newResponseCache(time.Minute, 10)
 	selectionKey := "cluster-a"
 
-	checker := permissions.NewCheckerWithReview(selectionKey, time.Minute, func(context.Context, string, string, string) (bool, error) {
+	checker := permissions.NewCheckerWithReview(selectionKey, time.Minute, func(context.Context, string, string, string, string) (bool, error) {
 		return false, nil
 	})
 	app.refreshSubsystems[selectionKey] = &system.Subsystem{RuntimePerms: checker}
@@ -39,7 +39,7 @@ func TestCanServeCachedResponseAllowedKeepsCaches(t *testing.T) {
 	app.responseCache = newResponseCache(time.Minute, 10)
 	selectionKey := "cluster-a"
 
-	checker := permissions.NewCheckerWithReview(selectionKey, time.Minute, func(context.Context, string, string, string) (bool, error) {
+	checker := permissions.NewCheckerWithReview(selectionKey, time.Minute, func(context.Context, string, string, string, string) (bool, error) {
 		return true, nil
 	})
 	app.refreshSubsystems[selectionKey] = &system.Subsystem{RuntimePerms: checker}

--- a/docs/architecture/namespace-scope.md
+++ b/docs/architecture/namespace-scope.md
@@ -40,7 +40,12 @@ checker, so the SSAR cache resets with it
 - **Namespaces domain**: scoped clusters synthesize name-only rows from the
   configured list — no namespaces informer, no cluster permission, runtime
   policy exempted (`RegisterNamespaceDomain`,
-  `backend/refresh/snapshot/namespaces.go`). Workload presence still comes
+  `backend/refresh/snapshot/namespaces.go`). NOTE: every domain has TWO
+  permission gates — registration-time (the gate/policy table) and
+  serve-time (`ensurePermissions` re-runs the runtime policy on every
+  snapshot request, `backend/refresh/snapshot/service.go`). An exemption
+  must cover both: `DomainConfig.RuntimePolicyExempt` is the single
+  declaration the serve-time gate honors. Workload presence still comes
   from ingest; when NOTHING is tracked (pre-data or fully denied), rows
   report `workloadsUnknown` so the sidebar never dims them as
   authoritatively empty. Browse's namespace groups serve the same list
@@ -54,7 +59,11 @@ checker, so the SSAR cache resets with it
   others; spill/restore keeps per-partition RVs for delta resume.
 - **Object catalog**: collection fans out per namespace
   (`Dependencies.AllowedNamespaces`), and one Forbidden namespace target is
-  skipped, never failing the kind (`backend/objectcatalog/collect.go`).
+  skipped, never failing the kind (`backend/objectcatalog/collect.go`). The
+  catalog's RBAC preflight asks the same way: namespaced descriptors are
+  evaluated per scope namespace (any-of) instead of one cluster-wide ask
+  that a scoped identity always fails (`backend/objectcatalog/sync.go`,
+  `preflightNamespaces`).
 - **Resource stream**: per-CRD dynamic informers fan out per namespace for
   namespaced CRDs; the namespace-custom all-namespaces view lists per scope
   namespace with per-target Forbidden skip.
@@ -67,6 +76,21 @@ checker, so the SSAR cache resets with it
   per-row hover delete (`frontend/src/ui/layout/NamespaceScopeEditor.tsx`).
   The editing affordances are also the only "scope active" indicator by
   design. Validation is syntactic (DNS-1123); the backend re-validates.
+
+## Scope-change convergence (the `cluster:scope:changed` event)
+
+A scope edit persists first, then rebuilds the cluster's subsystem through
+the coordinated selection-mutation path (rapid edits coalesce: a queued
+rebuild absorbs later edits; one that already started queues a fresh one).
+The frontend must NOT refetch on save — the rebuild takes seconds and an
+immediate fetch caches the stale pre-rebuild snapshot. Instead the backend
+emits `cluster:scope:changed` after the rebuild
+(`performClusterScopeRebuild`, `backend/app_cluster_settings.go`); the
+orchestrator then clears every permission-denied scope latch (a scope
+rebuild is the one in-session permission epoch change —
+`resetPermissionDeniedScopedDomainStates`, otherwise denied scopes never
+re-ask by design), restarts streaming, and NamespaceContext refetches the
+namespaces domain.
 
 ## Deliberately cluster-wide (follow-up: scope the factory-backed kinds)
 

--- a/docs/architecture/namespace-scope.md
+++ b/docs/architecture/namespace-scope.md
@@ -98,6 +98,17 @@ rebuild is the one in-session permission epoch change —
 re-ask by design), restarts streaming, and NamespaceContext refetches the
 namespaces domain.
 
+## Fail-fast contract for denied domains
+
+A typed 403 is a SETTLED answer everywhere it can surface: the orchestrator
+stamps `permissionDenied` and stops background refetches; the typed query
+hook reads the stamp, settles without warm-up retries, and the shared table
+rendering shows "Insufficient permissions" (`resolveEmptyStateMessage`)
+instead of a spinner or generic failure; a stream permission error frame
+blocks that scope's streaming (`refresh:resource-stream-permission-denied` →
+`blockStreaming`) instead of resync-looping. All three latches release on a
+namespace-scope change or auth recovery.
+
 ## Deliberately cluster-wide (follow-up: scope the factory-backed kinds)
 
 The typed shared-informer factory's namespaced informers (events,

--- a/docs/architecture/namespace-scope.md
+++ b/docs/architecture/namespace-scope.md
@@ -1,0 +1,80 @@
+# Per-Cluster Namespace Scope ("Accessible Namespaces")
+
+A cluster can be given a persisted namespace scope (`allowedNamespaces` in
+the per-cluster section of `settings.json`, keyed by clusterId). When the
+scope is non-empty, every namespaced data path for that cluster runs per
+configured namespace instead of cluster-wide, which makes the app usable for
+identities whose RBAC grants only per-namespace RoleBindings (issue #243) and
+doubles as a noise/perf scope on large clusters.
+
+## One code path, scope as a value
+
+There is no "restricted mode". Every enforcement point takes a list of
+namespaces where the empty list means cluster-wide; the unscoped path is the
+same loop with a single cluster-wide entry. Changing the scope
+(`SetClusterAllowedNamespaces`) persists first, then tears down and rebuilds
+exactly that cluster's subsystem — the rebuild recreates the permission
+checker, so the SSAR cache resets with it
+(`backend/refresh/system/manager.go` `NewSubsystemWithServices`).
+
+## The source-scope rule
+
+**A permission check's scope must always match its data source's scope.**
+
+- `permissions.Checker.Can` fans out over the scope (any-namespace-allows,
+  per-namespace results cached individually) ONLY for resources whose data
+  path is scoped — the predicate is "namespaced && ingest-owned"
+  (`scopedResourcePredicate`, `backend/refresh/system/manager.go`).
+- Resources served from cluster-wide sources (events, HPA, replicasets,
+  gateway informers, the helm-storage factory) keep cluster-wide checks, so
+  their domains register only when the identity can actually read the
+  source: a scoped identity sees an honest permission-denied state, never a
+  silently-empty view. `Checker.CanClusterWide` and
+  `ResourceRequirement.ClusterWide` are the explicit escape hatches
+  (helm-storage gate, namespace-helm runtime policy).
+- Per-namespace surfaces use `Checker.CanInNamespace` (the ingest
+  permission filter checks each reflector's own namespace).
+
+## Enforcement points
+
+- **Namespaces domain**: scoped clusters synthesize name-only rows from the
+  configured list — no namespaces informer, no cluster permission, runtime
+  policy exempted (`RegisterNamespaceDomain`,
+  `backend/refresh/snapshot/namespaces.go`). Workload presence still comes
+  from ingest; when NOTHING is tracked (pre-data or fully denied), rows
+  report `workloadsUnknown` so the sidebar never dims them as
+  authoritatively empty. Browse's namespace groups serve the same list
+  (`catalogNamespaceGroups`).
+- **Ingest**: one reflector per (kind, namespace) writing ONE shared store
+  through partition views; `ReplacePartition` fully defines only its own
+  namespace and fans per-row sink events (never the bulk kind-wide Replace,
+  whose contract would wipe sibling namespaces in maintained stores) —
+  `backend/refresh/ingest/partition.go`. Readiness counts only launched
+  partitions; a denied namespace is skipped without blanking or blocking the
+  others; spill/restore keeps per-partition RVs for delta resume.
+- **Object catalog**: collection fans out per namespace
+  (`Dependencies.AllowedNamespaces`), and one Forbidden namespace target is
+  skipped, never failing the kind (`backend/objectcatalog/collect.go`).
+- **Resource stream**: per-CRD dynamic informers fan out per namespace for
+  namespaced CRDs; the namespace-custom all-namespaces view lists per scope
+  namespace with per-target Forbidden skip.
+- **Metrics**: the pod-metrics poll runs per scope namespace and merges the
+  successes (`backend/refresh/metrics/poller.go`); node metrics stay
+  cluster-scoped and permission-degrade as before.
+- **Object map**: the live-LIST collectors (gateway kinds, HPA v2) list per
+  scope namespace; cluster-scoped kinds keep one cluster-wide list.
+- **UI**: the sidebar namespaces section IS the editor — add affordance +
+  per-row hover delete (`frontend/src/ui/layout/NamespaceScopeEditor.tsx`).
+  The editing affordances are also the only "scope active" indicator by
+  design. Validation is syntactic (DNS-1123); the backend re-validates.
+
+## Deliberately cluster-wide (follow-up: scope the factory-backed kinds)
+
+The typed shared-informer factory's namespaced informers (events,
+replicasets, HPA v1), the Gateway API informer factory, and the helm-storage
+factory still watch cluster-wide. Under a scope their domains stay
+permission-gated on the cluster-wide check (honest denial). Scoping them
+means N per-namespace client-go factories plus multiplexed listers/handlers
+at each consumer — tracked as the remaining Phase 4 slice in
+`docs/plans/namespace-scope.md`, along with per-namespace GET row enrichment
+(Phase 5) and the SSRR check optimization (reuse `backend/capabilities`).

--- a/docs/architecture/namespace-scope.md
+++ b/docs/architecture/namespace-scope.md
@@ -76,6 +76,12 @@ checker, so the SSAR cache resets with it
   per-row hover delete (`frontend/src/ui/layout/NamespaceScopeEditor.tsx`).
   The editing affordances are also the only "scope active" indicator by
   design. Validation is syntactic (DNS-1123); the backend re-validates.
+  Scoped rows are enriched by a TTL-cached per-namespace GET probe
+  (`probeScopedNamespace`): reachable namespaces serve their real
+  phase/status; unreachable entries carry `scopeStatus` — "not-found"
+  (permitted GET returned 404, definitive) or "no-access" (403 — may not
+  exist; a restricted identity cannot distinguish). Probe transitions
+  publish the "scope-probe" source clock so flag changes are delivered.
 
 ## Scope-change convergence (the `cluster:scope:changed` event)
 

--- a/docs/architecture/refresh-system.md
+++ b/docs/architecture/refresh-system.md
@@ -106,6 +106,72 @@ Keep common lifecycle plumbing shared where behavior matches. Do not collapse
 domain-specific identity, merge, cache, or recovery semantics into a generic
 handler.
 
+## Streaming Start Lifecycle (LOAD-BEARING — do not regress)
+
+This contract fixed the single largest perceived-performance defect the app
+ever had (2026-07-04): for months, EVERY first visit to a streaming view
+stalled 5–10 seconds (or loaded never, for scopes without an active fallback
+poller). The backend was innocent the whole time — it answered in ~1ms. The
+stall was a silent race in the frontend start pipeline. If first-visit
+latency ever regresses toward one fallback-poll interval, start here.
+
+### The race this contract closes
+
+View mount produces a lease flap: the scope is enabled, briefly disabled,
+and re-enabled within milliseconds. Without this contract that killed the
+scope's stream start:
+
+1. Enable begins `streaming.start` (in-flight promise).
+2. The transient disable calls `cancelStreamingStart`, flagging the
+   in-flight start.
+3. The immediate re-enable's own start attempt early-returns
+   ("already starting") because the doomed start is still pending.
+4. The doomed start resolves, sees the stale cancel flag, and dies silently.
+   Nothing owns the scope; nothing paints until the fallback poller's first
+   tick — and never for domains without an active poller.
+
+Log signature of a recurrence: a scope stuck in `initialising` with
+first-paint latency ≈ its poller interval, and no snapshot fetch between
+view open and the first tick.
+
+### The rules (all enforced by `orchestrator.streamingFlap.test.ts`)
+
+1. **Obsolete cancellation → adopt-restart.** A start that arrives cancelled
+   while its scope is ENABLED again must not die: clean up the doomed start
+   and immediately run `startStreamingScope` afresh. The stream manager's
+   `ensure` cancels the linger-scheduled unsubscribe
+   (`resourceStreamSubscriptions.ts` `ensureForCluster` →
+   `cancelPendingUnsubscribe`), so the subscription survives the handoff.
+2. **Teardown has exactly one owner.** Both the start's own continuation and
+   `stopStreamingScope`'s deferred block observe a cancelled start; the
+   cancel flag is the ownership token. The start continuation clears it in
+   every handled path; the stop's deferred block acts only if the flag is
+   still set. Running cleanup twice double-releases the manager
+   subscription's refcount.
+3. **A freshly started scope with no data fetches once, immediately.**
+   Streams signal CHANGES only — a quiet (or permission-denied) domain never
+   delivers a first frame. The `startStreamingScope` success path fires an
+   initial reconciliation fetch (`streamSignal: true`, deduped in-flight)
+   so the scope leaves `initialising` now, not at the first poll tick.
+4. **A typed 403 is a settled answer at every layer** (see
+   `docs/architecture/namespace-scope.md`, "Fail-fast contract"): the query
+   hook settles without warm-up retries, tables render "Insufficient
+   permissions", and stream permission frames block resync instead of
+   looping.
+
+### Guarding tests
+
+- `frontend/src/core/refresh/orchestrator.streamingFlap.test.ts` — the
+  flap race end to end at the real orchestrator seam (public
+  `registerDomain` + `setScopedDomainEnabled` with a controllable fake
+  streaming domain). Extend this harness for future orchestrator races.
+- `frontend/src/modules/resource-grid/queryBackedLeafFirstLoad.test.tsx`
+  ("settles a permission-denied domain…") — fail-fast at the view seam.
+
+Known follow-up: the mount-time lease flap itself (enable→disable→re-enable)
+still happens and is wasted work; the pipeline is robust to it. Tracing its
+source is tracked in `docs/plans/namespace-scope.md` follow-ups.
+
 ## Normalized Resource Query Provider Contract
 
 Snapshot domains that back a resource inventory table expose one normalized query

--- a/docs/architecture/refresh-system.md
+++ b/docs/architecture/refresh-system.md
@@ -153,6 +153,10 @@ view open and the first tick.
    delivers a first frame. The `startStreamingScope` success path fires an
    initial reconciliation fetch (`streamSignal: true`, deduped in-flight)
    so the scope leaves `initialising` now, not at the first poll tick.
+   EXCEPTION: registrations with `snapshotless: true` (container-logs) have
+   no snapshot endpoint — their data flows only through their own stream —
+   and are never snapshot-fetched; the backend answers such fetches
+   "unknown domain".
 4. **A typed 403 is a settled answer at every layer** (see
    `docs/architecture/namespace-scope.md`, "Fail-fast contract"): the query
    hook settles without warm-up retries, tables render "Insufficient

--- a/docs/plans/namespace-scope.md
+++ b/docs/plans/namespace-scope.md
@@ -155,11 +155,14 @@ discovered, for both the restricted and the perf-scope persona.
 
 Each phase is independently shippable and TDD'd; red/green per slice.
 
-- [ ] **Phase 1 — Plumbing.** Per-cluster settings storage + Wails RPC +
+- [x] ✅ **Phase 1 — Plumbing** (shipped 2026-07-04, `mage qc:prerelease`
+  green). Per-cluster settings storage + Wails RPC +
   frontend settings access for `allowedNamespaces`; thread the scope through
   `system.Config` into subsystem construction (carried but not yet
-  enforced); rebuild-on-change for the affected cluster only. Confirm the
-  rebuild path recreates the permission checker (SSAR cache reset).
+  enforced); rebuild-on-change for the affected cluster only. ✅ Confirmed
+  during implementation: the permission checker is created inside every
+  subsystem build (`backend/refresh/system/manager.go:131`), so the rebuild
+  resets the SSAR cache with no extra work.
 - [ ] **Phase 2 — Namespace list.** Scoped `namespaces`-domain registration
   serving the configured names; feed the same synthesized list into the
   catalog namespace-groups payload (Browse); inline sidebar editor (add +
@@ -212,7 +215,11 @@ Each phase is independently shippable and TDD'd; red/green per slice.
    optimization only: adopt it later if the fan-out shows up on the startup
    path of the restricted test cluster, and then only with a per-check SSAR
    fallback (SSRR may return incomplete rules on webhook-authorizer
-   clusters).
+   clusters). Note for that future pass: the capabilities subsystem already
+   runs SSRR with a configurable fetch concurrency
+   (`backend/capabilities/rules.go`, `SetPermissionSSRRFetchConcurrency` in
+   `backend/app_settings.go`) — reuse that machinery rather than adding a
+   second SSRR path.
 5. **Editor validation: syntactic only** (DNS-1123 label) at entry time;
    per-namespace access states on rows come from Phase 3's scoped checks,
    not edit-time probes.

--- a/docs/plans/namespace-scope.md
+++ b/docs/plans/namespace-scope.md
@@ -206,8 +206,12 @@ Each phase is independently shippable and TDD'd; red/green per slice.
   empty), enforced by the source-scope rule. Flipping a source to scoped =
   scope its informers AND add its resources to `scopedResourcePredicate`
   AND remove its ClusterWide overrides.
-- [ ] **Namespace row enrichment** (per-namespace GET where permitted) —
-  name-only rows shipped per decision 3.
+- [x] ✅ **Namespace row enrichment** (shipped 2026-07-04): scoped rows are
+  enriched by a TTL-cached per-namespace GET probe; entries the identity
+  cannot reach are flagged — "not-found" when a permitted GET returns 404
+  (definitive), "no-access" on 403 (honest: a restricted identity cannot
+  distinguish a missing namespace from a denied one). Flag transitions ride
+  their own snapshot source clock ("scope-probe").
 - [ ] **Verify degrade-only surfaces against the restricted test cluster**
   (ClusterRole details RoleBindings list, cluster-scoped object events) —
   needs the new 2-namespace RoleBindings SA from the test-setup note.

--- a/docs/plans/namespace-scope.md
+++ b/docs/plans/namespace-scope.md
@@ -1,0 +1,230 @@
+# Per-Cluster Namespace Scope ("Accessible Namespaces")
+
+Issue: [#243](https://github.com/luxury-yacht/app/issues/243)
+Todo item: `docs/todo.md` — "Allow the user to manually add namespaces if they
+don't have list namespaces permissions."
+
+A user whose RBAC grants access to only a few namespaces (RoleBindings, no
+cluster-wide grants) cannot use the app today: every cluster-wide LIST/WATCH
+and every cluster-scoped SelfSubjectAccessReview is denied, so nearly every
+domain registers as permission-denied. This plan adds a per-cluster list of
+namespaces the app should operate in. When the list is set, all namespaced
+data paths run per-namespace instead of cluster-wide.
+
+## Current state (verified 2026-07-04)
+
+- Every ingest reflector LIST/WATCHes cluster-wide. Both creation sites live
+  in `backend/refresh/ingest/manager.go`: `installReflector` (line 231,
+  `cache.NewListWatchFromClient(..., metav1.NamespaceAll, ...)`) and
+  `dynamicListWatch` (line 332, `.Namespace(metav1.NamespaceAll)`).
+- Every permission check is a cluster-scoped SSAR — no
+  `ResourceAttributes.Namespace`, no namespace in the cache key
+  (`backend/refresh/permissions/checker.go:86-94`).
+- The `namespaces` domain fails fast by design when cluster-wide list is
+  denied, with manual namespace entry named as the future work
+  (`backend/refresh/system/registrations.go:260-284`). The sidebar renders
+  "You do not have permission to list namespaces."
+  (`frontend/src/ui/layout/Sidebar.tsx:412-418`).
+- The object catalog collects every GVR cluster-wide: `sync.go:402` passes
+  `nil` namespaces into `collectResource`, but the whole collect layer is
+  already namespace-parameterized (`backend/objectcatalog/collect.go:27,95`,
+  `helpers.go:52-72`) — the hook exists, it is just never fed.
+- There are THREE cluster-wide shared-informer factories, not one: the typed
+  factory (`backend/refresh/informer/factory.go:135`), the label-filtered
+  Helm storage factory (`backend/refresh/informer/helm_storage.go:108`,
+  gated by cluster-scoped secret/configmap SSAR at lines 117-123), and the
+  Gateway API factory (`backend/cluster_clients.go:362`) which serves the
+  namespaced gateway kinds (`backend/objectcatalog/collect.go:80-89`). The
+  resource-stream dynamic informers are namespace-parameterized but fed
+  `NamespaceAll` (`backend/refresh/resourcestream/manager.go:463-467,504`).
+- The pod-metrics poller lists cluster-wide
+  (`backend/refresh/metrics/poller.go:409`, `PodMetricses("")`). With the
+  serve-time metric join, a scoped user gets no pod metrics unless the
+  poller fans out per namespace. Node metrics (`poller.go:368`) is a
+  cluster-scoped concern and can stay permission-gated like other
+  cluster-scoped kinds.
+- The object map does direct cluster-wide LISTs outside ingest: seven
+  gateway kinds (`backend/resources/{gateway,httproute,tlsroute,grpcroute,listenerset,referencegrant,backendtlspolicy}/objectmapnode.go:18`)
+  and HPA (`backend/refresh/snapshot/object_map.go:516`).
+- The CRD-backed namespace-custom domain lists each namespaced CRD at
+  `NamespaceAll` when the view scope is all-namespaces
+  (`backend/refresh/snapshot/namespace_custom.go:164-168`); errors route
+  through `shouldSkipError`, so under a scoped cluster the all-namespaces
+  variant would silently serve nothing.
+- The catalog snapshot carries its own namespace-groups payload via
+  `ObjectCatalogNamespaces` (`backend/app_refresh_setup.go:234` →
+  `backend/app_object_catalog.go:373`) — Browse's namespace list is a
+  separate consumer from the sidebar's `namespaces` domain.
+- Degrade-only cluster-wide reads (no scope plumbing planned; must 403
+  gracefully): ClusterRole details lists RoleBindings cluster-wide
+  (`backend/resources/clusterrole/details.go:68`); object events for
+  cluster-scoped objects list at `NamespaceAll`
+  (`backend/refresh/snapshot/object_events.go:176,194`) — only reachable in
+  scoped mode by the perf-scope persona, whose RBAC permits it.
+- There is no per-cluster settings store. Persisted settings are global
+  (`backend/app_settings.go:68`). Per-cluster keying precedents: favorites
+  and tab order key by clusterId (`kubeconfigName:context`,
+  `backend/kubeconfig_selection.go:122`); grid tables key by a hash of
+  `path:context`.
+- `system.Config` (`backend/refresh/system/manager.go:55`) is the single
+  struct through which per-cluster configuration reaches subsystem
+  construction. `rebuildClusterSubsystem` (`backend/cluster_auth.go:191`) is
+  the existing single-cluster teardown-and-rebuild path (used by auth
+  recovery).
+
+## Reference behavior (Lens/OpenLens/Freelens)
+
+Per-cluster "Accessible Namespaces" setting: a free-form list of namespace
+names. When non-empty: the namespace list is synthesized from the setting
+(no LIST, no WATCH of namespaces), and every namespaced resource store does
+one LIST + one WATCH per configured namespace. Cluster-scoped resources are
+gated independently by SSAR. When the cluster-wide namespace LIST 403s and
+no list is configured, a notification deep-links to the setting.
+
+Documented pitfalls to avoid (from lensapp/lens issues #2111, #2010, #1946,
+#2209): (a) "configured list" and "discovered list" as two separate code
+paths drift and break independently; (b) one forbidden namespace must not
+blank the others; (c) list permission does not imply watch permission.
+
+## Design
+
+### Guiding principle: one code path, scope as a value
+
+Do not build a parallel "restricted mode". Every namespaced data path gains
+an explicit scope value — a list of namespaces where `[""]`
+(`metav1.NamespaceAll` is the empty string) means cluster-wide. Unscoped
+clusters run the same loop with a one-element `[""]` list and produce
+exactly today's objects. This makes the Lens dual-path drift structurally
+impossible and keeps the change testable as a pure generalization.
+
+### Setting
+
+`allowedNamespaces: string[]` per cluster, empty by default. Non-empty means
+the scope applies unconditionally (not only when cluster-wide access is
+denied) — one predictable behavior, and it doubles as a noise/perf scope on
+large clusters. Stored in a new per-cluster section of `settings.json`
+keyed by clusterId, matching the favorites/tab-order precedent. Changing
+the setting triggers a single-cluster teardown and rebuild modeled on
+`rebuildClusterSubsystem`, which should also reset the SSAR cache — Phase 1
+must confirm the rebuild path actually recreates the permission checker
+(stale SSAR results after a scope change would mimic the known
+reconnect-after-RBAC-change issue).
+
+Cost note: because the scope applies unconditionally, a user configuring
+many namespaces on a large cluster gets kinds × namespaces watch streams
+(Lens has the same model). Phase 5 adds a soft warning in the editor above
+a threshold list size rather than any hard cap.
+
+### Enforcement points (all behind the same scope value)
+
+| Surface | Change |
+| --- | --- |
+| Ingest reflectors | `installReflector`/`dynamicListWatch` fan out one reflector per scope entry per GVR (namespaced kinds only). `[""]` degenerates to today's single reflector. |
+| Ingest stores | Replace from one namespace's reflector must not wipe rows from sibling namespaces. Same bug class as the multi-kind unscoped `BundleSink` wipe. Preferred direction for the Phase 4 design pass: one entry/store per (GVR, namespace) with a merged read path — keeps each reflector's Replace = full-state contract intact and sidesteps the wipe bug class structurally, vs. defending against it with source-partitioned Replace. |
+| Permission checks | Checks gain a namespace dimension (attributes + cache key, `checker.go:254` is `group/resource/verb` today). Scoped clusters check per configured namespace; a domain registers if allowed in at least one namespace; unscoped clusters check `""` = today. Strategy (SSAR fan-out vs per-namespace `SelfSubjectRulesReview`) is open decision 4. |
+| `namespaces` domain | When scope is set, register a variant that serves the configured names without the cluster-wide gate (rows enriched per-namespace where permitted; workload presence comes from scoped ingest as today). |
+| Object catalog | Feed the scope into `collectResource` (the `nil` at `sync.go:402`); per-namespace machinery already exists. Also feed the synthesized names into the catalog's namespace-groups payload (`ObjectCatalogNamespaces`) so Browse and the sidebar agree. |
+| Shared informer factories (×3) | Typed, Helm storage, and Gateway API factories all need per-namespace scoping for namespaced kinds (client-go `WithNamespace` takes one namespace). Helm storage additionally moves its secret/configmap gate from cluster-scoped to per-namespace (decided: Helm is included in scoped mode from Phase 4, not deferred). Cluster-scoped kinds (nodes, CRDs, *Class kinds) are unaffected — they stay permission-gated and degrade exactly as shipped in #244/#246. |
+| Resource stream | Pass scope namespaces into the already-parameterized `NewFilteredDynamicInformer` call. Also fan out the namespace-custom domain's all-namespaces LIST (`namespace_custom.go:164-168`) over the scope. |
+| Metrics poller | `PodMetricses("")` (`poller.go:409`) fans out per scope entry; node metrics stays cluster-gated. Without this, scoped users get no pod metrics at all (serve-time join has no other source). |
+| Object map | The seven gateway-kind direct LISTs (`objectmapnode.go:18`) and the HPA LIST (`object_map.go:516`) loop the scope entries. Everything else reaches the map via ingest stores and is covered by the ingest rows above. |
+
+Degrade-only surfaces (no scope plumbing; verify graceful 403 in Phase 5):
+ClusterRole details' RoleBindings list, object events for cluster-scoped
+objects. Both are unreachable or permitted for the restricted persona; the
+perf-scope persona has the RBAC for them.
+
+### UI
+
+The sidebar Namespaces section IS the editor — no modal, no settings
+surface. When a scope is set (or the cluster-wide list is denied), the
+section renders the configured names as an inline-editable list: an "Add
+namespace" affordance plus a hover delete icon per row, following the
+Favorites dropdown's inline-edit pattern. The permission-denied state —
+the discovery moment for exactly the user in #243 — swaps the static
+message for the same editable list, starting empty.
+
+Validation is syntactic only (DNS-1123 label) at entry time; per-namespace
+access states appear on the rows once Phase 3's scoped checks exist.
+
+No separate "scope active" indicator is needed: the editing affordances
+themselves make it visible that the list is user-curated rather than
+discovered, for both the restricted and the perf-scope persona.
+
+## Phases
+
+Each phase is independently shippable and TDD'd; red/green per slice.
+
+- [ ] **Phase 1 — Plumbing.** Per-cluster settings storage + Wails RPC +
+  frontend settings access for `allowedNamespaces`; thread the scope through
+  `system.Config` into subsystem construction (carried but not yet
+  enforced); rebuild-on-change for the affected cluster only. Confirm the
+  rebuild path recreates the permission checker (SSAR cache reset).
+- [ ] **Phase 2 — Namespace list.** Scoped `namespaces`-domain registration
+  serving the configured names; feed the same synthesized list into the
+  catalog namespace-groups payload (Browse); inline sidebar editor (add +
+  hover-delete, Favorites-dropdown pattern) replacing the permission-denied
+  message. User-visible win: restricted users get namespace navigation.
+  Individual views still show their permission-denied states until
+  Phases 3–4.
+  **Define workload-presence behavior for this intermediate state
+  explicitly:** ingest is still wholly permission-denied, so with
+  `DimInactiveNamespaces` on, the tracker must not dim every synthesized
+  namespace (same all-dimmed failure mode as the 2026-06-27 tracker bug —
+  treat "ingest has no data at all" as "presence unknown, don't dim").
+- [ ] **Phase 3 — Permission dimension.** Namespace-scoped checks in the
+  checker + cache + permission gate; scoped clusters evaluate domain
+  policies per configured namespace (register if any namespace allows;
+  surface per-namespace denials). Resolve open decision 4 (SSRR vs SSAR)
+  first; either way checks for the configured namespaces run concurrently —
+  N namespaces × ~40 kinds × 2-3 verbs of serial SSARs would land on the
+  already-measured slow startup path.
+- [ ] **Phase 4 — Data paths.** Ingest reflector fan-out with
+  partition-safe stores (per-(GVR, namespace) entries preferred — see
+  table); all three scoped shared-informer factories (typed, Helm storage,
+  Gateway API) incl. the Helm include-or-exclude decision; resource stream
+  scope + namespace-custom all-namespaces fan-out; catalog collect scope;
+  metrics-poller pod-metrics fan-out; object-map direct-LIST fan-out
+  (gateway kinds + HPA). This is the heavy phase; the store semantics need
+  their own design pass first, and the sub-surfaces here are independently
+  landable slices in roughly this order (ingest → factories → stream →
+  catalog → metrics → object map).
+- [ ] **Phase 5 — Polish.** Per-namespace degrade surfaces (one forbidden
+  namespace dims only itself), namespace row enrichment (per-namespace GET
+  where permitted), verify the degrade-only surfaces 403 gracefully
+  (ClusterRole details, cluster-scoped object events), editor soft warning
+  for large scope lists, docs (`docs/architecture/` updates), release
+  notes.
+
+## Decisions (resolved 2026-07-04)
+
+1. **Editor home: the sidebar Namespaces section itself.** No modal, no
+   Settings-modal section — inline editing per the UI section above,
+   following the Favorites dropdown's inline-edit pattern.
+2. **Persistence key: clusterId** (`name:context`), consistent with
+   favorites/tabs. Accepted tradeoff: a kubeconfig display-name change
+   orphans the setting, same as favorites/tabs today.
+3. **Namespace row fidelity: name-only rows in Phase 2** (Lens-style),
+   per-namespace GET enrichment in Phase 5.
+4. **Permission-check strategy: concurrent namespaced SSAR fan-out.** One
+   code path through the existing checker — namespace added to the request
+   attributes and the cache key. `SelfSubjectRulesReview` is a measured
+   optimization only: adopt it later if the fan-out shows up on the startup
+   path of the restricted test cluster, and then only with a per-check SSAR
+   fallback (SSRR may return incomplete rules on webhook-authorizer
+   clusters).
+5. **Editor validation: syntactic only** (DNS-1123 label) at entry time;
+   per-namespace access states on rows come from Phase 3's scoped checks,
+   not edit-time probes.
+6. **Helm: included in scoped mode from Phase 4** (per-namespace Helm
+   storage gating), not deferred.
+7. **No separate "scope active" indicator.** The inline-editable sidebar
+   list is itself the signal that the namespace list is user-curated rather
+   than discovered; no badge or connectivity-presentation mention.
+
+## Test setup note
+
+The existing restricted-cluster kind setup uses an SA with cluster-wide
+`view` — it can list namespaces, so it does not reproduce #243. Testing this
+feature needs an SA with RoleBindings in 2 namespaces and no cluster-scoped
+grants.

--- a/docs/plans/namespace-scope.md
+++ b/docs/plans/namespace-scope.md
@@ -163,41 +163,56 @@ Each phase is independently shippable and TDD'd; red/green per slice.
   during implementation: the permission checker is created inside every
   subsystem build (`backend/refresh/system/manager.go:131`), so the rebuild
   resets the SSAR cache with no extra work.
-- [ ] **Phase 2 — Namespace list.** Scoped `namespaces`-domain registration
-  serving the configured names; feed the same synthesized list into the
-  catalog namespace-groups payload (Browse); inline sidebar editor (add +
-  hover-delete, Favorites-dropdown pattern) replacing the permission-denied
-  message. User-visible win: restricted users get namespace navigation.
-  Individual views still show their permission-denied states until
-  Phases 3–4.
-  **Define workload-presence behavior for this intermediate state
-  explicitly:** ingest is still wholly permission-denied, so with
-  `DimInactiveNamespaces` on, the tracker must not dim every synthesized
-  namespace (same all-dimmed failure mode as the 2026-06-27 tracker bug —
-  treat "ingest has no data at all" as "presence unknown, don't dim").
-- [ ] **Phase 3 — Permission dimension.** Namespace-scoped checks in the
-  checker + cache + permission gate; scoped clusters evaluate domain
-  policies per configured namespace (register if any namespace allows;
-  surface per-namespace denials). Resolve open decision 4 (SSRR vs SSAR)
-  first; either way checks for the configured namespaces run concurrently —
-  N namespaces × ~40 kinds × 2-3 verbs of serial SSARs would land on the
-  already-measured slow startup path.
-- [ ] **Phase 4 — Data paths.** Ingest reflector fan-out with
-  partition-safe stores (per-(GVR, namespace) entries preferred — see
-  table); all three scoped shared-informer factories (typed, Helm storage,
-  Gateway API) incl. the Helm include-or-exclude decision; resource stream
-  scope + namespace-custom all-namespaces fan-out; catalog collect scope;
-  metrics-poller pod-metrics fan-out; object-map direct-LIST fan-out
-  (gateway kinds + HPA). This is the heavy phase; the store semantics need
-  their own design pass first, and the sub-surfaces here are independently
-  landable slices in roughly this order (ingest → factories → stream →
-  catalog → metrics → object map).
-- [ ] **Phase 5 — Polish.** Per-namespace degrade surfaces (one forbidden
-  namespace dims only itself), namespace row enrichment (per-namespace GET
-  where permitted), verify the degrade-only surfaces 403 gracefully
-  (ClusterRole details, cluster-scoped object events), editor soft warning
-  for large scope lists, docs (`docs/architecture/` updates), release
-  notes.
+- [x] ✅ **Phase 2 — Namespace list** (shipped 2026-07-04). Scoped
+  `namespaces`-domain registration serves the configured names (synthesized
+  rows, no informer, runtime policy exempted); Browse's namespace groups
+  serve the same list; inline sidebar editor (add + hover-delete) shipped in
+  `NamespaceScopeEditor.tsx` + `Sidebar.tsx`. Workload presence: "ingest
+  tracks no workload kind" reports `workloadsUnknown`, so scoped rows are
+  never dimmed as authoritatively empty (unscoped behavior unchanged).
+- [x] ✅ **Phase 3 — Permission dimension** (shipped 2026-07-04).
+  Namespace in the SSAR attributes + cache key; `Can` fans out concurrently
+  (any-namespace-allows) — but ONLY for resources whose data path is scoped
+  (`scopedResourcePredicate`: namespaced && ingest-owned). Cluster-wide
+  sources (events/HPA/RS/gateway/helm) keep cluster-wide checks via
+  `CanClusterWide` / `ResourceRequirement.ClusterWide`, so no domain can
+  register against a source it cannot read (no silent-empty). SSAR chosen
+  per decision 4; SSRR stays a measured future optimization.
+- [x] ✅ **Phase 4 — Data paths** (shipped 2026-07-04, EXCEPT the
+  factory-backed kinds — see follow-up below). Design pass outcome: ONE
+  store per GVR with per-namespace reflector partition views
+  (`ingest/partition.go`) — partition Replace fully defines only its own
+  namespace and fans per-row sink events, never the bulk kind-wide Replace,
+  which structurally prevents the maintained-store wipe class while keeping
+  every serve/sink/readiness surface unchanged. Per-namespace permission
+  skip (one denied namespace skips one reflector), per-partition spill/
+  resume RVs. Also shipped: catalog collect scope with per-namespace
+  Forbidden skip; resource-stream per-CRD informers fan out per namespace;
+  namespace-custom all-namespaces fan-out; metrics-poller pod fan-out with
+  partial-failure merge; object-map gateway/HPA LIST fan-out.
+- [x] ✅ **Phase 5 — Polish** (shipped 2026-07-04, except row enrichment).
+  One forbidden namespace degrades only itself on every scoped surface;
+  editor soft warning above 20 namespaces; architecture doc
+  `docs/architecture/namespace-scope.md`; release-note fragment.
+
+### Remaining follow-ups (not blocking #243)
+
+- [ ] **Scope the factory-backed kinds** (the deliberate Phase 4 leftover):
+  events, replicasets, HPA v1 (typed factory), the 8 gateway kinds (gateway
+  factory), helm secrets/configmaps (helm-storage factory). Requires N
+  per-namespace client-go factories + multiplexed listers/handlers at each
+  consumer (~10 sites mapped this session). Until then these domains show
+  an HONEST permission-denied state for scoped identities (never silent
+  empty), enforced by the source-scope rule. Flipping a source to scoped =
+  scope its informers AND add its resources to `scopedResourcePredicate`
+  AND remove its ClusterWide overrides.
+- [ ] **Namespace row enrichment** (per-namespace GET where permitted) —
+  name-only rows shipped per decision 3.
+- [ ] **Verify degrade-only surfaces against the restricted test cluster**
+  (ClusterRole details RoleBindings list, cluster-scoped object events) —
+  needs the new 2-namespace RoleBindings SA from the test-setup note.
+- [ ] **SSRR optimization** if scoped-connect SSAR fan-out measures slow
+  (decision 4 note: reuse `backend/capabilities` machinery).
 
 ## Decisions (resolved 2026-07-04)
 

--- a/docs/plans/namespace-scope.md
+++ b/docs/plans/namespace-scope.md
@@ -195,7 +195,13 @@ Each phase is independently shippable and TDD'd; red/green per slice.
   editor soft warning above 20 namespaces; architecture doc
   `docs/architecture/namespace-scope.md`; release-note fragment.
 
-### Remaining follow-ups (not blocking #243)
+### Remaining follow-ups
+
+- Trace WHY the scoped-domain lease flaps on every view mount
+  (enable→disable→re-enable within ~10ms; observed via [DEBUG-qtime]
+  2026-07-04). The streaming-start pipeline is now robust to it
+  (adopt-restart, `orchestrator.streamingFlap.test.ts`), but the flap itself
+  is wasted work and churns scoped state. (not blocking #243)
 
 - [ ] **Scope the factory-backed kinds** (the deliberate Phase 4 leftover):
   events, replicasets, HPA v1 (typed factory), the 8 gateway kinds (gateway

--- a/docs/release/pending.md
+++ b/docs/release/pending.md
@@ -1,5 +1,6 @@
 ### Added
 
+- Accessible-namespace entries that don't resolve are flagged in the sidebar: a warning glyph marks a namespace that was not found (or that the identity cannot access), with the detail in its tooltip.
 - Per-cluster "accessible namespaces" ([#243](https://github.com/luxury-yacht/app/issues/243)): identities without permission to list namespaces cluster-wide can now add the namespaces they can access directly in the sidebar (with a hover delete on each added row). When a scope is set, tables, Browse, streams, metrics, and the object map all operate per-namespace — one namespace the identity cannot read degrades only itself. Views whose data source still reads cluster-wide (Events, Autoscaling, Helm, Gateway API) show their permission-denied state for scoped identities rather than empty data. The scope also works as a noise/performance filter on large clusters for users with full access.
 - The Cluster Overview's Resource Utilization card now shows "Collecting metrics…" while the first metrics collection is in flight.
 

--- a/docs/release/pending.md
+++ b/docs/release/pending.md
@@ -1,5 +1,6 @@
 ### Added
 
+- Per-cluster "accessible namespaces" ([#243](https://github.com/luxury-yacht/app/issues/243)): identities without permission to list namespaces cluster-wide can now add the namespaces they can access directly in the sidebar (with a hover delete on each added row). When a scope is set, tables, Browse, streams, metrics, and the object map all operate per-namespace — one namespace the identity cannot read degrades only itself. Views whose data source still reads cluster-wide (Events, Autoscaling, Helm, Gateway API) show their permission-denied state for scoped identities rather than empty data. The scope also works as a noise/performance filter on large clusters for users with full access.
 - The Cluster Overview's Resource Utilization card now shows "Collecting metrics…" while the first metrics collection is in flight.
 
 ### Changed

--- a/docs/release/pending.md
+++ b/docs/release/pending.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Views backed by a domain the identity cannot read now settle immediately into an "Insufficient permissions" state instead of an endless loading spinner, and stop retrying (both the table query and its stream stop asking until permissions or the namespace scope change).
+
 - Clusters where the user lacks permission to list namespaces now fail fast. The sidebar shows "You do not have permission to list namespaces."
 - The Cluster Overview no longer requires node permissions ([#244](https://github.com/luxury-yacht/app/issues/244)). Identities without node access (such as the standard `view` role) now see pods, namespaces, workloads, and events instead of the page failing with "permission denied". Each affected card explains its own gap in place: the Nodes card notes the missing node permission, and Resource Utilization indicates when cluster capacity or pod requests/limits are unavailable.
 - Resource bars now render the portion of usage that exceeds the declared limits as a striped overlay, so the limit position stays visible even when the bar is fully red.

--- a/docs/release/pending.md
+++ b/docs/release/pending.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Streaming views paint immediately on first visit: a mount-time race silently killed the stream start (leaving views loading until a 5-10s fallback poll, or indefinitely), and newly started streams now fetch their initial snapshot instead of waiting for the first poll tick.
+
 - Views backed by a domain the identity cannot read now settle immediately into an "Insufficient permissions" state instead of an endless loading spinner, and stop retrying (both the table query and its stream stop asking until permissions or the namespace scope change).
 
 - Clusters where the user lacks permission to list namespaces now fail fast. The sidebar shows "You do not have permission to list namespaces."

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,5 +1,6 @@
 - Need a restricted-permissions pass to make the app behave better when the user is missing important permissions.
   - Allow the user to manually add namespaces if they don't have list namespaces permissions
+    ([#243](https://github.com/luxury-yacht/app/issues/243), plan: `docs/plans/namespace-scope.md`)
   - Fail fast instead of attempting loads (ex: Nodes shows loading spinner that will never work)
 
 - Build a plugin architecture

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,7 +1,4 @@
-- Need a restricted-permissions pass to make the app behave better when the user is missing important permissions.
-  - Allow the user to manually add namespaces if they don't have list namespaces permissions
-    ([#243](https://github.com/luxury-yacht/app/issues/243), plan: `docs/plans/namespace-scope.md`)
-  - Fail fast instead of attempting loads (ex: Nodes shows loading spinner that will never work)
+- Embedded pods do not show -- "insufficient permissions for Metrics API". Should show pods w/o metrics
 
 - Build a plugin architecture
   - AI

--- a/frontend/src/core/events/eventBus.ts
+++ b/frontend/src/core/events/eventBus.ts
@@ -77,6 +77,13 @@ export interface AppEvents {
   'refresh:registered': { name: string };
   'refresh:start': { name: string; isManual: boolean };
   'refresh:complete': { name: string; isManual: boolean; success: boolean; error?: unknown };
+  /** A stream scope got a permission-denied error frame: streaming for it is
+   *  blocked (settled) until scope change / auth recovery clears the block. */
+  'refresh:resource-stream-permission-denied': {
+    domain: DoorbellStreamDomain;
+    scope: string;
+    reason: string;
+  };
   'refresh:resource-stream-drift': {
     domain: ResourceStreamDomain;
     scope: string;

--- a/frontend/src/core/events/eventBus.ts
+++ b/frontend/src/core/events/eventBus.ts
@@ -54,6 +54,12 @@ export interface AppEvents {
   'cluster:auth:failed': { clusterId: string };
   'cluster:auth:recovered': { clusterId: string };
 
+  // A cluster's namespace scope changed and its refresh subsystem finished
+  // rebuilding (docs/plans/namespace-scope.md) — bridged from the Wails
+  // cluster:scope:changed event by KubeconfigContext. Streams must restart
+  // and the cluster's domains refetch.
+  'cluster:scope-changed': { clusterId: string };
+
   // View events
   'view:reset': void;
   'view:toggle-diagnostics': void;

--- a/frontend/src/core/refresh/domainRegistrations.ts
+++ b/frontend/src/core/refresh/domainRegistrations.ts
@@ -34,6 +34,7 @@ export function registerDefaultRefreshDomains(registrar: RefreshDomainRegistrar)
 
   const registerContainerLogsDomain = () => {
     registerRefreshDomain('container-logs', {
+      snapshotless: true,
       start: (scope) => containerLogsStreamManager.startStream(scope),
       stop: (scope, options) => containerLogsStreamManager.stop(scope, options?.reset ?? false),
       refreshOnce: (scope) => containerLogsStreamManager.refreshOnce(scope),

--- a/frontend/src/core/refresh/orchestrator.streamingFlap.test.ts
+++ b/frontend/src/core/refresh/orchestrator.streamingFlap.test.ts
@@ -148,6 +148,37 @@ describe('streaming start under the mount-time lease flap', () => {
     expect(fetchedScopes).toContain(SCOPE);
   });
 
+  it('never snapshot-fetches a snapshotless (stream-only) domain on start', async () => {
+    // container-logs regression: the domain has no snapshot endpoint (its
+    // data flows through its own stream manager), so the initial
+    // reconciliation fetch must skip it — the backend answers such fetches
+    // with "unknown domain", surfaced to the user as an error toast.
+    refreshOrchestrator.registerDomain({
+      domain: DOMAIN,
+      refresherName: 'test-flap-refresher',
+      category: 'namespace',
+      streaming: {
+        snapshotless: true,
+        start: (scope: string) => {
+          startCalls.push(scope);
+          return new Promise<() => void>((resolve) => {
+            resolvers.push(resolve);
+          });
+        },
+        stop: (scope: string) => {
+          stopCalls.push(scope);
+        },
+      },
+    } as never);
+
+    refreshOrchestrator.setScopedDomainEnabled(DOMAIN, SCOPE, true);
+    await flush();
+    expect(startCalls).toHaveLength(1);
+    resolvers[0](() => {});
+    await flush();
+    expect(fetchSnapshotMock).not.toHaveBeenCalled();
+  });
+
   it('tears a cancelled start down exactly once when the scope stays disabled', async () => {
     refreshOrchestrator.setScopedDomainEnabled(DOMAIN, SCOPE, true);
     await flush();

--- a/frontend/src/core/refresh/orchestrator.streamingFlap.test.ts
+++ b/frontend/src/core/refresh/orchestrator.streamingFlap.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Regression: the mount-time lease flap must not kill a streaming scope's
+ * first start.
+ *
+ * Observed live (restricted-cluster, every first visit to a streaming view):
+ * mount enables the scope and begins streaming.start; a transient disable
+ * cancels the in-flight start; the immediate re-enable's own start attempt
+ * early-returns because the doomed start is still pending; the doomed start
+ * then arrives cancelled and died silently. Nothing owned the scope anymore,
+ * so the view sat in 'initialising' until the fallback poller's first tick
+ * (5–10s) — or forever for scopes without an active poller.
+ *
+ * Contract under test: a start that arrives cancelled while the scope is
+ * ENABLED is an obsolete cancellation — the orchestrator must clean up the
+ * doomed start and immediately restart streaming (the manager re-ensures the
+ * lingering subscription), then run the initial reconciliation fetch. A start
+ * that arrives cancelled while DISABLED still tears down, exactly once.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { fetchSnapshotMock } = vi.hoisted(() => ({
+  fetchSnapshotMock: vi.fn(),
+}));
+
+vi.mock('./client', () => ({
+  ensureRefreshBaseURL: () => Promise.resolve('http://127.0.0.1:0'),
+  invalidateRefreshBaseURL: () => {},
+  fetchSnapshot: (...args: unknown[]) => fetchSnapshotMock(...args),
+  isSnapshotPermissionDenied: () => false,
+  setMetricsActive: () => {},
+}));
+
+vi.mock('./RefreshManager', () => ({
+  refreshManager: {
+    subscribe: () => () => {},
+    enable: () => {},
+    disable: () => {},
+    register: () => {},
+    updateContext: () => {},
+    triggerManualRefreshForContext: () => Promise.resolve(),
+  },
+}));
+
+// Keep the singleton lean: no default domains, no stream-manager wiring.
+vi.mock('./domainRegistrations', () => ({
+  registerDefaultRefreshDomains: () => {},
+}));
+
+// The flap contract is view-independent: bypass the view-activity and
+// auto-refresh gates so shouldStreamScope answers on scope shape alone.
+vi.mock('./resourceStreamViews', () => ({
+  isResourceStreamDomain: () => false,
+  isResourceStreamViewActive: () => true,
+}));
+
+vi.mock('@/core/settings/appPreferences', () => ({
+  getAutoRefreshEnabled: () => true,
+}));
+
+vi.mock('@/core/logging/appLogsClient', () => ({
+  APP_LOG_SOURCES: new Proxy({}, { get: (_t, key) => String(key) }),
+  logAppLogsInfo: () => {},
+  logAppLogsWarn: () => {},
+  logAppLogsError: () => {},
+}));
+
+import { refreshOrchestrator } from './orchestrator';
+
+const DOMAIN = 'namespace-storage' as const;
+const SCOPE = 'flap-cluster:flap-cluster|namespace:flap-ns';
+
+const flush = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+type StartResolver = (cleanup: () => void) => void;
+
+describe('streaming start under the mount-time lease flap', () => {
+  let startCalls: string[];
+  let stopCalls: string[];
+  let resolvers: StartResolver[];
+
+  beforeEach(() => {
+    startCalls = [];
+    stopCalls = [];
+    resolvers = [];
+    fetchSnapshotMock.mockReset();
+    fetchSnapshotMock.mockResolvedValue({
+      snapshot: { data: { rows: [] }, sourceVersion: 'v1' },
+      etag: 'v1',
+      notModified: false,
+    });
+    refreshOrchestrator.registerDomain({
+      domain: DOMAIN,
+      refresherName: 'test-flap-refresher',
+      category: 'namespace',
+      streaming: {
+        start: (scope: string) => {
+          startCalls.push(scope);
+          return new Promise<() => void>((resolve) => {
+            resolvers.push(resolve);
+          });
+        },
+        stop: (scope: string) => {
+          stopCalls.push(scope);
+        },
+      },
+    } as never);
+  });
+
+  afterEach(() => {
+    refreshOrchestrator.setScopedDomainEnabled(DOMAIN, SCOPE, false);
+  });
+
+  it('restarts a cancelled in-flight start when the scope was re-enabled', async () => {
+    refreshOrchestrator.setScopedDomainEnabled(DOMAIN, SCOPE, true);
+    await flush();
+    expect(startCalls).toHaveLength(1);
+
+    // The flap: disable cancels the in-flight start; the immediate re-enable's
+    // start attempt early-returns on the still-pending doomed start.
+    refreshOrchestrator.setScopedDomainEnabled(DOMAIN, SCOPE, false);
+    refreshOrchestrator.setScopedDomainEnabled(DOMAIN, SCOPE, true);
+    await flush();
+    expect(startCalls).toHaveLength(1);
+
+    // The doomed start arrives cancelled while the scope is enabled: the
+    // orchestrator must clean it up exactly once and start fresh.
+    const doomedCleanup = vi.fn();
+    resolvers[0](doomedCleanup);
+    await flush();
+    expect(doomedCleanup).toHaveBeenCalledTimes(1);
+    expect(startCalls).toHaveLength(2);
+
+    // The fresh start completes: streaming is active and the initial
+    // reconciliation fetch runs so the scope leaves 'initialising' now, not
+    // at the fallback poller's first tick.
+    resolvers[1](() => {});
+    await flush();
+    expect(fetchSnapshotMock).toHaveBeenCalled();
+    // fetchSnapshot(domain, options) — the scope rides in the options.
+    const fetchedScopes = fetchSnapshotMock.mock.calls.map(
+      (call) => (call[1] as { scope?: string } | undefined)?.scope
+    );
+    expect(fetchedScopes).toContain(SCOPE);
+  });
+
+  it('tears a cancelled start down exactly once when the scope stays disabled', async () => {
+    refreshOrchestrator.setScopedDomainEnabled(DOMAIN, SCOPE, true);
+    await flush();
+    expect(startCalls).toHaveLength(1);
+
+    refreshOrchestrator.setScopedDomainEnabled(DOMAIN, SCOPE, false);
+    const doomedCleanup = vi.fn();
+    resolvers[0](doomedCleanup);
+    await flush();
+
+    // Both the start's own continuation and the stop's deferred block see the
+    // doomed start; only one of them may release the subscription.
+    expect(doomedCleanup).toHaveBeenCalledTimes(1);
+    expect(startCalls).toHaveLength(1);
+    expect(fetchSnapshotMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/core/refresh/orchestrator.ts
+++ b/frontend/src/core/refresh/orchestrator.ts
@@ -756,9 +756,10 @@ class RefreshOrchestrator {
             }
           }
           if (enabledNow) {
-            // A stop cancelled this start mid-flight, but the scope was
-            // re-enabled before it resolved (the mount-time lease flap on
-            // every first view visit). The re-enable's own start attempt
+            // LOAD-BEARING — docs/architecture/refresh-system.md,
+            // "Streaming Start Lifecycle". A stop cancelled this start
+            // mid-flight, but the scope was re-enabled before it resolved
+            // (the mount-time lease flap on every first view visit). The re-enable's own start attempt
             // early-returned on THIS pending start, so dying here would
             // orphan the scope in 'initialising' until the fallback poller's
             // first tick (observed live: 5-10s first-paint stalls; forever
@@ -817,9 +818,11 @@ class RefreshOrchestrator {
     if (pending) {
       pending
         .then((cleanup) => {
-          // The start's own continuation (attached first) already handled a
-          // cancelled arrival — teardown, or an adopted restart when the
-          // scope was re-enabled — and cleared the cancel flag. Acting here
+          // LOAD-BEARING — docs/architecture/refresh-system.md, "Streaming
+          // Start Lifecycle": teardown has exactly one owner. The start's
+          // own continuation (attached first) already handled a cancelled
+          // arrival — teardown, or an adopted restart when the scope was
+          // re-enabled — and cleared the cancel flag. Acting here
           // too would release the manager subscription twice. The flag still
           // being set means this stop still owns the teardown.
           if (!runtime.isStreamingCancelled(domain, scope)) {

--- a/frontend/src/core/refresh/orchestrator.ts
+++ b/frontend/src/core/refresh/orchestrator.ts
@@ -761,6 +761,21 @@ class RefreshOrchestrator {
         }
 
         runtime.finishStreamingStart(domain, scope, cleanup ?? noopStreamingCleanup);
+        // Initial reconciliation: a freshly-subscribed scope has no snapshot
+        // yet and the stream only signals CHANGES, so a quiet (or denied)
+        // domain would sit in 'initialising' until the first fallback poll
+        // tick — observed live as 5–10s first-paint stalls on every first
+        // visit to a streaming view. Fetch once now; streamSignal bypasses
+        // the healthy-stream skip, performFetch dedupes in-flight, and a
+        // denied domain gets its typed-403 stamp immediately.
+        if (!getScopedDomainState(domain, scope).data) {
+          void this.performFetch(domain, scope, {
+            isManual: false,
+            streamSignal: true,
+          }).catch(() => {
+            // Failures land in the scoped state via performFetch's own path.
+          });
+        }
       })
       .catch((error) => {
         runtime.failStreamingStart(domain, scope);

--- a/frontend/src/core/refresh/orchestrator.ts
+++ b/frontend/src/core/refresh/orchestrator.ts
@@ -22,6 +22,7 @@ import {
   getScopedDomainState,
   markPendingRequest,
   resetAllScopedDomainStates,
+  resetPermissionDeniedScopedDomainStates,
   resetScopedDomainState,
   setScopedDomainState,
 } from './store';
@@ -113,6 +114,7 @@ class RefreshOrchestrator {
     eventBus.on('refresh:resource-stream-health', this.handleResourceStreamHealth);
     eventBus.on('cluster:auth:failed', this.handleClusterAuthFailed);
     eventBus.on('cluster:auth:recovered', this.handleClusterAuthRecovered);
+    eventBus.on('cluster:scope-changed', this.handleClusterScopeChanged);
     clusterReadiness.onBecameServiceable((clusterId) =>
       this.handleClusterBecameServiceable(clusterId)
     );
@@ -1129,8 +1131,10 @@ class RefreshOrchestrator {
 
     const previousState = getScopedDomainState(domain, normalizedScope);
     // A permission-denied scope is SETTLED: the backend refused it with a
-    // typed 403 and permission changes are not expected mid-session (recovery
-    // is an app restart). Background retries here caused a request every ~2s
+    // typed 403 and permission changes are not expected mid-session (the
+    // exceptions — a namespace-scope rebuild, and manual refresh below —
+    // clear the latch explicitly; see handleClusterScopeChanged). Background
+    // retries here caused a request every ~2s
     // (the no-data fetch clause) and flicked the state through 'loading' —
     // observed live as a spinner flashing over the permission message. Manual
     // refresh remains a deliberate re-ask.
@@ -1445,6 +1449,30 @@ class RefreshOrchestrator {
     // Restart streaming for all enabled scopes. The ensureRefreshBaseURL retry
     // loop (30 attempts with backoff) naturally waits for the backend refresh
     // subsystem to reinitialise after auth recovery.
+    this.handleStreamingScopeChanges();
+  };
+
+  private handleClusterScopeChanged = (payload: { clusterId: string }) => {
+    // The cluster's namespace scope changed and the backend finished tearing
+    // down + rebuilding its refresh subsystem (docs/plans/namespace-scope.md):
+    // every stream to that subsystem is dead and every cached snapshot is
+    // pre-rebuild. Resume exactly as auth recovery does (minus the pause
+    // bookkeeping — auth never went invalid).
+    logInfo('[refresh] namespace scope changed — restarting streams', {
+      clusterId: payload.clusterId,
+    });
+    // Permission-denied scopes are settled for the session — EXCEPT across a
+    // scope rebuild, which is a real permission epoch change: domains denied
+    // cluster-wide may now be served per-namespace. Clear the latches so the
+    // affected scopes re-ask (they hold no data, so nothing blanks).
+    resetPermissionDeniedScopedDomainStates();
+    this.incrementContextVersion();
+    invalidateRefreshBaseURL();
+    // Suppress transient errors while the rebuilt subsystem starts serving.
+    this.errorNotifier.suppressNetworkErrors(6000);
+    this.clearAllBlockedStreaming();
+    this.clearAllStreamHealth();
+    this.errorNotifier.clearAll();
     this.handleStreamingScopeChanges();
   };
 

--- a/frontend/src/core/refresh/orchestrator.ts
+++ b/frontend/src/core/refresh/orchestrator.ts
@@ -111,6 +111,10 @@ class RefreshOrchestrator {
     eventBus.on('kubeconfig:selection-changed', this.handleKubeconfigSelectionChanged);
     eventBus.on('settings:auto-refresh', this.handleAutoRefreshChanged);
     eventBus.on('refresh:resource-stream-drift', this.handleResourceStreamDrift);
+    eventBus.on(
+      'refresh:resource-stream-permission-denied',
+      this.handleResourceStreamPermissionDenied
+    );
     eventBus.on('refresh:resource-stream-health', this.handleResourceStreamHealth);
     eventBus.on('cluster:auth:failed', this.handleClusterAuthFailed);
     eventBus.on('cluster:auth:recovered', this.handleClusterAuthRecovered);
@@ -1374,6 +1378,37 @@ class RefreshOrchestrator {
       this.teardownInFlight(runtime, key, details);
     }
   }
+
+  private handleResourceStreamPermissionDenied = (
+    payload: AppEvents['refresh:resource-stream-permission-denied']
+  ): void => {
+    const scope = payload.scope.trim();
+    if (!scope) {
+      return;
+    }
+    // A settled denial: block the scope's streaming (cleared on scope change
+    // or auth recovery) so it does not resync-loop against a 403 forever.
+    const domain = payload.domain as RefreshDomain;
+    const runtime = this.getRuntimeForScope(domain, scope);
+    if (!runtime.blockStreaming(domain, scope)) {
+      return;
+    }
+    const config = this.configs.get(domain);
+    if (config?.streaming) {
+      this.stopStreamingScope(domain, scope, config.streaming, false);
+    }
+    logWarning(
+      `[refresh] stream permission denied — streaming blocked domain=${domain} scope=${scope} reason=${payload.reason}`,
+      { clusterId: parseClusterScope(scope).clusterId }
+    );
+    // Settle the scope's snapshot state NOW: the fetch gets the same typed
+    // 403 instantly and stamps permissionDenied, so anything gated on this
+    // scope's initial load (the typed-query tables) resolves immediately
+    // instead of waiting out stream teardown timing.
+    void this.performFetch(domain, scope, { isManual: true }).catch(() => {
+      // The stamp lands via the fetch's own error path; nothing to add here.
+    });
+  };
 
   private handleResourceStreamDrift = (
     payload: AppEvents['refresh:resource-stream-drift']

--- a/frontend/src/core/refresh/orchestrator.ts
+++ b/frontend/src/core/refresh/orchestrator.ts
@@ -744,10 +744,8 @@ class RefreshOrchestrator {
 
     startPromise
       .then((cleanup) => {
-        if (
-          !this.isScopedDomainEnabledInternal(domain, scope) ||
-          runtime.isStreamingCancelled(domain, scope)
-        ) {
+        const enabledNow = this.isScopedDomainEnabledInternal(domain, scope);
+        if (!enabledNow || runtime.isStreamingCancelled(domain, scope)) {
           runtime.failStreamingStart(domain, scope);
           runtime.clearStreamingCancelled(domain, scope);
           if (typeof cleanup === 'function') {
@@ -756,6 +754,18 @@ class RefreshOrchestrator {
             } catch (error) {
               console.error(`Failed to clean up streaming domain ${domain}::${scope}`, error);
             }
+          }
+          if (enabledNow) {
+            // A stop cancelled this start mid-flight, but the scope was
+            // re-enabled before it resolved (the mount-time lease flap on
+            // every first view visit). The re-enable's own start attempt
+            // early-returned on THIS pending start, so dying here would
+            // orphan the scope in 'initialising' until the fallback poller's
+            // first tick (observed live: 5-10s first-paint stalls; forever
+            // without an active poller). The cancellation is obsolete —
+            // restart cleanly; the stream manager re-ensures the
+            // linger-stopped subscription.
+            this.startStreamingScope(domain, scope, streaming);
           }
           return;
         }
@@ -807,6 +817,16 @@ class RefreshOrchestrator {
     if (pending) {
       pending
         .then((cleanup) => {
+          // The start's own continuation (attached first) already handled a
+          // cancelled arrival — teardown, or an adopted restart when the
+          // scope was re-enabled — and cleared the cancel flag. Acting here
+          // too would release the manager subscription twice. The flag still
+          // being set means this stop still owns the teardown.
+          if (!runtime.isStreamingCancelled(domain, scope)) {
+            return;
+          }
+          runtime.failStreamingStart(domain, scope);
+          runtime.clearStreamingCancelled(domain, scope);
           if (typeof cleanup === 'function') {
             try {
               cleanup();
@@ -815,7 +835,7 @@ class RefreshOrchestrator {
             }
           }
         })
-        .finally(() => {
+        .catch(() => {
           runtime.failStreamingStart(domain, scope);
           runtime.clearStreamingCancelled(domain, scope);
         });

--- a/frontend/src/core/refresh/orchestrator.ts
+++ b/frontend/src/core/refresh/orchestrator.ts
@@ -779,7 +779,7 @@ class RefreshOrchestrator {
         // visit to a streaming view. Fetch once now; streamSignal bypasses
         // the healthy-stream skip, performFetch dedupes in-flight, and a
         // denied domain gets its typed-403 stamp immediately.
-        if (!getScopedDomainState(domain, scope).data) {
+        if (!streaming.snapshotless && !getScopedDomainState(domain, scope).data) {
           void this.performFetch(domain, scope, {
             isManual: false,
             streamSignal: true,

--- a/frontend/src/core/refresh/refreshRegistration.ts
+++ b/frontend/src/core/refresh/refreshRegistration.ts
@@ -8,6 +8,10 @@ export type StreamingRegistration = {
   refreshOnce?: (scope: string) => Promise<void>;
   // Pause scheduled polling while streaming is active; resume polling as a fallback when it stops.
   pauseRefresherWhenStreaming?: boolean;
+  // No snapshot endpoint backs this domain (its data flows only through its
+  // own stream, e.g. container-logs) — the orchestrator must never issue
+  // snapshot fetches for it; the backend answers them "unknown domain".
+  snapshotless?: boolean;
 };
 
 export type DomainRegistration<K extends RefreshDomain> = {

--- a/frontend/src/core/refresh/store.test.ts
+++ b/frontend/src/core/refresh/store.test.ts
@@ -16,6 +16,7 @@ import {
   markPendingRequest,
   resetAllScopedDomainStates,
   resetDomainState,
+  resetPermissionDeniedScopedDomainStates,
   resetScopedDomainState,
   setDomainState,
   setScopedDomainState,
@@ -168,5 +169,32 @@ describe('refresh store helpers', () => {
 
     markPendingRequest(-5);
     expect(getRefreshState().pendingRequests).toBe(0);
+  });
+});
+
+describe('resetPermissionDeniedScopedDomainStates', () => {
+  afterEach(() => {
+    resetAllScopedDomainStates('namespace-config');
+    resetAllScopedDomainStates('namespaces');
+  });
+
+  it('drops only permission-denied scope states so they re-ask after a scope change', () => {
+    setScopedDomainState('namespaces', 'cluster-a|', (prev) => ({
+      ...prev,
+      status: 'error',
+      permissionDenied: true,
+    }));
+    setScopedDomainState('namespace-config', 'cluster-a|namespace:prod', (prev) => ({
+      ...prev,
+      status: 'ready',
+    }));
+
+    resetPermissionDeniedScopedDomainStates();
+
+    expect(getScopedDomainState('namespaces', 'cluster-a|').permissionDenied).not.toBe(true);
+    expect(getScopedDomainState('namespaces', 'cluster-a|').status).not.toBe('error');
+    expect(getScopedDomainState('namespace-config', 'cluster-a|namespace:prod').status).toBe(
+      'ready'
+    );
   });
 });

--- a/frontend/src/core/refresh/store.ts
+++ b/frontend/src/core/refresh/store.ts
@@ -291,6 +291,31 @@ export const resetAllScopedDomainStates = <K extends RefreshDomain>(domain: K): 
   notify();
 };
 
+/**
+ * Drops every scoped domain state latched permission-denied, so those scopes
+ * re-ask on their next (non-manual) refresh. Permission-denied is normally
+ * settled for the session, but a namespace-scope rebuild
+ * (docs/plans/namespace-scope.md) is a real permission epoch change: domains
+ * denied cluster-wide may now be served per-namespace. Denied scopes hold no
+ * data, so dropping them never blanks a rendered view; every other scope
+ * state is untouched.
+ */
+export const resetPermissionDeniedScopedDomainStates = (): void => {
+  const denied: Array<{ domain: RefreshDomain; scope: string }> = [];
+  for (const [domain, scopes] of Object.entries(state.scopedDomains)) {
+    for (const [scope, snapshot] of Object.entries(
+      scopes as Record<string, DomainSnapshotState<unknown>>
+    )) {
+      if (snapshot.permissionDenied) {
+        denied.push({ domain: domain as RefreshDomain, scope });
+      }
+    }
+  }
+  for (const entry of denied) {
+    resetScopedDomainState(entry.domain, entry.scope);
+  }
+};
+
 export const markPendingRequest = (delta: number): void => {
   state.pendingRequests = Math.max(0, state.pendingRequests + delta);
   notify();

--- a/frontend/src/core/refresh/streaming/resourceStreamManager.ts
+++ b/frontend/src/core/refresh/streaming/resourceStreamManager.ts
@@ -17,7 +17,7 @@ import {
   logAppLogsInfo,
   type AppLogsClusterMeta,
 } from '@/core/logging/appLogsClient';
-import { resolvePermissionDeniedMessage } from '../permissionErrors';
+import { isPermissionDeniedStatus, resolvePermissionDeniedMessage } from '../permissionErrors';
 import {
   domainSupportsSourceClock,
   isResourceStreamSourceClock,
@@ -425,6 +425,20 @@ export class ResourceStreamManager {
           return;
         case SIGNAL_TYPES.error:
           this.recordSubscriptionError(subscription, errorMessage || 'stream error');
+          // A permission-denied frame is a SETTLED answer: resyncing cannot
+          // succeed until RBAC or the namespace scope changes. Hand the scope
+          // to the orchestrator's streaming block (cleared on scope change /
+          // auth recovery) instead of the endless resync loop. Health keeps
+          // reporting "unhealthy (permissions)" for diagnostics.
+          if (isPermissionDeniedStatus(update.errorDetails)) {
+            this.updateHealthForSubscription(subscription);
+            eventBus.emit('refresh:resource-stream-permission-denied', {
+              domain: subscription.domain,
+              scope: subscription.storeScope,
+              reason: errorMessage || 'permission denied',
+            });
+            return;
+          }
           void this.resyncSubscription(subscription, errorMessage || 'stream error', true);
           this.updateHealthForSubscription(subscription);
           return;

--- a/frontend/src/core/refresh/types.ts
+++ b/frontend/src/core/refresh/types.ts
@@ -136,6 +136,12 @@ export interface NamespaceSummary extends ClusterMeta {
   creationTimestamp: number;
   hasWorkloads?: boolean;
   workloadsUnknown?: boolean;
+  /**
+   * Flags a configured scope entry the identity cannot reach
+   * (docs/plans/namespace-scope.md): "not-found" is definitive; "no-access"
+   * may mean missing or denied. Absent for reachable/unscoped rows.
+   */
+  scopeStatus?: 'not-found' | 'no-access';
 }
 
 export interface NamespaceSnapshotPayload extends ClusterMeta {

--- a/frontend/src/core/settings/clusterAllowedNamespaces.test.ts
+++ b/frontend/src/core/settings/clusterAllowedNamespaces.test.ts
@@ -1,0 +1,76 @@
+/**
+ * frontend/src/core/settings/clusterAllowedNamespaces.test.ts
+ *
+ * Tests for the typed per-cluster namespace-scope accessors.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@wailsjs/go/backend/App', () => ({
+  GetClusterAllowedNamespaces: vi.fn(),
+  SetClusterAllowedNamespaces: vi.fn(),
+}));
+
+import { GetClusterAllowedNamespaces, SetClusterAllowedNamespaces } from '@wailsjs/go/backend/App';
+import {
+  getClusterAllowedNamespaces,
+  setClusterAllowedNamespaces,
+} from './clusterAllowedNamespaces';
+
+const getBinding = vi.mocked(GetClusterAllowedNamespaces);
+const setBinding = vi.mocked(SetClusterAllowedNamespaces);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('getClusterAllowedNamespaces', () => {
+  it('returns the persisted scope for the cluster', async () => {
+    getBinding.mockResolvedValue(['prod', 'dev']);
+
+    await expect(getClusterAllowedNamespaces('kc:ctx')).resolves.toEqual(['prod', 'dev']);
+    expect(getBinding).toHaveBeenCalledWith('kc:ctx');
+  });
+
+  it('normalizes a null backend response (unset scope) to an empty list', async () => {
+    getBinding.mockResolvedValue(null as unknown as string[]);
+
+    await expect(getClusterAllowedNamespaces('kc:ctx')).resolves.toEqual([]);
+  });
+
+  it('rejects an empty clusterId without calling the backend', async () => {
+    await expect(getClusterAllowedNamespaces('')).rejects.toThrow(/clusterId/);
+    expect(getBinding).not.toHaveBeenCalled();
+  });
+});
+
+describe('setClusterAllowedNamespaces', () => {
+  it('persists and returns the backend-normalized scope', async () => {
+    setBinding.mockResolvedValue(['prod', 'dev']);
+
+    await expect(setClusterAllowedNamespaces('kc:ctx', [' prod ', 'dev'])).resolves.toEqual([
+      'prod',
+      'dev',
+    ]);
+    expect(setBinding).toHaveBeenCalledWith('kc:ctx', [' prod ', 'dev']);
+  });
+
+  it('normalizes a null backend response (cleared scope) to an empty list', async () => {
+    setBinding.mockResolvedValue(null as unknown as string[]);
+
+    await expect(setClusterAllowedNamespaces('kc:ctx', [])).resolves.toEqual([]);
+  });
+
+  it('rejects an empty clusterId without calling the backend', async () => {
+    await expect(setClusterAllowedNamespaces('', ['prod'])).rejects.toThrow(/clusterId/);
+    expect(setBinding).not.toHaveBeenCalled();
+  });
+
+  it('propagates backend validation errors', async () => {
+    setBinding.mockRejectedValue(new Error('invalid namespace name "Bad!"'));
+
+    await expect(setClusterAllowedNamespaces('kc:ctx', ['Bad!'])).rejects.toThrow(
+      'invalid namespace name "Bad!"'
+    );
+  });
+});

--- a/frontend/src/core/settings/clusterAllowedNamespaces.ts
+++ b/frontend/src/core/settings/clusterAllowedNamespaces.ts
@@ -1,0 +1,27 @@
+/**
+ * frontend/src/core/settings/clusterAllowedNamespaces.ts
+ *
+ * Typed access to the per-cluster namespace scope ("accessible namespaces",
+ * docs/plans/namespace-scope.md). Validation, normalization, persistence, and
+ * the rebuild side effect are backend-owned; these wrappers add types, the
+ * clusterId guard, and null-safety (an unset scope arrives as null).
+ */
+
+import { GetClusterAllowedNamespaces, SetClusterAllowedNamespaces } from '@wailsjs/go/backend/App';
+
+export async function getClusterAllowedNamespaces(clusterId: string): Promise<string[]> {
+  if (!clusterId) {
+    throw new Error('clusterId is required');
+  }
+  return (await GetClusterAllowedNamespaces(clusterId)) ?? [];
+}
+
+export async function setClusterAllowedNamespaces(
+  clusterId: string,
+  namespaces: string[]
+): Promise<string[]> {
+  if (!clusterId) {
+    throw new Error('clusterId is required');
+  }
+  return (await SetClusterAllowedNamespaces(clusterId, namespaces)) ?? [];
+}

--- a/frontend/src/modules/cluster/components/ClusterOverview.tsx
+++ b/frontend/src/modules/cluster/components/ClusterOverview.tsx
@@ -915,7 +915,7 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
               >
                 <span className="metrics-warning-banner__dot" />
                 <span className="metrics-warning-banner__text">
-                  Requests and limits unavailable (no pod access)
+                  Requests and limits unavailable
                 </span>
                 <Tooltip
                   content="Pod requests and limits data is unavailable. Only current usage is shown. Your account is missing required Pod permissions: list, watch."

--- a/frontend/src/modules/cluster/components/ClusterViewCustom.test.tsx
+++ b/frontend/src/modules/cluster/components/ClusterViewCustom.test.tsx
@@ -283,10 +283,11 @@ describe('ClusterViewCustom', () => {
       await Promise.resolve();
     });
 
-    // No in-table banner exists; an errored empty table reads "Unable to load
-    // data" instead of the generic empty message.
+    // No in-table banner exists. A permission-classified catalog error reads
+    // as the designed permission state; non-permission errors keep the
+    // "Unable to load data" treatment (covered by the inventory-table tests).
     expect(container.querySelector('[role="alert"]')).toBeNull();
-    expect(gridTablePropsRef.current?.emptyMessage).toBe('Unable to load data');
+    expect(gridTablePropsRef.current?.emptyMessage).toBe('Insufficient permissions');
   });
 
   it('passes the unfiltered total through to the filter options', async () => {

--- a/frontend/src/modules/kubernetes/config/KubeconfigContext.tsx
+++ b/frontend/src/modules/kubernetes/config/KubeconfigContext.tsx
@@ -25,6 +25,7 @@ import {
   runGridTableGC,
 } from '@shared/components/tables/persistence/gridTablePersistenceGC';
 import { eventBus, useEventBus } from '@/core/events';
+import { logAppLogsInfo } from '@/core/logging/appLogsClient';
 import { refreshOrchestrator, useBackgroundRefresh } from '@/core/refresh';
 import {
   getClusterTabOrder,
@@ -587,6 +588,24 @@ export const KubeconfigProvider: React.FC<KubeconfigProviderProps> = ({ children
       }
     };
   }, [loadKubeconfigs]);
+
+  // Bridge the backend's namespace-scope rebuild completion to the internal
+  // event bus (docs/plans/namespace-scope.md): the orchestrator restarts the
+  // cluster's streams and NamespaceContext refetches the namespaces list.
+  useEffect(() => {
+    const cancel = EventsOn('cluster:scope:changed', (payload?: { clusterId?: string }) => {
+      logAppLogsInfo(
+        `namespace-scope: cluster:scope:changed received for "${payload?.clusterId ?? ''}"`
+      );
+      eventBus.emit('cluster:scope-changed', { clusterId: payload?.clusterId ?? '' });
+    });
+
+    return () => {
+      if (typeof cancel === 'function') {
+        cancel();
+      }
+    };
+  }, []);
 
   // Run GridTable persistence GC when kubeconfigs change or selection changes
   useEffect(() => {

--- a/frontend/src/modules/namespace/contexts/NamespaceContext.tsx
+++ b/frontend/src/modules/namespace/contexts/NamespaceContext.tsx
@@ -46,6 +46,7 @@ export interface NamespaceListItem {
   hasWorkloads: boolean;
   workloadsUnknown: boolean;
   resourceVersion: string;
+  scopeStatus?: 'not-found' | 'no-access';
   isSynthetic?: boolean;
   // Multi-cluster identity — required for stable row keys and scoped operations.
   clusterId?: string;
@@ -222,6 +223,7 @@ export const NamespaceProvider: React.FC<NamespaceProviderProps> = ({ children }
         hasWorkloads: ns.hasWorkloads ?? false,
         workloadsUnknown,
         resourceVersion: ns.resourceVersion,
+        scopeStatus: ns.scopeStatus,
         clusterId: ns.clusterId,
         clusterName: ns.clusterName,
       } satisfies NamespaceListItem;

--- a/frontend/src/modules/namespace/contexts/NamespaceContext.tsx
+++ b/frontend/src/modules/namespace/contexts/NamespaceContext.tsx
@@ -495,16 +495,42 @@ export const NamespaceProvider: React.FC<NamespaceProviderProps> = ({ children }
       });
     };
 
+    // A namespace-scope rebuild finished (docs/plans/namespace-scope.md): the
+    // namespaces domain now serves the new scope. Derive the scope from the
+    // EVENT's clusterId — the local scope memo can be empty or stale at this
+    // moment (the cluster cycled through teardown) — and re-ask on a short
+    // schedule so convergence never depends on one fetch racing the rebuilt
+    // subsystem's HTTP wiring.
+    const scopeRefetchTimers: number[] = [];
+    const handleClusterScopeChanged = (payload: { clusterId: string }) => {
+      const scope = payload.clusterId ? buildClusterScope(payload.clusterId, '') : namespacesScope;
+      if (!scope) {
+        return;
+      }
+      setRefreshDomainEnabled({ domain: 'namespaces', scope, enabled: true });
+      requestedNamespaceScopesRef.current.add(scope);
+      [0, 2000, 6000].forEach((delay) => {
+        scopeRefetchTimers.push(
+          window.setTimeout(() => {
+            void requestRefreshDomain({ domain: 'namespaces', scope, reason: 'user' });
+          }, delay)
+        );
+      });
+    };
+
     const unsubReset = eventBus.on('view:reset', handleResetViews);
     const unsubChanging = eventBus.on('kubeconfig:changing', handleKubeconfigChanging);
     const unsubChanged = eventBus.on('kubeconfig:changed', handleKubeconfigChanged);
+    const unsubScopeChanged = eventBus.on('cluster:scope-changed', handleClusterScopeChanged);
 
     return () => {
       unsubReset();
       unsubChanging();
       unsubChanged();
+      unsubScopeChanged();
+      scopeRefetchTimers.forEach((timer) => window.clearTimeout(timer));
     };
-  }, [clearSelection, namespaceScopes, updateNamespaces]);
+  }, [clearSelection, namespaceScopes, namespacesScope, updateNamespaces]);
 
   // Structural flag stamped by the orchestrator from the typed 403 (checked
   // once per session; the scope is settled and background retries stop).

--- a/frontend/src/modules/resource-grid/ResourceInventoryTable.test.tsx
+++ b/frontend/src/modules/resource-grid/ResourceInventoryTable.test.tsx
@@ -92,10 +92,19 @@ describe('ResourceInventoryTable error surface', () => {
   it('renders the errored empty state without any in-table banner', () => {
     // Error details belong to the refresh error toasts; the table only
     // distinguishes an errored empty from a genuine empty.
-    renderTable(src({ error: 'pods is forbidden: User cannot list resource' }));
+    renderTable(src({ error: 'connection reset while listing pods' }));
     expect(container.querySelector('[role="alert"]')).toBeNull();
     expect(container.textContent).toContain('Unable to load data');
     expect(container.textContent).not.toContain('No data available');
+  });
+
+  it('renders a permission-classified error as the designed permission state', () => {
+    // A typed 403 is a settled, designed state (e.g. a domain the identity
+    // cannot read under a namespace scope) — never the generic failure text.
+    renderTable(src({ error: 'pods is forbidden: User cannot list resource' }));
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+    expect(container.textContent).toContain('Insufficient permissions');
+    expect(container.textContent).not.toContain('Unable to load data');
   });
 
   it('does not show the settled-empty message while errored', () => {

--- a/frontend/src/modules/resource-grid/ResourceInventoryTable.tsx
+++ b/frontend/src/modules/resource-grid/ResourceInventoryTable.tsx
@@ -15,6 +15,7 @@
  * behavior of its own.
  */
 import type React from 'react';
+import { resolveEmptyStateMessage } from '@/utils/emptyState';
 import GridTable, { type GridTableProps } from '@shared/components/tables/GridTable';
 import ResourceLoadingBoundary from '@shared/components/ResourceLoadingBoundary';
 import {
@@ -72,11 +73,14 @@ export default function ResourceInventoryTable<T>({
 
   // A genuinely errored empty table must not read as the generic "No data
   // available"; the error detail itself is reported through the refresh error
-  // toasts, never an in-table banner.
+  // toasts, never an in-table banner. Permission-classified errors are the
+  // exception: they are a designed, settled state (a typed 403 from a domain
+  // the identity cannot read — e.g. under a namespace scope), so they render
+  // the shared "Insufficient permissions" message in place.
   const emptyMessageForState = render.isEmpty
     ? emptyMessage
     : render.error
-      ? 'Unable to load data'
+      ? resolveEmptyStateMessage(render.error, 'Unable to load data')
       : undefined;
 
   return (

--- a/frontend/src/modules/resource-grid/deriveQueryBackedData.test.ts
+++ b/frontend/src/modules/resource-grid/deriveQueryBackedData.test.ts
@@ -15,6 +15,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   deriveQueryBackedData,
+  isLiveDomainInitialLoadPending,
   typedQueryPageLimitOrDefault,
 } from './useQueryBackedResourceGridTable';
 
@@ -108,5 +109,23 @@ describe('typedQueryPageLimitOrDefault', () => {
     expect(typedQueryPageLimitOrDefault(null, 100)).toBe(100);
     expect(typedQueryPageLimitOrDefault(undefined, 100)).toBe(100);
     expect(typedQueryPageLimitOrDefault(333, 100)).toBe(100);
+  });
+});
+
+describe('isLiveDomainInitialLoadPending', () => {
+  it('treats a permission-denied live scope as settled, never pending', () => {
+    // The live-observed 7s spinner: a denied domain's live scope sits in
+    // 'initialising' with no data while its (blocked) stream machinery winds
+    // down — the typed query must not be gated on it.
+    expect(
+      isLiveDomainInitialLoadPending({
+        status: 'initialising',
+        data: undefined,
+        permissionDenied: true,
+      })
+    ).toBe(false);
+    expect(isLiveDomainInitialLoadPending({ status: 'initialising', data: undefined })).toBe(true);
+    expect(isLiveDomainInitialLoadPending({ status: 'loading', data: undefined })).toBe(true);
+    expect(isLiveDomainInitialLoadPending({ status: 'ready', data: { rows: [] } })).toBe(false);
   });
 });

--- a/frontend/src/modules/resource-grid/queryBackedLeafFirstLoad.test.tsx
+++ b/frontend/src/modules/resource-grid/queryBackedLeafFirstLoad.test.tsx
@@ -546,6 +546,49 @@ describe('query-backed leaf first load', () => {
     });
   });
 
+  it('settles a permission-denied domain without warm-up retries and shows the permission state', async () => {
+    // The live failure this pins (restricted identity, docs/plans/namespace-scope.md):
+    // the backend registers namespace-autoscaling permission-denied and every
+    // snapshot fetch 403s with a typed body. The orchestrator stamps
+    // permissionDenied on the query scope's state — the typed query must READ
+    // that stamp and settle (fail fast), never re-arm the 1s warm-up loop that
+    // rendered as an endless first-load spinner.
+    vi.useFakeTimers();
+    try {
+      requestRefreshDomainStateMock.mockResolvedValue({
+        status: 'executed',
+        data: {
+          status: 'error',
+          error:
+            'permission denied for domain namespace-autoscaling (autoscaling/horizontalpodautoscalers)',
+          permissionDenied: true,
+          data: undefined,
+        },
+      });
+      await act(async () => {
+        root.render(
+          <NsViewAutoscaling namespace={ALL_NAMESPACES_SCOPE} showNamespaceColumn={true} />
+        );
+        await Promise.resolve();
+      });
+      await flushQueryEffects();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+      });
+      await flushQueryEffects();
+
+      expect(requestRefreshDomainStateMock).toHaveBeenCalledTimes(1);
+      // GridTable is stubbed in this harness; the rendered message is its
+      // emptyMessage prop (GridTable's own contract displays it when empty).
+      expect(gridTablePropsRef.current).not.toBeNull();
+      expect(gridTablePropsRef.current.emptyMessage).toBe('Insufficient permissions');
+      expect(gridTablePropsRef.current.data).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('uses the typed query result on first load for namespace autoscaling', async () => {
     await expectQueryFirstLoad({
       element: <NsViewAutoscaling namespace={ALL_NAMESPACES_SCOPE} showNamespaceColumn={true} />,

--- a/frontend/src/modules/resource-grid/useQueryBackedResourceGridTable.ts
+++ b/frontend/src/modules/resource-grid/useQueryBackedResourceGridTable.ts
@@ -1,5 +1,4 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react';
-import { logAppLogsInfo } from '@/core/logging/appLogsClient';
 import type { RefreshDomain } from '@/core/refresh/types';
 import { useRefreshScopedDomain } from '@/core/refresh';
 import { useScopedRefreshDomainLifecycle } from '@/core/data-access';
@@ -251,13 +250,6 @@ function useTypedQueryLifecycle<
   // (empty + loading) state until a cluster and persistence are ready.
   const queryEnabled =
     Boolean(clusterId) && tableStateReady && persistence.hydrated && !liveDomainInitialLoadPending;
-  // [DEBUG-qtime] temporary latency instrumentation — remove after diagnosis.
-  const debugGateRef = useRef<string>('');
-  const debugGate = `${queryEnabled}|cluster=${Boolean(clusterId)}|stateReady=${tableStateReady}|hydrated=${persistence.hydrated}|livePending=${liveDomainInitialLoadPending}|liveStatus=${liveDomain.status}|liveDenied=${Boolean(liveDomain.permissionDenied)}`;
-  if (debugGateRef.current !== debugGate) {
-    debugGateRef.current = debugGate;
-    logAppLogsInfo(`[DEBUG-qtime] ${domain} queryEnabled=${debugGate}`);
-  }
 
   // One query serves every sort, including cpu/memory: the backend joins live
   // usage onto the rows at serve and sorts by it, so there is no separate

--- a/frontend/src/modules/resource-grid/useQueryBackedResourceGridTable.ts
+++ b/frontend/src/modules/resource-grid/useQueryBackedResourceGridTable.ts
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react';
+import { logAppLogsInfo } from '@/core/logging/appLogsClient';
 import type { RefreshDomain } from '@/core/refresh/types';
 import { useRefreshScopedDomain } from '@/core/refresh';
 import { useScopedRefreshDomainLifecycle } from '@/core/data-access';
@@ -113,8 +114,19 @@ export function deriveQueryBackedData<TRow>({
   };
 }
 
-const isLiveDomainInitialLoadPending = (state: { status?: string; data?: unknown }): boolean =>
-  !state.data && (state.status === 'loading' || state.status === 'initialising');
+// A permission-denied live scope is SETTLED, not pending: gating the typed
+// query on it would hold the table in its loading state for as long as the
+// (blocked) stream machinery takes to move — observed live as a 7s spinner
+// before "Insufficient permissions". The query issues its own fetch and gets
+// the same typed 403 immediately.
+export const isLiveDomainInitialLoadPending = (state: {
+  status?: string;
+  data?: unknown;
+  permissionDenied?: boolean;
+}): boolean =>
+  !state.data &&
+  !state.permissionDenied &&
+  (state.status === 'loading' || state.status === 'initialising');
 
 export interface QueryBackedNamespaceGridResult<
   T extends ResourceGridTableRow,
@@ -239,6 +251,13 @@ function useTypedQueryLifecycle<
   // (empty + loading) state until a cluster and persistence are ready.
   const queryEnabled =
     Boolean(clusterId) && tableStateReady && persistence.hydrated && !liveDomainInitialLoadPending;
+  // [DEBUG-qtime] temporary latency instrumentation — remove after diagnosis.
+  const debugGateRef = useRef<string>('');
+  const debugGate = `${queryEnabled}|cluster=${Boolean(clusterId)}|stateReady=${tableStateReady}|hydrated=${persistence.hydrated}|livePending=${liveDomainInitialLoadPending}|liveStatus=${liveDomain.status}|liveDenied=${Boolean(liveDomain.permissionDenied)}`;
+  if (debugGateRef.current !== debugGate) {
+    debugGateRef.current = debugGate;
+    logAppLogsInfo(`[DEBUG-qtime] ${domain} queryEnabled=${debugGate}`);
+  }
 
   // One query serves every sort, including cpu/memory: the backend joins live
   // usage onto the rows at serve and sorts by it, so there is no separate

--- a/frontend/src/modules/resource-grid/useTypedResourceQuery.ts
+++ b/frontend/src/modules/resource-grid/useTypedResourceQuery.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { requestRefreshDomainState } from '@/core/data-access';
+import { logAppLogsInfo } from '@/core/logging/appLogsClient';
 import type {
   GridTableFilterState,
   GridTableFilterOptions,
@@ -335,6 +336,8 @@ export function useTypedResourceQuery<TPayload extends TypedQueryPayload, TRow>(
     setLoading(true);
     setError(null);
 
+    // [DEBUG-qtime] temporary latency instrumentation — remove after diagnosis.
+    logAppLogsInfo(`[DEBUG-qtime] ${domain} query fetch attempt=${warmupAttempt} scope=${scope}`);
     void (async () => {
       try {
         const result = await requestRefreshDomainState({
@@ -348,6 +351,9 @@ export function useTypedResourceQuery<TPayload extends TypedQueryPayload, TRow>(
         if (cancelled || queryIdentityRef.current !== identityAtRequest) {
           return;
         }
+        logAppLogsInfo(
+          `[DEBUG-qtime] ${domain} query result status=${result.status} hasPayload=${Boolean(result.data?.data)} denied=${Boolean(result.data?.permissionDenied)}`
+        );
         if (result.status !== 'executed') {
           // A blocked refresh (cluster still connecting, auto-refresh paused) is a
           // warm-up condition, not a failure: stay not-loaded so the table keeps its
@@ -361,6 +367,17 @@ export function useTypedResourceQuery<TPayload extends TypedQueryPayload, TRow>(
         }
         const payload = result.data?.data as TPayload | null | undefined;
         if (!payload) {
+          if (result.data?.permissionDenied) {
+            // The backend refused this domain with a typed 403 — a SETTLED
+            // answer, not a warm-up: retrying cannot succeed until RBAC or
+            // the namespace scope changes (which rebuilds the subsystem and
+            // resets this state). Settle so the table renders the permission
+            // state instead of an endless first-load spinner.
+            revertFailedNavigation();
+            setError(result.data.error ?? 'Insufficient permissions');
+            setLoaded(true);
+            return;
+          }
           // Executed but the scoped state carries no payload yet (backend caches
           // still syncing) — same warm-up treatment as a blocked request.
           revertFailedNavigation();
@@ -466,6 +483,9 @@ export function useTypedResourceQuery<TPayload extends TypedQueryPayload, TRow>(
           cleanup: true,
           preserveState: false,
         });
+        logAppLogsInfo(
+          `[DEBUG-qtime] ${domain} query result status=${result.status} hasPayload=${Boolean(result.data?.data)} denied=${Boolean(result.data?.permissionDenied)}`
+        );
         if (result.status !== 'executed') {
           throw new Error(`${exportLabel} export failed: page ${page + 1} request was blocked`);
         }

--- a/frontend/src/modules/resource-grid/useTypedResourceQuery.ts
+++ b/frontend/src/modules/resource-grid/useTypedResourceQuery.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { requestRefreshDomainState } from '@/core/data-access';
-import { logAppLogsInfo } from '@/core/logging/appLogsClient';
 import type {
   GridTableFilterState,
   GridTableFilterOptions,
@@ -336,8 +335,6 @@ export function useTypedResourceQuery<TPayload extends TypedQueryPayload, TRow>(
     setLoading(true);
     setError(null);
 
-    // [DEBUG-qtime] temporary latency instrumentation — remove after diagnosis.
-    logAppLogsInfo(`[DEBUG-qtime] ${domain} query fetch attempt=${warmupAttempt} scope=${scope}`);
     void (async () => {
       try {
         const result = await requestRefreshDomainState({
@@ -351,9 +348,6 @@ export function useTypedResourceQuery<TPayload extends TypedQueryPayload, TRow>(
         if (cancelled || queryIdentityRef.current !== identityAtRequest) {
           return;
         }
-        logAppLogsInfo(
-          `[DEBUG-qtime] ${domain} query result status=${result.status} hasPayload=${Boolean(result.data?.data)} denied=${Boolean(result.data?.permissionDenied)}`
-        );
         if (result.status !== 'executed') {
           // A blocked refresh (cluster still connecting, auto-refresh paused) is a
           // warm-up condition, not a failure: stay not-loaded so the table keeps its
@@ -483,9 +477,6 @@ export function useTypedResourceQuery<TPayload extends TypedQueryPayload, TRow>(
           cleanup: true,
           preserveState: false,
         });
-        logAppLogsInfo(
-          `[DEBUG-qtime] ${domain} query result status=${result.status} hasPayload=${Boolean(result.data?.data)} denied=${Boolean(result.data?.permissionDenied)}`
-        );
         if (result.status !== 'executed') {
           throw new Error(`${exportLabel} export failed: page ${page + 1} request was blocked`);
         }

--- a/frontend/src/ui/layout/NamespaceScopeEditor.tsx
+++ b/frontend/src/ui/layout/NamespaceScopeEditor.tsx
@@ -67,6 +67,9 @@ export function useNamespaceScope(clusterId: string | undefined): NamespaceScope
   const apply = useCallback(
     async (next: string[]) => {
       if (!clusterId) {
+        // Never swallow an edit: without a cluster id the save cannot be
+        // attributed, and a silent no-op looks like the bug it masks.
+        setError('No active cluster selected — cannot save the namespace scope.');
         return;
       }
       setSaving(true);

--- a/frontend/src/ui/layout/NamespaceScopeEditor.tsx
+++ b/frontend/src/ui/layout/NamespaceScopeEditor.tsx
@@ -1,0 +1,191 @@
+/**
+ * frontend/src/ui/layout/NamespaceScopeEditor.tsx
+ *
+ * The sidebar's inline "accessible namespaces" editor
+ * (docs/plans/namespace-scope.md): the namespaces section itself is the
+ * editor — an add-namespace affordance plus per-row hover delete (the row
+ * buttons live in Sidebar.tsx). No modal, no settings surface; the editing
+ * affordances are also the only "scope active" signal the design needs.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { PlusIcon } from '@shared/components/icons/SharedIcons';
+import {
+  NAMESPACE_SCOPE_SOFT_WARNING_THRESHOLD,
+  addNamespaceToScope,
+  loadNamespaceScope,
+  removeNamespaceFromScope,
+  saveNamespaceScope,
+} from './namespaceScope';
+
+export interface NamespaceScopeState {
+  /** The persisted scope for the active cluster (empty = unscoped). */
+  scope: string[];
+  /** True once the initial load for the active cluster finished. */
+  loaded: boolean;
+  saving: boolean;
+  error: string | null;
+  addNamespace: (name: string) => boolean;
+  removeNamespace: (name: string) => void;
+  clearError: () => void;
+}
+
+export function useNamespaceScope(clusterId: string | undefined): NamespaceScopeState {
+  const [scope, setScope] = useState<string[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setScope([]);
+    setError(null);
+    setLoaded(false);
+    if (!clusterId) {
+      setLoaded(true);
+      return;
+    }
+    void loadNamespaceScope(clusterId).then(
+      (names) => {
+        if (!cancelled) {
+          setScope(names);
+          setLoaded(true);
+        }
+      },
+      () => {
+        // Unreadable settings degrade to "no scope" — same as the backend.
+        if (!cancelled) {
+          setLoaded(true);
+        }
+      }
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [clusterId]);
+
+  const apply = useCallback(
+    async (next: string[]) => {
+      if (!clusterId) {
+        return;
+      }
+      setSaving(true);
+      setError(null);
+      try {
+        setScope(await saveNamespaceScope(clusterId, next));
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setSaving(false);
+      }
+    },
+    [clusterId]
+  );
+
+  const addNamespace = useCallback(
+    (name: string): boolean => {
+      const result = addNamespaceToScope(scope, name);
+      if (result.error) {
+        setError(result.error);
+        return false;
+      }
+      void apply(result.next ?? scope);
+      return true;
+    },
+    [scope, apply]
+  );
+
+  const removeNamespace = useCallback(
+    (name: string) => {
+      void apply(removeNamespaceFromScope(scope, name));
+    },
+    [scope, apply]
+  );
+
+  const clearError = useCallback(() => setError(null), []);
+
+  return { scope, loaded, saving, error, addNamespace, removeNamespace, clearError };
+}
+
+interface NamespaceScopeAddRowProps {
+  state: NamespaceScopeState;
+}
+
+/**
+ * The "Add namespace" row: a sidebar item that turns into an inline input.
+ * Enter commits (backend validates and rebuilds), Escape cancels.
+ */
+export function NamespaceScopeAddRow({ state }: NamespaceScopeAddRowProps) {
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editing) {
+      inputRef.current?.focus();
+    }
+  }, [editing]);
+
+  const commit = () => {
+    const name = value.trim();
+    if (name === '') {
+      setEditing(false);
+      return;
+    }
+    if (state.addNamespace(name)) {
+      setValue('');
+      setEditing(false);
+    }
+  };
+
+  return (
+    <div className="namespace-scope-editor">
+      {editing ? (
+        <input
+          ref={inputRef}
+          className="namespace-scope-input"
+          type="text"
+          value={value}
+          placeholder="namespace name"
+          spellCheck={false}
+          disabled={state.saving}
+          onChange={(event) => {
+            state.clearError();
+            setValue(event.target.value);
+          }}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') {
+              commit();
+            } else if (event.key === 'Escape') {
+              setValue('');
+              setEditing(false);
+              state.clearError();
+            }
+          }}
+          onBlur={() => {
+            if (value.trim() === '') {
+              setEditing(false);
+              state.clearError();
+            }
+          }}
+        />
+      ) : (
+        <div
+          className="sidebar-item namespace-scope-add"
+          role="button"
+          tabIndex={-1}
+          onClick={() => setEditing(true)}
+        >
+          <PlusIcon width={14} height={14} />
+          <span>Add namespace</span>
+        </div>
+      )}
+      {state.error ? <div className="namespace-scope-error">{state.error}</div> : null}
+      {state.scope.length > NAMESPACE_SCOPE_SOFT_WARNING_THRESHOLD ? (
+        <div className="namespace-scope-warning">
+          Large scopes open one watch per resource kind per namespace.
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/ui/layout/NamespaceScopeEditor.tsx
+++ b/frontend/src/ui/layout/NamespaceScopeEditor.tsx
@@ -157,9 +157,16 @@ export function NamespaceScopeAddRow({ state }: NamespaceScopeAddRowProps) {
             setValue(event.target.value);
           }}
           onKeyDown={(event) => {
+            // The editor owns its keys (docs/frontend/keyboard.md): stop
+            // propagation so sidebar/global shortcuts never see them, and
+            // prevent the default on the keys we consume — an unconsumed
+            // Enter reaching the native layer beeps on macOS.
+            event.stopPropagation();
             if (event.key === 'Enter') {
+              event.preventDefault();
               commit();
             } else if (event.key === 'Escape') {
+              event.preventDefault();
               setValue('');
               setEditing(false);
               state.clearError();

--- a/frontend/src/ui/layout/Sidebar.css
+++ b/frontend/src/ui/layout/Sidebar.css
@@ -297,3 +297,60 @@ body.sidebar-resizing * {
     col-resize !important;
   user-select: none !important;
 }
+
+/* Inline "accessible namespaces" scope editor (docs/plans/namespace-scope.md).
+   Hover-reveal delete follows the favorites-dropdown pattern. */
+.namespace-scope-remove {
+  display: none;
+  margin-left: auto;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: 0 0.15rem;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+}
+
+.sidebar-item:hover .namespace-scope-remove {
+  display: inline-flex;
+}
+
+.namespace-scope-remove:hover {
+  color: var(--color-danger);
+}
+
+.namespace-scope-add {
+  color: var(--color-text-secondary);
+}
+
+.namespace-scope-add:hover {
+  color: var(--color-text);
+}
+
+.namespace-scope-input {
+  width: calc(100% - 1rem);
+  margin: 0.15rem 0.5rem;
+  padding: 0.1rem 0.3rem;
+  font-size: var(--font-size-normal);
+  color: var(--color-text);
+  background-color: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: 3px;
+}
+
+.namespace-scope-error,
+.namespace-scope-warning {
+  padding: 0.15rem 0.5rem;
+  font-size: var(--font-size-small);
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+.namespace-scope-error {
+  color: var(--color-danger);
+}
+
+.namespace-scope-warning {
+  color: var(--color-text-secondary);
+}

--- a/frontend/src/ui/layout/Sidebar.css
+++ b/frontend/src/ui/layout/Sidebar.css
@@ -354,3 +354,23 @@ body.sidebar-resizing * {
 .namespace-scope-warning {
   color: var(--color-text-secondary);
 }
+
+/* Flags a configured scope namespace the identity cannot reach
+   (not-found / no-access) — targeted glyph, tooltip carries the detail. */
+.namespace-scope-flag {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 0.25rem;
+  color: var(--color-warning, #b58900);
+}
+
+/* Inaccessible scope entries cannot expand: no pointer affordance, muted
+   text; the hover delete (and flag tooltip) remain the row's only actions. */
+.sidebar-item.scope-inaccessible {
+  cursor: default;
+  color: var(--color-text-secondary);
+}
+
+.sidebar-item.scope-inaccessible:hover {
+  color: var(--color-text-secondary);
+}

--- a/frontend/src/ui/layout/Sidebar.test.tsx
+++ b/frontend/src/ui/layout/Sidebar.test.tsx
@@ -170,15 +170,65 @@ describe('Sidebar', () => {
     vi.clearAllMocks();
   });
 
-  it('shows the permission message instead of a namespace list when listing is denied', () => {
+  it('shows the permission message and the scope editor when listing is denied', () => {
     // Fail-fast design: no catalog inference, no empty list — the user is told
-    // exactly why the sidebar has no namespaces.
+    // exactly why the sidebar has no namespaces, and the inline scope editor
+    // (docs/plans/namespace-scope.md) is the way in for a restricted identity.
     namespaceState.namespacesPermissionDenied = true;
     namespaceState.namespaces = [];
     renderSidebar();
 
-    expect(container!.textContent).toContain('You do not have permission to list namespaces.');
+    expect(container!.textContent).toContain('Insufficient permission to list namespaces.');
+    expect(container!.textContent).toContain('Add namespace');
     expect(container!.querySelector('[data-sidebar-target-kind="namespace-toggle"]')).toBeNull();
+  });
+
+  it('does not expand inaccessible scope namespaces', () => {
+    // A scope entry flagged not-found/no-access has no views to offer: the
+    // row must not expand on click, must be excluded from keyboard
+    // navigation, and must carry the warning flag.
+    namespaceState.namespaces = [
+      {
+        name: 'ghost',
+        scope: 'ghost',
+        resourceVersion: '',
+        hasWorkloads: false,
+        workloadsUnknown: true,
+        scopeStatus: 'not-found',
+        details: '',
+      },
+      {
+        name: 'default',
+        scope: 'default',
+        resourceVersion: '1',
+        hasWorkloads: true,
+        workloadsUnknown: false,
+        details: '',
+      },
+    ] as NamespaceEntry[];
+    renderSidebar();
+
+    const rows = Array.from(
+      container!.querySelectorAll<HTMLElement>('[data-sidebar-target-kind="namespace-toggle"]')
+    );
+    const ghostRow = rows.find((row) => row.textContent?.includes('ghost'));
+    const defaultRow = rows.find((row) => row.textContent?.includes('default'));
+    expect(ghostRow).toBeDefined();
+    expect(defaultRow).toBeDefined();
+
+    expect(ghostRow!.getAttribute('data-sidebar-focusable')).toBeNull();
+    expect(ghostRow!.querySelector('.namespace-scope-flag')).not.toBeNull();
+    expect(defaultRow!.getAttribute('data-sidebar-focusable')).toBe('true');
+
+    act(() => {
+      ghostRow!.click();
+    });
+    expect(container!.querySelector('.namespaces-section .sidebar-views')).toBeNull();
+
+    act(() => {
+      defaultRow!.click();
+    });
+    expect(container!.querySelector('.namespaces-section .sidebar-views')).not.toBeNull();
   });
 
   it('toggles the sidebar when the toolbar button is pressed', () => {

--- a/frontend/src/ui/layout/Sidebar.tsx
+++ b/frontend/src/ui/layout/Sidebar.tsx
@@ -18,9 +18,11 @@ import {
   ClusterOverviewIcon,
   ClusterResourcesIcon,
   CategoryIcon,
+  CloseIcon,
   NamespaceIcon,
   NamespaceOpenIcon,
 } from '@shared/components/icons/SharedIcons';
+import { NamespaceScopeAddRow, useNamespaceScope } from './NamespaceScopeEditor';
 import type { NamespaceViewType, ClusterViewType } from '@/types/navigation/views';
 import { isMacPlatform } from '@/utils/platform';
 import { useKubeconfig } from '@modules/kubernetes/config/KubeconfigContext';
@@ -78,6 +80,10 @@ function Sidebar() {
   } = useNamespace();
   const { suppressPassiveLoading } = useAutoRefreshLoadingState();
   const { selectedClusterId } = useKubeconfig();
+  // The active cluster's "accessible namespaces" scope
+  // (docs/plans/namespace-scope.md): the namespaces section doubles as its
+  // inline editor when a scope is set or the cluster-wide list is denied.
+  const namespaceScope = useNamespaceScope(selectedClusterId || undefined);
   const dimInactiveNamespaces = useDimInactiveNamespaces();
   const exclusiveNamespaces = useExclusiveNamespaces();
   // The namespaces domain is the ONLY membership source. It is
@@ -411,11 +417,17 @@ function Sidebar() {
               <h3>Namespaces</h3>
               {namespacesPermissionDenied ? (
                 // Fail fast: the namespaces domain is permission-gated
-                // backend-side; there is no fallback inference (manual
-                // namespace entry is future work, docs/todo.md).
-                <div className="sidebar-empty-message">
-                  You do not have permission to list namespaces.
-                </div>
+                // backend-side; there is no fallback inference. The inline
+                // scope editor below is the way in for a restricted identity
+                // (docs/plans/namespace-scope.md): added names become the
+                // cluster's "accessible namespaces" scope.
+                <>
+                  <div className="sidebar-empty-message">
+                    You do not have permission to list namespaces. Add the namespaces you can
+                    access:
+                  </div>
+                  <NamespaceScopeAddRow state={namespaceScope} />
+                </>
               ) : showNamespaceLoading ? (
                 <LoadingSpinner message="Loading namespaces..." />
               ) : showNamespacePausedMessage ? (
@@ -472,6 +484,23 @@ function Sidebar() {
                             <NamespaceIcon width={14} height={14} />
                           )}
                           <span>{namespace.name}</span>
+                          {namespaceScope.scope.includes(namespace.name) &&
+                          scope !== ALL_NAMESPACES_SCOPE ? (
+                            <button
+                              type="button"
+                              className="namespace-scope-remove"
+                              title={`Remove "${namespace.name}" from accessible namespaces`}
+                              disabled={namespaceScope.saving}
+                              onClick={(event) => {
+                                // The row click expands/navigates; removal is
+                                // its own action.
+                                event.stopPropagation();
+                                namespaceScope.removeNamespace(namespace.name);
+                              }}
+                            >
+                              <CloseIcon width={12} height={12} />
+                            </button>
+                          ) : null}
                         </div>
                         {isExpanded && (
                           <div className="sidebar-views">
@@ -515,6 +544,11 @@ function Sidebar() {
                       </div>
                     );
                   })}
+                  {namespaceScope.scope.length > 0 ? (
+                    // A scoped cluster's list is user-curated: the same
+                    // add affordance that created it stays available.
+                    <NamespaceScopeAddRow state={namespaceScope} />
+                  ) : null}
                 </div>
               )}
             </div>

--- a/frontend/src/ui/layout/Sidebar.tsx
+++ b/frontend/src/ui/layout/Sidebar.tsx
@@ -19,6 +19,7 @@ import {
   ClusterResourcesIcon,
   CategoryIcon,
   CloseIcon,
+  WarningOutlineIcon,
   NamespaceIcon,
   NamespaceOpenIcon,
 } from '@shared/components/icons/SharedIcons';
@@ -423,8 +424,8 @@ function Sidebar() {
                 // cluster's "accessible namespaces" scope.
                 <>
                   <div className="sidebar-empty-message">
-                    You do not have permission to list namespaces. Add the namespaces you can
-                    access:
+                    Insufficient permission to list namespaces. You may manually add the namespaces
+                    you are allowed to access:
                   </div>
                   <NamespaceScopeAddRow state={namespaceScope} />
                 </>
@@ -437,7 +438,11 @@ function Sidebar() {
                   {namespaces.map((namespace) => {
                     const scope = namespace.scope ?? namespace.name;
                     const namespaceKey = toNamespaceKey(selectedClusterId ?? '', scope);
-                    const isExpanded = expandedNamespaceKeys.has(namespaceKey);
+                    // An inaccessible scope entry (not-found / no-access) has
+                    // no views to offer: it cannot expand, is skipped by
+                    // keyboard navigation, and only supports hover-delete.
+                    const inaccessible = Boolean(namespace.scopeStatus);
+                    const isExpanded = !inaccessible && expandedNamespaceKeys.has(namespaceKey);
                     const namespaceViews =
                       scope === ALL_NAMESPACES_SCOPE
                         ? NAMESPACE_VIEWS.filter((view) => view.id !== 'map')
@@ -450,6 +455,7 @@ function Sidebar() {
                           className={buildSidebarItemClassName(
                             [
                               'sidebar-item',
+                              inaccessible ? 'scope-inaccessible' : '',
                               // Only a CONFIRMED absence of workloads changes the
                               // presentation; while workload presence is still
                               // unknown (ingest stores settling after connect) the
@@ -470,9 +476,12 @@ function Sidebar() {
                             if (!keyboardActivationRef.current) {
                               clearKeyboardPreview();
                             }
+                            if (inaccessible) {
+                              return;
+                            }
                             handleNamespaceSelect(scope, selectedClusterId || undefined);
                           }}
-                          data-sidebar-focusable="true"
+                          data-sidebar-focusable={inaccessible ? undefined : 'true'}
                           data-sidebar-target-kind="namespace-toggle"
                           data-sidebar-target-namespace={namespaceKey}
                           title={namespace.details || undefined}
@@ -484,6 +493,18 @@ function Sidebar() {
                             <NamespaceIcon width={14} height={14} />
                           )}
                           <span>{namespace.name}</span>
+                          {namespace.scopeStatus ? (
+                            <span
+                              className="namespace-scope-flag"
+                              title={
+                                namespace.scopeStatus === 'not-found'
+                                  ? 'Namespace not found on the cluster.'
+                                  : 'Insufficient permissions to access this namespace (or it does not exist).'
+                              }
+                            >
+                              <WarningOutlineIcon width={12} height={12} />
+                            </span>
+                          ) : null}
                           {namespaceScope.scope.includes(namespace.name) &&
                           scope !== ALL_NAMESPACES_SCOPE ? (
                             <button

--- a/frontend/src/ui/layout/SidebarKeys.test.tsx
+++ b/frontend/src/ui/layout/SidebarKeys.test.tsx
@@ -248,6 +248,48 @@ describe('useSidebarKeyboardControls', () => {
     vi.clearAllMocks();
   });
 
+  it('leaves keys to a focused input inside the sidebar', async () => {
+    // The inline namespace-scope editor lives inside the sidebar: while it
+    // has focus the navigation scope must not claim Enter/arrows — a claimed
+    // Enter gets its default prevented and macOS beeps for the key the
+    // input needed (docs/frontend/keyboard.md: preserve native editing).
+    const { container, cleanup } = renderHarness({
+      selectionTarget: { kind: 'overview' },
+    });
+    const sidebarRoot = container.querySelector<HTMLElement>(
+      '[data-sidebar-target-kind="overview"]'
+    )!.parentElement!;
+    const input = document.createElement('input');
+    sidebarRoot.appendChild(input);
+    input.focus();
+
+    const enter = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+      cancelable: true,
+    });
+    await act(async () => {
+      input.dispatchEvent(enter);
+      await Promise.resolve();
+    });
+    expect(enter.defaultPrevented).toBe(false);
+
+    const arrow = new KeyboardEvent('keydown', {
+      key: 'ArrowDown',
+      bubbles: true,
+      cancelable: true,
+    });
+    await act(async () => {
+      input.dispatchEvent(arrow);
+      await Promise.resolve();
+    });
+    expect(arrow.defaultPrevented).toBe(false);
+    expect(document.activeElement).toBe(input);
+
+    input.remove();
+    cleanup();
+  });
+
   it('marks active/preview items', () => {
     const { ref, container, cleanup } = renderHarness({
       selectionTarget: { kind: 'overview' },

--- a/frontend/src/ui/layout/SidebarKeys.ts
+++ b/frontend/src/ui/layout/SidebarKeys.ts
@@ -269,6 +269,13 @@ export const useSidebarKeyboardControls = ({
       if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) {
         return false;
       }
+      // Native text editing owns the keys while an input inside the sidebar
+      // has focus (the inline namespace-scope editor): claiming Enter/arrows
+      // here would both break editing and beep — the framework prevents the
+      // default on a key the input needed. Mirrors the Tab branch's guard.
+      if (isInputElement(resolveEventElement(event.target))) {
+        return false;
+      }
 
       const items = getFocusableItems();
       if (items.length === 0) {

--- a/frontend/src/ui/layout/namespaceScope.test.ts
+++ b/frontend/src/ui/layout/namespaceScope.test.ts
@@ -78,18 +78,21 @@ describe('loadNamespaceScope', () => {
 });
 
 describe('saveNamespaceScope', () => {
-  it('persists and then requests a namespaces refresh for the cluster', async () => {
+  it('persists and returns the normalized scope WITHOUT an immediate refetch', async () => {
+    // The refetch must NOT fire here: the backend tears down and rebuilds the
+    // cluster's subsystem for seconds after the save, so an immediate fetch
+    // races the rebuild and caches the stale pre-rebuild snapshot. The
+    // frontend converges on the backend's cluster:scope:changed event
+    // instead (orchestrator + NamespaceContext listeners).
     setMock.mockResolvedValue(['prod', 'dev']);
 
     const result = await saveNamespaceScope('kc:ctx', ['prod', 'dev']);
     expect(result).toEqual(['prod', 'dev']);
     expect(setMock).toHaveBeenCalledWith('kc:ctx', ['prod', 'dev']);
-    expect(refreshMock).toHaveBeenCalledWith(
-      expect.objectContaining({ domain: 'namespaces', reason: 'user' })
-    );
+    expect(refreshMock).not.toHaveBeenCalled();
   });
 
-  it('propagates backend validation errors without refreshing', async () => {
+  it('propagates backend validation errors', async () => {
     setMock.mockRejectedValue(new Error('invalid namespace name "Bad!"'));
 
     await expect(saveNamespaceScope('kc:ctx', ['Bad!'])).rejects.toThrow('invalid namespace');

--- a/frontend/src/ui/layout/namespaceScope.test.ts
+++ b/frontend/src/ui/layout/namespaceScope.test.ts
@@ -1,0 +1,105 @@
+/**
+ * frontend/src/ui/layout/namespaceScope.test.ts
+ *
+ * Tests for the sidebar namespace-scope editor logic
+ * (docs/plans/namespace-scope.md).
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/core/settings/clusterAllowedNamespaces', () => ({
+  getClusterAllowedNamespaces: vi.fn(),
+  setClusterAllowedNamespaces: vi.fn(),
+}));
+vi.mock('@/core/data-access', () => ({
+  requestRefreshDomain: vi.fn(),
+}));
+
+import {
+  getClusterAllowedNamespaces,
+  setClusterAllowedNamespaces,
+} from '@/core/settings/clusterAllowedNamespaces';
+import { requestRefreshDomain } from '@/core/data-access';
+import {
+  NAMESPACE_SCOPE_SOFT_WARNING_THRESHOLD,
+  addNamespaceToScope,
+  isValidNamespaceName,
+  loadNamespaceScope,
+  removeNamespaceFromScope,
+  saveNamespaceScope,
+} from './namespaceScope';
+
+const getMock = vi.mocked(getClusterAllowedNamespaces);
+const setMock = vi.mocked(setClusterAllowedNamespaces);
+const refreshMock = vi.mocked(requestRefreshDomain);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('isValidNamespaceName', () => {
+  it('accepts DNS-1123 labels and rejects everything else', () => {
+    expect(isValidNamespaceName('prod')).toBe(true);
+    expect(isValidNamespaceName('team-a1')).toBe(true);
+    expect(isValidNamespaceName('')).toBe(false);
+    expect(isValidNamespaceName('Prod')).toBe(false);
+    expect(isValidNamespaceName('-lead')).toBe(false);
+    expect(isValidNamespaceName('trail-')).toBe(false);
+    expect(isValidNamespaceName('has_underscore')).toBe(false);
+    expect(isValidNamespaceName('a'.repeat(64))).toBe(false);
+    expect(isValidNamespaceName('a'.repeat(63))).toBe(true);
+  });
+});
+
+describe('scope list operations', () => {
+  it('adds a trimmed name, rejecting duplicates and invalid names', () => {
+    expect(addNamespaceToScope(['prod'], ' dev ')).toEqual({ next: ['prod', 'dev'] });
+    expect(addNamespaceToScope(['prod'], 'prod').error).toMatch(/already/);
+    expect(addNamespaceToScope(['prod'], 'Not Valid').error).toMatch(/lowercase/);
+  });
+
+  it('removes a name', () => {
+    expect(removeNamespaceFromScope(['prod', 'dev'], 'prod')).toEqual(['dev']);
+    expect(removeNamespaceFromScope(['prod'], 'absent')).toEqual(['prod']);
+  });
+});
+
+describe('loadNamespaceScope', () => {
+  it('reads the persisted scope for the cluster', async () => {
+    getMock.mockResolvedValue(['prod']);
+    await expect(loadNamespaceScope('kc:ctx')).resolves.toEqual(['prod']);
+    expect(getMock).toHaveBeenCalledWith('kc:ctx');
+  });
+
+  it('returns an empty scope when no cluster is selected', async () => {
+    await expect(loadNamespaceScope('')).resolves.toEqual([]);
+    expect(getMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('saveNamespaceScope', () => {
+  it('persists and then requests a namespaces refresh for the cluster', async () => {
+    setMock.mockResolvedValue(['prod', 'dev']);
+
+    const result = await saveNamespaceScope('kc:ctx', ['prod', 'dev']);
+    expect(result).toEqual(['prod', 'dev']);
+    expect(setMock).toHaveBeenCalledWith('kc:ctx', ['prod', 'dev']);
+    expect(refreshMock).toHaveBeenCalledWith(
+      expect.objectContaining({ domain: 'namespaces', reason: 'user' })
+    );
+  });
+
+  it('propagates backend validation errors without refreshing', async () => {
+    setMock.mockRejectedValue(new Error('invalid namespace name "Bad!"'));
+
+    await expect(saveNamespaceScope('kc:ctx', ['Bad!'])).rejects.toThrow('invalid namespace');
+    expect(refreshMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('soft warning threshold', () => {
+  it('is a sane bound (watches scale with kinds × namespaces)', () => {
+    expect(NAMESPACE_SCOPE_SOFT_WARNING_THRESHOLD).toBeGreaterThan(5);
+    expect(NAMESPACE_SCOPE_SOFT_WARNING_THRESHOLD).toBeLessThanOrEqual(50);
+  });
+});

--- a/frontend/src/ui/layout/namespaceScope.ts
+++ b/frontend/src/ui/layout/namespaceScope.ts
@@ -1,0 +1,72 @@
+/**
+ * frontend/src/ui/layout/namespaceScope.ts
+ *
+ * Logic for the sidebar's inline "accessible namespaces" scope editor
+ * (docs/plans/namespace-scope.md). Validation here is syntactic only — the
+ * backend re-validates, persists, and rebuilds the cluster's subsystem; after
+ * a save the namespaces domain re-serves the synthesized list.
+ */
+
+import {
+  getClusterAllowedNamespaces,
+  setClusterAllowedNamespaces,
+} from '@/core/settings/clusterAllowedNamespaces';
+import { requestRefreshDomain } from '@/core/data-access';
+import { buildClusterScope } from '@/core/refresh/clusterScope';
+
+/**
+ * Above this many namespaces the editor shows a soft performance note:
+ * a scoped cluster runs one watch per kind per namespace.
+ */
+export const NAMESPACE_SCOPE_SOFT_WARNING_THRESHOLD = 20;
+
+const DNS1123_LABEL = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
+
+export function isValidNamespaceName(name: string): boolean {
+  return name.length > 0 && name.length <= 63 && DNS1123_LABEL.test(name);
+}
+
+export interface ScopeAddResult {
+  next?: string[];
+  error?: string;
+}
+
+export function addNamespaceToScope(scope: string[], rawName: string): ScopeAddResult {
+  const name = rawName.trim();
+  if (!isValidNamespaceName(name)) {
+    return {
+      error: 'Namespace names are lowercase letters, digits, and dashes (max 63 characters).',
+    };
+  }
+  if (scope.includes(name)) {
+    return { error: `"${name}" is already in the list.` };
+  }
+  return { next: [...scope, name] };
+}
+
+export function removeNamespaceFromScope(scope: string[], name: string): string[] {
+  return scope.filter((entry) => entry !== name);
+}
+
+export async function loadNamespaceScope(clusterId: string): Promise<string[]> {
+  if (!clusterId) {
+    return [];
+  }
+  return getClusterAllowedNamespaces(clusterId);
+}
+
+/**
+ * Persists the scope (the backend validates, rewrites settings.json, and
+ * rebuilds the cluster's refresh subsystem), then requests a namespaces
+ * refresh so the sidebar converges promptly — the doorbell after the rebuild
+ * covers any remaining staleness.
+ */
+export async function saveNamespaceScope(clusterId: string, next: string[]): Promise<string[]> {
+  const normalized = await setClusterAllowedNamespaces(clusterId, next);
+  void requestRefreshDomain({
+    domain: 'namespaces',
+    scope: buildClusterScope(clusterId, ''),
+    reason: 'user',
+  });
+  return normalized;
+}

--- a/frontend/src/ui/layout/namespaceScope.ts
+++ b/frontend/src/ui/layout/namespaceScope.ts
@@ -11,8 +11,7 @@ import {
   getClusterAllowedNamespaces,
   setClusterAllowedNamespaces,
 } from '@/core/settings/clusterAllowedNamespaces';
-import { requestRefreshDomain } from '@/core/data-access';
-import { buildClusterScope } from '@/core/refresh/clusterScope';
+import { logAppLogsError, logAppLogsInfo } from '@/core/logging/appLogsClient';
 
 /**
  * Above this many namespaces the editor shows a soft performance note:
@@ -56,17 +55,21 @@ export async function loadNamespaceScope(clusterId: string): Promise<string[]> {
 }
 
 /**
- * Persists the scope (the backend validates, rewrites settings.json, and
- * rebuilds the cluster's refresh subsystem), then requests a namespaces
- * refresh so the sidebar converges promptly — the doorbell after the rebuild
- * covers any remaining staleness.
+ * Persists the scope. The backend validates, rewrites settings.json, and
+ * tears down + rebuilds the cluster's refresh subsystem (seconds); when the
+ * rebuild finishes it emits `cluster:scope:changed`, which the orchestrator
+ * and NamespaceContext handle by restarting streams and refetching — an
+ * immediate refetch here would race the rebuild and cache the stale
+ * pre-rebuild snapshot.
  */
 export async function saveNamespaceScope(clusterId: string, next: string[]): Promise<string[]> {
-  const normalized = await setClusterAllowedNamespaces(clusterId, next);
-  void requestRefreshDomain({
-    domain: 'namespaces',
-    scope: buildClusterScope(clusterId, ''),
-    reason: 'user',
-  });
-  return normalized;
+  logAppLogsInfo(`namespace-scope: saving [${next.join(', ')}] for cluster "${clusterId}"`);
+  try {
+    const normalized = await setClusterAllowedNamespaces(clusterId, next);
+    logAppLogsInfo(`namespace-scope: saved [${normalized.join(', ')}] for cluster "${clusterId}"`);
+    return normalized;
+  } catch (error) {
+    logAppLogsError(`namespace-scope: save failed for cluster "${clusterId}": ${String(error)}`);
+    throw error;
+  }
 }

--- a/frontend/wailsjs/go/backend/App.d.ts
+++ b/frontend/wailsjs/go/backend/App.d.ts
@@ -107,6 +107,8 @@ export function GetBackendTLSPolicy(arg1:string,arg2:string,arg3:string):Promise
 
 export function GetCatalogDiagnostics():Promise<backend.CatalogDiagnostics>;
 
+export function GetClusterAllowedNamespaces(arg1:string):Promise<Array<string>>;
+
 export function GetClusterAuthState(arg1:string):Promise<string|string>;
 
 export function GetClusterPortForwardCount(arg1:string):Promise<number>;
@@ -286,6 +288,8 @@ export function SetAppearanceMode(arg1:string):Promise<void>;
 export function SetAutoRefreshEnabled(arg1:boolean):Promise<void>;
 
 export function SetBackgroundRefreshEnabled(arg1:boolean):Promise<void>;
+
+export function SetClusterAllowedNamespaces(arg1:string,arg2:Array<string>):Promise<Array<string>>;
 
 export function SetClusterTabOrder(arg1:Array<string>):Promise<void>;
 

--- a/frontend/wailsjs/go/backend/App.js
+++ b/frontend/wailsjs/go/backend/App.js
@@ -130,6 +130,10 @@ export function GetCatalogDiagnostics() {
   return window['go']['backend']['App']['GetCatalogDiagnostics']();
 }
 
+export function GetClusterAllowedNamespaces(arg1) {
+  return window['go']['backend']['App']['GetClusterAllowedNamespaces'](arg1);
+}
+
 export function GetClusterAuthState(arg1) {
   return window['go']['backend']['App']['GetClusterAuthState'](arg1);
 }
@@ -488,6 +492,10 @@ export function SetAutoRefreshEnabled(arg1) {
 
 export function SetBackgroundRefreshEnabled(arg1) {
   return window['go']['backend']['App']['SetBackgroundRefreshEnabled'](arg1);
+}
+
+export function SetClusterAllowedNamespaces(arg1, arg2) {
+  return window['go']['backend']['App']['SetClusterAllowedNamespaces'](arg1, arg2);
 }
 
 export function SetClusterTabOrder(arg1) {

--- a/test/kind/restricted.sh
+++ b/test/kind/restricted.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Manages a local Kind cluster with namespace-scoped view access.
+# Manages a local Kind cluster with namespace-scoped management access.
 # Usage: ./restricted.sh start | stop
 
 set -euo pipefail
@@ -23,10 +23,17 @@ KIND_CONTEXT="kind-${CLUSTER_NAME}"
 ADMIN_CONTEXT="restricted-cluster-admin"
 RESTRICTED_CONTEXT="restricted-cluster"
 
-RESTRICTED_NAMESPACE="luxury-yacht-restricted"
-RESTRICTED_SERVICE_ACCOUNT="restricted-viewer"
-RESTRICTED_USER="restricted-viewer"
-RESTRICTED_ROLE_BINDING="restricted-viewer-view"
+IDENTITY_NAMESPACE="luxury-yacht-restricted"
+RESTRICTED_SERVICE_ACCOUNT="restricted-manager"
+RESTRICTED_USER="restricted-manager"
+RESTRICTED_ROLE_BINDING="restricted-manager-edit"
+MANAGED_NAMESPACE_PREFIX="test-"
+VERIFY_TEST_NAMESPACE="test-managed"
+STATIC_MANAGED_NAMESPACES=("kube-system")
+
+LEGACY_RESTRICTED_NAMESPACE="luxury-yacht-restricted"
+LEGACY_SERVICE_ACCOUNT="restricted-viewer"
+LEGACY_ROLE_BINDING="restricted-viewer-view"
 LEGACY_CLUSTER_ROLE_BINDING="restricted-viewer-view"
 
 cluster_exists() {
@@ -68,12 +75,36 @@ ensure_admin_context() {
 install_restricted_rbac() {
   echo "Installing restricted RBAC..."
 
-  admin_kctl create namespace "${RESTRICTED_NAMESPACE}" --dry-run=client -o yaml | admin_kctl apply -f -
-  admin_kctl -n "${RESTRICTED_NAMESPACE}" create serviceaccount "${RESTRICTED_SERVICE_ACCOUNT}" --dry-run=client -o yaml | admin_kctl apply -f -
+  admin_kctl create namespace "${IDENTITY_NAMESPACE}" --dry-run=client -o yaml | admin_kctl apply -f -
+  admin_kctl create namespace "${VERIFY_TEST_NAMESPACE}" --dry-run=client -o yaml | admin_kctl apply -f -
+  admin_kctl -n "${IDENTITY_NAMESPACE}" create serviceaccount "${RESTRICTED_SERVICE_ACCOUNT}" --dry-run=client -o yaml | admin_kctl apply -f -
   admin_kctl delete clusterrolebinding "${LEGACY_CLUSTER_ROLE_BINDING}" --ignore-not-found
-  admin_kctl -n "${RESTRICTED_NAMESPACE}" create rolebinding "${RESTRICTED_ROLE_BINDING}" \
-    --clusterrole=view \
-    --serviceaccount="${RESTRICTED_NAMESPACE}:${RESTRICTED_SERVICE_ACCOUNT}" \
+  admin_kctl -n "${LEGACY_RESTRICTED_NAMESPACE}" delete rolebinding "${LEGACY_ROLE_BINDING}" --ignore-not-found
+  admin_kctl -n "${LEGACY_RESTRICTED_NAMESPACE}" delete serviceaccount "${LEGACY_SERVICE_ACCOUNT}" --ignore-not-found
+
+  while IFS= read -r namespace; do
+    [[ -n "${namespace}" ]] || continue
+    bind_restricted_namespace "${namespace}"
+  done < <(managed_namespaces)
+}
+
+managed_namespaces() {
+  printf '%s\n' "${STATIC_MANAGED_NAMESPACES[@]}"
+  admin_kctl get namespaces -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' \
+    | while IFS= read -r namespace; do
+        if [[ "${namespace}" == "${MANAGED_NAMESPACE_PREFIX}"* ]]; then
+          printf '%s\n' "${namespace}"
+        fi
+      done \
+    | sort -u
+}
+
+bind_restricted_namespace() {
+  local namespace="$1"
+
+  admin_kctl -n "${namespace}" create rolebinding "${RESTRICTED_ROLE_BINDING}" \
+    --clusterrole=edit \
+    --serviceaccount="${IDENTITY_NAMESPACE}:${RESTRICTED_SERVICE_ACCOUNT}" \
     --dry-run=client \
     -o yaml | admin_kctl apply -f -
 }
@@ -82,7 +113,7 @@ write_restricted_kubeconfig() {
   local token
 
   echo "Writing restricted kubeconfig..."
-  token="$(admin_kctl -n "${RESTRICTED_NAMESPACE}" create token "${RESTRICTED_SERVICE_ACCOUNT}" --duration=8760h)"
+  token="$(admin_kctl -n "${IDENTITY_NAMESPACE}" create token "${RESTRICTED_SERVICE_ACCOUNT}" --duration=8760h)"
 
   cp "${ADMIN_KUBECONFIG}" "${RESTRICTED_KUBECONFIG}"
   kubectl config set-credentials "${RESTRICTED_USER}" \
@@ -111,8 +142,18 @@ verify_restricted_access() {
     exit 1
   fi
 
-  if ! restricted_kctl auth can-i list pods -n "${RESTRICTED_NAMESPACE}" --quiet; then
-    echo "Error: restricted user cannot list pods in ${RESTRICTED_NAMESPACE}; expected view access." >&2
+  if ! restricted_kctl auth can-i create deployments.apps -n kube-system --quiet; then
+    echo "Error: restricted user cannot create deployments in kube-system; expected edit access." >&2
+    exit 1
+  fi
+
+  if ! restricted_kctl auth can-i create deployments.apps -n "${VERIFY_TEST_NAMESPACE}" --quiet; then
+    echo "Error: restricted user cannot create deployments in ${VERIFY_TEST_NAMESPACE}; expected edit access." >&2
+    exit 1
+  fi
+
+  if restricted_kctl auth can-i create deployments.apps -n default --quiet; then
+    echo "Error: restricted user can create deployments in default; expected denial." >&2
     exit 1
   fi
 }
@@ -144,7 +185,8 @@ start_cluster() {
   echo ""
   echo "Restricted cluster ready."
   echo "  admin:      ${ADMIN_KUBECONFIG} (context: ${ADMIN_CONTEXT})"
-  echo "  restricted: ${RESTRICTED_KUBECONFIG} (context: ${RESTRICTED_CONTEXT}, namespace RoleBinding: view)"
+  echo "  restricted: ${RESTRICTED_KUBECONFIG} (context: ${RESTRICTED_CONTEXT}, namespace RoleBinding: edit)"
+  echo "  managed:    kube-system and current ${MANAGED_NAMESPACE_PREFIX}* namespaces"
 }
 
 stop_cluster() {


### PR DESCRIPTION
**Working with clusters where you can't list namespaces (#243)**

- Previously, if a user connected to a cluster without namespace `list` permissions, the namespace list in the sidebar just came up empty for them. Now, the sidebar lets them type in the names of namespaces they know they're allowed to use. The user can add and delete namespaces from the list. The app remembers that list per cluster, and everything that they have permissions for should work within those namespaces.
- If someone adds a namespace that doesn't exist or that they can't actually access, it gets a small warning icon explaining why, and it can't be expanded.
- Users with namespace list permissions should see no change.
- Known gap: a few resource types (Events, ReplicaSets, autoscalers, Gateway API, Helm) still require cluster-wide access and will show "Insufficient permissions" for restricted users, even inside an added namespace. A fix for this is planned as a follow-up.

**Fixed timing bug for faster data loads**

- The app should be **dramatically** faster when opening views and loading data. There was a race condition between two internal steps. One would cancel the other, then the view would sit for a few seconds, waiting for a backup timer. This race, and a few related bugs, are now fixed. All this means that tables should now load in less than one second most of the time.
