### PR TITLE
Bug fixes

### DIFF
--- a/backend/kind/streamrows/streamrows.go
+++ b/backend/kind/streamrows/streamrows.go
@@ -390,12 +390,22 @@ type PodSummary struct {
 	OwnerName            string `json:"ownerName"`
 	PortForwardAvailable bool   `json:"portForwardAvailable"`
 	OwnerAPIVersion      string `json:"ownerApiVersion,omitempty"`
-	CPURequest           string `json:"cpuRequest"`
-	CPULimit             string `json:"cpuLimit"`
-	CPUUsage             string `json:"cpuUsage"`
-	MemRequest           string `json:"memRequest"`
-	MemLimit             string `json:"memLimit"`
-	MemUsage             string `json:"memUsage"`
+	// DirectOwner* is the pod's direct controlling ownerRef as written on the
+	// pod, BEFORE the ReplicaSet->Deployment collapse Owner* applies. For a
+	// Deployment's pod Owner* is the Deployment and DirectOwner* the ReplicaSet;
+	// for every other pod the two are equal. Workload-scoped serving and
+	// doorbell routing match BOTH, so a ReplicaSet-scoped Pods window sees the
+	// pods the collapse removes from the Owner* fields. Own-object data — no
+	// cross-kind input, so it needs no heal (see docs/architecture/data-layer.md).
+	DirectOwnerKind       string `json:"directOwnerKind,omitempty"`
+	DirectOwnerName       string `json:"directOwnerName,omitempty"`
+	DirectOwnerAPIVersion string `json:"directOwnerApiVersion,omitempty"`
+	CPURequest            string `json:"cpuRequest"`
+	CPULimit              string `json:"cpuLimit"`
+	CPUUsage              string `json:"cpuUsage"`
+	MemRequest            string `json:"memRequest"`
+	MemLimit              string `json:"memLimit"`
+	MemUsage              string `json:"memUsage"`
 }
 
 // WorkloadSummary is a Deployment/StatefulSet/DaemonSet/Job/CronJob/Pod row

--- a/backend/refresh/ingest/manager.go
+++ b/backend/refresh/ingest/manager.go
@@ -1042,6 +1042,26 @@ func (m *IngestManager) RowsByIndex(gvr schema.GroupVersionResource, indexName s
 	return store.RowsByIndex(indexName, values)
 }
 
+// RewriteBundlesByIndex applies rewrite to gvr's stored bundles reachable through
+// indexName/values — the out-of-band projection correction path (the pod owner
+// heal; see ProjectingStore.RewriteBundlesByIndex) — and returns the new bundles,
+// or nil when the manager has no entry for gvr. The store call runs outside the
+// manager lock (StoreFor resolves the entry under the leaf mutex): the rewrite's
+// sink delivery may legally call back into the manager, exactly like a reflector
+// mutation — see AddSink for the leaf-lock rule.
+func (m *IngestManager) RewriteBundlesByIndex(
+	gvr schema.GroupVersionResource,
+	indexName string,
+	values []string,
+	rewrite func(Bundle) (Bundle, bool),
+) []Bundle {
+	store := m.StoreFor(gvr)
+	if store == nil {
+		return nil
+	}
+	return store.RewriteBundlesByIndex(indexName, values, rewrite)
+}
+
 // StoreResourceVersion returns the latest list/watch resourceVersion gvr's store has
 // observed (from its relist or a watch bookmark), or "" when the manager has no entry
 // for gvr. It is the ingest equivalent of the highest object resourceVersion a typed

--- a/backend/refresh/ingest/projecting_store.go
+++ b/backend/refresh/ingest/projecting_store.go
@@ -628,6 +628,71 @@ func (s *ProjectingStore) RowsByIndex(indexName string, values []string) []inter
 	return out
 }
 
+// RewriteBundlesByIndex applies an out-of-band correction to stored Bundles — a
+// consumer-side fix for a projection whose input dependency arrived AFTER the
+// object was projected (the pod owner heal: a pod projected before its
+// ReplicaSet was observed). For every stored Bundle reachable through indexName/
+// values where rewrite returns (newBundle, true), the store delivers the FULL new
+// bundle to every sink exactly like a reflector Update, replaces the stored copy
+// (honoring retainTable), and moves its secondary-index entries. Bundles the
+// rewrite declines are untouched. It returns the new bundles so the caller can
+// emit any extra signals (e.g. stale-scope deletes) for what changed.
+//
+// The rewrite func receives the STORED bundle: on a retainTable store it carries
+// the Table half; elsewhere the Table half is nil, so a Table-dependent rewrite
+// is only meaningful for retainTable kinds (pods). Sinks run under the store's
+// write lock — the same rule as every mutation path — so rewrite and sinks must
+// not call back into this store.
+func (s *ProjectingStore) RewriteBundlesByIndex(
+	indexName string,
+	values []string,
+	rewrite func(Bundle) (Bundle, bool),
+) []Bundle {
+	if indexName == "" || len(values) == 0 || rewrite == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	byValue := s.indexes[indexName]
+	if len(byValue) == 0 {
+		return nil
+	}
+	keySet := make(map[string]struct{})
+	for _, value := range values {
+		for key := range byValue[value] {
+			keySet[key] = struct{}{}
+		}
+	}
+	if len(keySet) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(keySet))
+	for key := range keySet {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	rewritten := make([]Bundle, 0, len(keys))
+	for _, key := range keys {
+		stored, ok := s.rows[key].(Bundle)
+		if !ok {
+			continue
+		}
+		next, changed := rewrite(stored)
+		if !changed {
+			continue
+		}
+		if s.hasSinks() {
+			s.emitUpsert(next)
+		}
+		s.removeIndexesForKey(key, stored)
+		nextStored := s.storedValue(next)
+		s.rows[key] = nextStored
+		s.addIndexesForKey(key, nextStored)
+		rewritten = append(rewritten, next)
+	}
+	return rewritten
+}
+
 // ListKeys returns a snapshot slice of the keys currently associated with a
 // projected row.
 func (s *ProjectingStore) ListKeys() []string {

--- a/backend/refresh/ingest/projecting_store_rewrite_test.go
+++ b/backend/refresh/ingest/projecting_store_rewrite_test.go
@@ -1,0 +1,175 @@
+/*
+ * backend/refresh/ingest/projecting_store_rewrite_test.go
+ *
+ * RewriteBundlesByIndex: an out-of-band correction to stored bundles (the pod
+ * owner heal) must behave exactly like a reflector Update for every observer —
+ * sinks fed the full new bundle, secondary indexes moved, stored copy replaced —
+ * while untouched bundles stay untouched.
+ */
+
+package ingest
+
+import (
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ownerRow is the rewrite tests' Table half: a row whose Owner field is the
+// rewrite target (mirroring the pod row's projected owner).
+type ownerRow struct {
+	NS    string
+	Name  string
+	Owner string
+}
+
+const ownerIndexName = "test:owner"
+
+// projectOwnerBundle projects a ConfigMap into a Bundle whose Table half carries
+// an owner read from the "owner" annotation and whose index tracks that owner.
+func projectOwnerBundle(obj interface{}) (interface{}, error) {
+	cm, ok := obj.(*corev1.ConfigMap)
+	if !ok {
+		return nil, fmt.Errorf("projectOwnerBundle: unexpected type %T", obj)
+	}
+	owner := cm.Annotations["owner"]
+	return Bundle{
+		Table:   ownerRow{NS: cm.Namespace, Name: cm.Name, Owner: owner},
+		Catalog: row{NS: cm.Namespace, Name: cm.Name},
+		Indexes: map[string][]string{ownerIndexName: {owner}},
+	}, nil
+}
+
+func ownedConfigMap(ns, name, owner string) *corev1.ConfigMap {
+	cm := configMap(ns, name)
+	cm.Annotations = map[string]string{"owner": owner}
+	return cm
+}
+
+// captureBundleSink records every bundle delivery.
+type captureBundleSink struct {
+	upserts []Bundle
+	deletes []Bundle
+}
+
+func (s *captureBundleSink) UpsertBundle(bundle Bundle) { s.upserts = append(s.upserts, bundle) }
+func (s *captureBundleSink) DeleteBundle(bundle Bundle) { s.deletes = append(s.deletes, bundle) }
+
+// captureTableSink records every Table-half delivery.
+type captureTableSink struct {
+	upserts []interface{}
+	deletes []interface{}
+}
+
+func (s *captureTableSink) Upsert(tableRow interface{}) { s.upserts = append(s.upserts, tableRow) }
+func (s *captureTableSink) Delete(tableRow interface{}) { s.deletes = append(s.deletes, tableRow) }
+
+// rewriteOwner returns a rewrite func that retargets rows owned by from to to,
+// updating the Table half and the owner index — the shape the pod heal uses.
+func rewriteOwner(from, to string) func(Bundle) (Bundle, bool) {
+	return func(b Bundle) (Bundle, bool) {
+		table, ok := b.Table.(ownerRow)
+		if !ok || table.Owner != from {
+			return b, false
+		}
+		table.Owner = to
+		b.Table = table
+		b.Indexes = map[string][]string{ownerIndexName: {to}}
+		return b, true
+	}
+}
+
+func TestRewriteBundlesByIndexUpdatesStoreSinksAndIndexes(t *testing.T) {
+	store := NewProjectingStore(projectOwnerBundle)
+	store.SetRetainTable(true)
+
+	if err := store.Add(ownedConfigMap("default", "app-1", "rs-1")); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := store.Add(ownedConfigMap("default", "app-2", "rs-1")); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := store.Add(ownedConfigMap("default", "other", "rs-2")); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	tableSink := &captureTableSink{}
+	bundleSink := &captureBundleSink{}
+	store.AddSink(tableSink)
+	store.AddBundleSink(bundleSink)
+
+	rewritten := store.RewriteBundlesByIndex(ownerIndexName, []string{"rs-1"}, rewriteOwner("rs-1", "deploy-1"))
+
+	if len(rewritten) != 2 {
+		t.Fatalf("rewritten = %d bundles, want 2", len(rewritten))
+	}
+	for _, b := range rewritten {
+		if got := b.Table.(ownerRow).Owner; got != "deploy-1" {
+			t.Fatalf("rewritten bundle owner = %q, want deploy-1", got)
+		}
+	}
+
+	// The stored copies are replaced (read back through the index under the NEW value).
+	byNew := store.RowsByIndex(ownerIndexName, []string{"deploy-1"})
+	if len(byNew) != 2 {
+		t.Fatalf("RowsByIndex(deploy-1) = %d rows, want 2", len(byNew))
+	}
+	// The OLD index value no longer reaches them.
+	if byOld := store.RowsByIndex(ownerIndexName, []string{"rs-1"}); len(byOld) != 0 {
+		t.Fatalf("RowsByIndex(rs-1) = %d rows, want 0 after rewrite", len(byOld))
+	}
+	// The untouched bundle is still reachable and unmodified.
+	byOther := store.RowsByIndex(ownerIndexName, []string{"rs-2"})
+	if len(byOther) != 1 {
+		t.Fatalf("RowsByIndex(rs-2) = %d rows, want 1", len(byOther))
+	}
+	if got := byOther[0].(Bundle).Table.(ownerRow).Owner; got != "rs-2" {
+		t.Fatalf("untouched bundle owner = %q, want rs-2", got)
+	}
+
+	// Sinks observed the rewrite exactly like a reflector Update: the FULL new
+	// bundle (Table half present) to the bundle sink, the new Table half to the
+	// table sink, and no deletes.
+	if len(bundleSink.upserts) != 2 || len(bundleSink.deletes) != 0 {
+		t.Fatalf("bundle sink saw %d upserts / %d deletes, want 2 / 0", len(bundleSink.upserts), len(bundleSink.deletes))
+	}
+	for _, b := range bundleSink.upserts {
+		if got := b.Table.(ownerRow).Owner; got != "deploy-1" {
+			t.Fatalf("bundle sink upsert owner = %q, want deploy-1", got)
+		}
+	}
+	if len(tableSink.upserts) != 2 || len(tableSink.deletes) != 0 {
+		t.Fatalf("table sink saw %d upserts / %d deletes, want 2 / 0", len(tableSink.upserts), len(tableSink.deletes))
+	}
+	for _, r := range tableSink.upserts {
+		if got := r.(ownerRow).Owner; got != "deploy-1" {
+			t.Fatalf("table sink upsert owner = %q, want deploy-1", got)
+		}
+	}
+}
+
+func TestRewriteBundlesByIndexNoMatchIsNoOp(t *testing.T) {
+	store := NewProjectingStore(projectOwnerBundle)
+	store.SetRetainTable(true)
+	if err := store.Add(ownedConfigMap("default", "app-1", "rs-1")); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	bundleSink := &captureBundleSink{}
+	store.AddBundleSink(bundleSink)
+
+	// Unknown index value: nothing reachable, nothing rewritten.
+	if got := store.RewriteBundlesByIndex(ownerIndexName, []string{"missing"}, rewriteOwner("rs-1", "deploy-1")); len(got) != 0 {
+		t.Fatalf("rewrite(missing) = %d bundles, want 0", len(got))
+	}
+	// Reachable but the rewrite declines: stored copy and sinks untouched.
+	if got := store.RewriteBundlesByIndex(ownerIndexName, []string{"rs-1"}, rewriteOwner("other-rs", "deploy-1")); len(got) != 0 {
+		t.Fatalf("rewrite(declined) = %d bundles, want 0", len(got))
+	}
+	if len(bundleSink.upserts) != 0 || len(bundleSink.deletes) != 0 {
+		t.Fatalf("bundle sink saw %d upserts / %d deletes, want 0 / 0", len(bundleSink.upserts), len(bundleSink.deletes))
+	}
+	if rows := store.RowsByIndex(ownerIndexName, []string{"rs-1"}); len(rows) != 1 {
+		t.Fatalf("RowsByIndex(rs-1) = %d rows, want 1 (untouched)", len(rows))
+	}
+}

--- a/backend/refresh/resourcestream/derived_rows.go
+++ b/backend/refresh/resourcestream/derived_rows.go
@@ -91,17 +91,12 @@ func (m *Manager) handlePodEvent(oldObj interface{}, newObj interface{}, updateT
 
 func (m *Manager) handleReplicaSetEvent(oldObj interface{}, newObj interface{}, updateType MessageType) {
 	switch updateType {
-	case MessageTypeAdded:
-		newRS := replicaSetFromObject(newObj)
-		m.healPodsForReplicaSet(newRS, replicaSetStaleWorkloadScopes(nil, newRS))
+	case MessageTypeAdded, MessageTypeModified:
+		m.healPodsForReplicaSet(replicaSetFromObject(newObj))
 	case MessageTypeDeleted:
 		// Nothing to heal: a deleted RS cascades to its pods, whose own delete
 		// events clean every scope; an orphaned pod's owner-ref removal arrives
 		// as a pod update and re-projects its row.
-	case MessageTypeModified:
-		oldRS := replicaSetFromObject(oldObj)
-		newRS := replicaSetFromObject(newObj)
-		m.healPodsForReplicaSet(newRS, replicaSetStaleWorkloadScopes(oldRS, newRS))
 	}
 }
 
@@ -109,14 +104,14 @@ func (m *Manager) handleReplicaSetEvent(oldObj interface{}, newObj interface{}, 
 // Deployment owner could not be resolved when they were projected. The pod
 // projector reads the shared factory's RS lister, but the owned pod reflector
 // starts BEFORE the factory (ingest_hub.go), so pods projected in that window
-// carry OwnerKind=ReplicaSet — the Deployment's workload-scoped pods query then
-// serves nothing and its doorbell never rings, and owned reflectors never resync
-// to repair it. Healing on the RS informer's events closes the race: the rewrite
-// fans through the store's sinks like a reflector update (maintained store +
-// live-notify signal on the NEW Deployment scope), and each healed pod is
-// additionally signalled as Deleted on the stale fallback scopes so any window
-// subscribed there refetches.
-func (m *Manager) healPodsForReplicaSet(rs *appsv1.ReplicaSet, staleScopes []string) {
+// carry the unresolved ReplicaSet as their collapsed owner — the Deployment's
+// workload-scoped pods query then serves nothing and its doorbell never rings,
+// and owned reflectors never resync to repair it. Healing on the RS informer's
+// events closes the race: the rewrite fans through the store's sinks like a
+// reflector update, and the pod notify sink signals every scope the healed row
+// belongs to — namespace, node, the NEW Deployment scope, and the ReplicaSet
+// scope, which the row still occupies through its direct owner.
+func (m *Manager) healPodsForReplicaSet(rs *appsv1.ReplicaSet) {
 	if rs == nil || m.podIngest == nil {
 		return
 	}
@@ -125,7 +120,7 @@ func (m *Manager) healPodsForReplicaSet(rs *appsv1.ReplicaSet, staleScopes []str
 		// A standalone RS's pods correctly keep the ReplicaSet owner.
 		return
 	}
-	healed := m.podIngest.RewriteBundlesByIndex(
+	m.podIngest.RewriteBundlesByIndex(
 		podGVR,
 		snapshot.PodOwnerKeyIndexName,
 		snapshot.PodOwnerHealIndexValues(rs.Namespace, rs.Name, deployment),
@@ -133,12 +128,6 @@ func (m *Manager) healPodsForReplicaSet(rs *appsv1.ReplicaSet, staleScopes []str
 			return snapshot.HealPodBundleReplicaSetOwner(bundle, rs.Namespace, rs.Name, deployment)
 		},
 	)
-	if len(staleScopes) == 0 {
-		return
-	}
-	for _, bundle := range healed {
-		m.broadcastHealedPodStaleScopes(bundle, staleScopes)
-	}
 }
 
 // broadcastNodeNotification emits a row-less node change notification on the

--- a/backend/refresh/resourcestream/derived_rows.go
+++ b/backend/refresh/resourcestream/derived_rows.go
@@ -18,6 +18,7 @@ import (
 
 	podres "github.com/luxury-yacht/app/backend/resources/pods"
 
+	"github.com/luxury-yacht/app/backend/refresh/ingest"
 	"github.com/luxury-yacht/app/backend/refresh/metrics"
 	"github.com/luxury-yacht/app/backend/refresh/snapshot"
 	"github.com/luxury-yacht/app/backend/refresh/telemetry"
@@ -26,7 +27,6 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 )
 
 func (m *Manager) handlePod(obj interface{}, updateType MessageType) {
@@ -93,57 +93,51 @@ func (m *Manager) handleReplicaSetEvent(oldObj interface{}, newObj interface{}, 
 	switch updateType {
 	case MessageTypeAdded:
 		newRS := replicaSetFromObject(newObj)
-		m.refreshPodsForReplicaSet(newRS, replicaSetStaleWorkloadScopes(nil, newRS))
+		m.healPodsForReplicaSet(newRS, replicaSetStaleWorkloadScopes(nil, newRS))
 	case MessageTypeDeleted:
-		oldRS := replicaSetFromObject(oldObj)
-		m.refreshPodsForReplicaSet(oldRS, replicaSetStaleWorkloadScopes(oldRS, nil))
+		// Nothing to heal: a deleted RS cascades to its pods, whose own delete
+		// events clean every scope; an orphaned pod's owner-ref removal arrives
+		// as a pod update and re-projects its row.
 	case MessageTypeModified:
 		oldRS := replicaSetFromObject(oldObj)
 		newRS := replicaSetFromObject(newObj)
-		staleScopes := replicaSetStaleWorkloadScopes(oldRS, newRS)
-		seen := make(map[string]struct{})
-		m.refreshPodsForReplicaSetOnce(oldRS, staleScopes, seen)
-		m.refreshPodsForReplicaSetOnce(newRS, staleScopes, seen)
+		m.healPodsForReplicaSet(newRS, replicaSetStaleWorkloadScopes(oldRS, newRS))
 	}
 }
 
-func (m *Manager) refreshPodsForReplicaSet(rs *appsv1.ReplicaSet, staleScopes []string) {
-	m.refreshPodsForReplicaSetOnce(rs, staleScopes, make(map[string]struct{}))
-}
-
-func (m *Manager) refreshPodsForReplicaSetOnce(
-	rs *appsv1.ReplicaSet,
-	staleScopes []string,
-	seen map[string]struct{},
-) {
-	// Pods is cut: production wires no podLister here, so this re-broadcast is a no-op in
-	// production. It is unnecessary there because the pod bundle sink already broadcasts
-	// on every real pod lifecycle change (an RS scale/rollout creates or deletes pods,
-	// each firing the sink). The only case it covered uniquely — an RS whose controller
-	// Deployment owner changes in place without any pod change — does not occur. The
-	// typed path remains for the unit tests that exercise it with an injected podLister.
-	if rs == nil || m.podLister == nil {
+// healPodsForReplicaSet re-resolves stored pod bundles whose ReplicaSet->
+// Deployment owner could not be resolved when they were projected. The pod
+// projector reads the shared factory's RS lister, but the owned pod reflector
+// starts BEFORE the factory (ingest_hub.go), so pods projected in that window
+// carry OwnerKind=ReplicaSet — the Deployment's workload-scoped pods query then
+// serves nothing and its doorbell never rings, and owned reflectors never resync
+// to repair it. Healing on the RS informer's events closes the race: the rewrite
+// fans through the store's sinks like a reflector update (maintained store +
+// live-notify signal on the NEW Deployment scope), and each healed pod is
+// additionally signalled as Deleted on the stale fallback scopes so any window
+// subscribed there refetches.
+func (m *Manager) healPodsForReplicaSet(rs *appsv1.ReplicaSet, staleScopes []string) {
+	if rs == nil || m.podIngest == nil {
 		return
 	}
-	pods, err := m.podLister.Pods(rs.Namespace).List(labels.Everything())
-	if err != nil {
-		m.logWarn(fmt.Sprintf("resource stream: list pods for replicaset %s/%s failed: %v", rs.Namespace, rs.Name, err))
+	deployment := replicaSetDeploymentOwnerName(rs)
+	if deployment == "" {
+		// A standalone RS's pods correctly keep the ReplicaSet owner.
 		return
 	}
-	podUsage := m.podMetricsSnapshot()
-	for _, pod := range pods {
-		if !podOwnedByReplicaSet(pod, rs) {
-			continue
-		}
-		key := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
-		if _, ok := seen[key]; ok {
-			continue
-		}
-		seen[key] = struct{}{}
-		if len(staleScopes) > 0 {
-			m.broadcastPodRow(pod, MessageTypeDeleted, staleScopes, podUsage)
-		}
-		m.broadcastPodRow(pod, MessageTypeModified, nil, podUsage)
+	healed := m.podIngest.RewriteBundlesByIndex(
+		podGVR,
+		snapshot.PodOwnerKeyIndexName,
+		snapshot.PodOwnerHealIndexValues(rs.Namespace, rs.Name, deployment),
+		func(bundle ingest.Bundle) (ingest.Bundle, bool) {
+			return snapshot.HealPodBundleReplicaSetOwner(bundle, rs.Namespace, rs.Name, deployment)
+		},
+	)
+	if len(staleScopes) == 0 {
+		return
+	}
+	for _, bundle := range healed {
+		m.broadcastHealedPodStaleScopes(bundle, staleScopes)
 	}
 }
 

--- a/backend/refresh/resourcestream/ingest_notify_pods.go
+++ b/backend/refresh/resourcestream/ingest_notify_pods.go
@@ -30,10 +30,16 @@ var podGVR = schema.GroupVersionResource{Group: podres.Identity.Group, Version: 
 
 // podBundleSource supplies the cut pod kind's projected bundles for the manager's
 // by-key lookups (the HPA->standalone-pod workload signal needs a specific pod's UID/RV
-// + namespace/name, which the projected bundle carries). *ingest.IngestManager satisfies
-// it.
+// + namespace/name, which the projected bundle carries) and the owner-heal rewrite
+// (healPodsForReplicaSet). *ingest.IngestManager satisfies it.
 type podBundleSource interface {
 	Rows(gvr schema.GroupVersionResource) []interface{}
+	RewriteBundlesByIndex(
+		gvr schema.GroupVersionResource,
+		indexName string,
+		values []string,
+		rewrite func(ingest.Bundle) (ingest.Bundle, bool),
+	) []ingest.Bundle
 }
 
 // lookupPodBundle returns the projected bundle for the pod namespace/name, or false when
@@ -56,6 +62,37 @@ func (m *Manager) lookupPodBundle(namespace, name string) (snapshot.PodSummary, 
 		return summary, catalog, true
 	}
 	return snapshot.PodSummary{}, objectcatalog.Summary{}, false
+}
+
+// broadcastHealedPodStaleScopes signals a healed pod (healPodsForReplicaSet) as
+// DELETED on the workload scopes its row just left — the ReplicaSet fallback
+// scope its unresolved owner had it filed under — so any window subscribed there
+// refetches. The Ref is built from the bundle's halves exactly like
+// broadcastBundle; the Modified signal on the NEW scopes is emitted by the
+// bundle sink during the rewrite itself.
+func (m *Manager) broadcastHealedPodStaleScopes(bundle ingest.Bundle, staleScopes []string) {
+	summary, ok := bundle.Table.(snapshot.PodSummary)
+	if !ok {
+		return
+	}
+	catalog, ok := bundle.Catalog.(objectcatalog.Summary)
+	if !ok {
+		return
+	}
+	ref := resourcemodel.NewResourceRef(
+		m.clusterMeta.ClusterID,
+		podres.Identity.Group, podres.Identity.Version, podres.Identity.Kind, podres.Identity.Resource,
+		summary.Namespace, summary.Name, catalog.UID,
+	)
+	update := Update{
+		Type:            MessageTypeDeleted,
+		Domain:          domainPods,
+		ClusterID:       m.clusterMeta.ClusterID,
+		ClusterName:     m.clusterMeta.ClusterName,
+		ResourceVersion: catalog.ResourceVersion,
+		Ref:             &ref,
+	}
+	m.broadcast(domainPods, staleScopes, update)
 }
 
 // podNotifyBundleSink adapts the pod live-stream notify to an ingest whole-Bundle sink.

--- a/backend/refresh/resourcestream/ingest_notify_pods.go
+++ b/backend/refresh/resourcestream/ingest_notify_pods.go
@@ -64,37 +64,6 @@ func (m *Manager) lookupPodBundle(namespace, name string) (snapshot.PodSummary, 
 	return snapshot.PodSummary{}, objectcatalog.Summary{}, false
 }
 
-// broadcastHealedPodStaleScopes signals a healed pod (healPodsForReplicaSet) as
-// DELETED on the workload scopes its row just left — the ReplicaSet fallback
-// scope its unresolved owner had it filed under — so any window subscribed there
-// refetches. The Ref is built from the bundle's halves exactly like
-// broadcastBundle; the Modified signal on the NEW scopes is emitted by the
-// bundle sink during the rewrite itself.
-func (m *Manager) broadcastHealedPodStaleScopes(bundle ingest.Bundle, staleScopes []string) {
-	summary, ok := bundle.Table.(snapshot.PodSummary)
-	if !ok {
-		return
-	}
-	catalog, ok := bundle.Catalog.(objectcatalog.Summary)
-	if !ok {
-		return
-	}
-	ref := resourcemodel.NewResourceRef(
-		m.clusterMeta.ClusterID,
-		podres.Identity.Group, podres.Identity.Version, podres.Identity.Kind, podres.Identity.Resource,
-		summary.Namespace, summary.Name, catalog.UID,
-	)
-	update := Update{
-		Type:            MessageTypeDeleted,
-		Domain:          domainPods,
-		ClusterID:       m.clusterMeta.ClusterID,
-		ClusterName:     m.clusterMeta.ClusterName,
-		ResourceVersion: catalog.ResourceVersion,
-		Ref:             &ref,
-	}
-	m.broadcast(domainPods, staleScopes, update)
-}
-
 // podNotifyBundleSink adapts the pod live-stream notify to an ingest whole-Bundle sink.
 // Each UpsertBundle fires a MODIFIED signal (the pod's row may have changed) and each
 // DeleteBundle a DELETED signal — the same Add/Update/Delete -> broadcast mapping the

--- a/backend/refresh/resourcestream/manager.go
+++ b/backend/refresh/resourcestream/manager.go
@@ -56,7 +56,6 @@ import (
 	hpapkg "github.com/luxury-yacht/app/backend/resources/hpa"
 	jobpkg "github.com/luxury-yacht/app/backend/resources/job"
 	podspkg "github.com/luxury-yacht/app/backend/resources/pods"
-	replicasetpkg "github.com/luxury-yacht/app/backend/resources/replicaset"
 	servicepkg "github.com/luxury-yacht/app/backend/resources/service"
 	statefulsetpkg "github.com/luxury-yacht/app/backend/resources/statefulset"
 )
@@ -188,13 +187,12 @@ type Manager struct {
 
 	dynamicClient dynamic.Interface
 
-	// podLister, the workload listers (deployment/stateful/daemon/job/cronJob), and nodeLister
+	// The workload listers (deployment/stateful/daemon/job/cronJob) and nodeLister
 	// are wired only by unit tests that drive the typed handlePod*/handleWorkload/handleNode/
-	// RS/HPA paths directly. Production reads pods, the workload kinds, AND nodes from the
+	// HPA paths directly. Production reads pods, the workload kinds, AND nodes from the
 	// ingest store (all cut), so those typed informers are never instantiated; podIngest /
 	// workloadIngest / nodeIngest are the production sources (lookupWorkloadRef / lookupNodeRef
 	// prefer a wired lister for tests, else ingest).
-	podLister        corelisters.PodLister
 	podIngest        podBundleSource
 	workloadIngest   workloadBundleSource
 	nodeIngest       nodeBundleSource
@@ -1361,18 +1359,6 @@ func parseWorkloadOwnerKey(key string) (namespace, kind, name string, ok bool) {
 		return "", "", "", false
 	}
 	return namespace, kind, name, true
-}
-
-func podOwnedByReplicaSet(pod *corev1.Pod, rs *appsv1.ReplicaSet) bool {
-	if pod == nil || rs == nil || pod.Namespace != rs.Namespace || rs.Name == "" {
-		return false
-	}
-	for _, owner := range pod.OwnerReferences {
-		if owner.Controller != nil && *owner.Controller && owner.Kind == replicasetpkg.Identity.Kind && owner.Name == rs.Name {
-			return true
-		}
-	}
-	return false
 }
 
 func replicaSetStaleWorkloadScopes(oldRS *appsv1.ReplicaSet, newRS *appsv1.ReplicaSet) []string {

--- a/backend/refresh/resourcestream/manager.go
+++ b/backend/refresh/resourcestream/manager.go
@@ -1361,38 +1361,6 @@ func parseWorkloadOwnerKey(key string) (namespace, kind, name string, ok bool) {
 	return namespace, kind, name, true
 }
 
-func replicaSetStaleWorkloadScopes(oldRS *appsv1.ReplicaSet, newRS *appsv1.ReplicaSet) []string {
-	oldScope := replicaSetWorkloadScope(oldRS)
-	newScope := replicaSetWorkloadScope(newRS)
-	if oldRS == nil && newRS != nil {
-		oldScope = replicaSetFallbackWorkloadScope(newRS)
-	}
-	if oldRS != nil && newRS == nil {
-		newScope = replicaSetFallbackWorkloadScope(oldRS)
-	}
-	if oldScope == "" || oldScope == newScope {
-		return nil
-	}
-	return uniqueScopes([]string{oldScope})
-}
-
-func replicaSetWorkloadScope(rs *appsv1.ReplicaSet) string {
-	if rs == nil {
-		return ""
-	}
-	if ownerName := replicaSetDeploymentOwnerName(rs); ownerName != "" {
-		return fmt.Sprintf("workload:%s:apps:v1:Deployment:%s", rs.Namespace, ownerName)
-	}
-	return replicaSetFallbackWorkloadScope(rs)
-}
-
-func replicaSetFallbackWorkloadScope(rs *appsv1.ReplicaSet) string {
-	if rs == nil || rs.Name == "" {
-		return ""
-	}
-	return fmt.Sprintf("workload:%s:apps:v1:ReplicaSet:%s", rs.Namespace, rs.Name)
-}
-
 func replicaSetDeploymentOwnerName(rs *appsv1.ReplicaSet) string {
 	if rs == nil {
 		return ""
@@ -1406,7 +1374,7 @@ func replicaSetDeploymentOwnerName(rs *appsv1.ReplicaSet) string {
 }
 
 func scopesForPod(summary snapshot.PodSummary) []string {
-	scopes := make([]string, 0, 4)
+	scopes := make([]string, 0, 5)
 	if summary.Namespace != "" {
 		scopes = append(scopes, fmt.Sprintf("namespace:%s", summary.Namespace), "namespace:all")
 	}
@@ -1418,7 +1386,16 @@ func scopesForPod(summary snapshot.PodSummary) []string {
 			scopes = append(scopes, scope)
 		}
 	}
-	return scopes
+	// The DIRECT owner's window (a ReplicaSet-scoped Pods tab) subscribes to a
+	// scope the collapsed owner no longer names; ring it too. Equal to the
+	// collapsed scope for non-collapsed pods — uniqueScopes in the broadcast
+	// path deduplicates.
+	if summary.DirectOwnerKind != "" && summary.DirectOwnerName != "" {
+		if scope := workloadScopeForOwner(summary.Namespace, summary.DirectOwnerAPIVersion, summary.DirectOwnerKind, summary.DirectOwnerName); scope != "" {
+			scopes = append(scopes, scope)
+		}
+	}
+	return uniqueScopes(scopes)
 }
 
 func workloadScopeForOwner(namespace, apiVersion, kind, name string) string {

--- a/backend/refresh/resourcestream/manager_test.go
+++ b/backend/refresh/resourcestream/manager_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/luxury-yacht/app/backend/internal/applog"
 	"github.com/luxury-yacht/app/backend/internal/config"
+	"github.com/luxury-yacht/app/backend/refresh/ingest"
 	"github.com/luxury-yacht/app/backend/refresh/snapshot"
 	"github.com/luxury-yacht/app/backend/resourcemodel"
 	"github.com/luxury-yacht/app/backend/resources/clusterrole"
@@ -1089,7 +1090,6 @@ func TestManagerWorkloadEventBroadcastsNotifyOnly(t *testing.T) {
 	manager := &Manager{
 		clusterMeta:      snapshot.ClusterMeta{ClusterID: "c1", ClusterName: "cluster"},
 		logger:           applog.Noop,
-		podLister:        testsupport.NewPodLister(t),
 		deploymentLister: testsupport.NewDeploymentLister(t, deployment),
 		subscribers:      make(map[string]map[string]map[uint64]*subscription),
 	}
@@ -1127,7 +1127,6 @@ func TestManagerHPADeleteRefreshesTargetWorkloadRow(t *testing.T) {
 	manager := &Manager{
 		clusterMeta:      snapshot.ClusterMeta{ClusterID: "c1", ClusterName: "cluster"},
 		logger:           applog.Noop,
-		podLister:        testsupport.NewPodLister(t),
 		deploymentLister: testsupport.NewDeploymentLister(t, deployment),
 		subscribers:      make(map[string]map[string]map[uint64]*subscription),
 	}
@@ -1164,7 +1163,6 @@ func TestManagerHPAUpdateRefreshesOldAndNewTargets(t *testing.T) {
 	manager := &Manager{
 		clusterMeta:      snapshot.ClusterMeta{ClusterID: "c1", ClusterName: "cluster"},
 		logger:           applog.Noop,
-		podLister:        testsupport.NewPodLister(t),
 		deploymentLister: testsupport.NewDeploymentLister(t, oldDeployment, newDeployment),
 		subscribers:      make(map[string]map[string]map[uint64]*subscription),
 	}
@@ -1197,7 +1195,6 @@ func TestManagerPodMoveRefreshesOldAndNewNodeRows(t *testing.T) {
 	manager := &Manager{
 		clusterMeta: snapshot.ClusterMeta{ClusterID: "c1", ClusterName: "cluster"},
 		logger:      applog.Noop,
-		podLister:   testsupport.NewPodLister(t, newPod),
 		nodeLister:  testsupport.NewNodeLister(t, nodeA, nodeB),
 		subscribers: make(map[string]map[string]map[uint64]*subscription),
 	}
@@ -1283,10 +1280,47 @@ func TestManagerEndpointSliceRetargetRefreshesOldAndNewServices(t *testing.T) {
 	require.True(t, seenServices["new-svc"])
 }
 
-func TestManagerReplicaSetUpdateRefreshesOldAndNewPodOwnerScopes(t *testing.T) {
-	pod := &corev1.Pod{
+// podIngestStoreAdapter adapts a raw ProjectingStore to the manager's
+// podBundleSource seam, standing in for the production IngestManager (whose
+// methods delegate to the same store calls).
+type podIngestStoreAdapter struct {
+	store *ingest.ProjectingStore
+}
+
+func (a podIngestStoreAdapter) Rows(schema.GroupVersionResource) []interface{} {
+	return a.store.List()
+}
+
+func (a podIngestStoreAdapter) RewriteBundlesByIndex(
+	_ schema.GroupVersionResource,
+	indexName string,
+	values []string,
+	rewrite func(ingest.Bundle) (ingest.Bundle, bool),
+) []ingest.Bundle {
+	return a.store.RewriteBundlesByIndex(indexName, values, rewrite)
+}
+
+// newRacedPodIngestStore projects pod through the REAL pod ingest projector with
+// an EMPTY ReplicaSet lister — the connect-race state whose rows carry the
+// unresolved ReplicaSet owner — and returns the store wired the production way
+// (retained Table half + the manager's pod notify bundle sink).
+func newRacedPodIngestStore(t *testing.T, manager *Manager, pod *corev1.Pod) *ingest.ProjectingStore {
+	t.Helper()
+	project := snapshot.NewPodIngestProjector(
+		snapshot.ClusterMeta{ClusterID: "c1", ClusterName: "cluster"},
+		testsupport.NewReplicaSetLister(t),
+	)
+	store := ingest.NewProjectingStore(project)
+	store.SetRetainTable(true)
+	require.NoError(t, store.Add(pod))
+	store.AddBundleSink(podNotifyBundleSink{manager: manager})
+	return store
+}
+
+func racedOwnerPod() *corev1.Pod {
+	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            "pod-1",
+			Name:            "web-12345-abcde",
 			Namespace:       "default",
 			UID:             "pod-uid",
 			ResourceVersion: "7",
@@ -1294,58 +1328,136 @@ func TestManagerReplicaSetUpdateRefreshesOldAndNewPodOwnerScopes(t *testing.T) {
 				Kind:       "ReplicaSet",
 				Name:       "web-12345",
 				Controller: ptrBool(true),
+				APIVersion: "apps/v1",
 			}},
 		},
 		Status: corev1.PodStatus{Phase: corev1.PodRunning},
 	}
-	oldRS := &appsv1.ReplicaSet{
+}
+
+// TestManagerReplicaSetAddHealsRacedPodOwnerRows is the regression test for the
+// empty Deployment Pods tab: a pod projected BEFORE its ReplicaSet was observed
+// keeps OwnerKind=ReplicaSet, so the Deployment workload scope neither serves nor
+// signals it. When the RS informer delivers the ReplicaSet, the manager must heal
+// the stored bundle (store + maintained-store sink) and signal both the new
+// Deployment scope (Modified) and the stale ReplicaSet fallback scope (Deleted).
+func TestManagerReplicaSetAddHealsRacedPodOwnerRows(t *testing.T) {
+	rs := &appsv1.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "web-12345",
 			Namespace: "default",
 			OwnerReferences: []metav1.OwnerReference{{
 				Kind:       "Deployment",
-				Name:       "web-old",
+				Name:       "web",
 				Controller: ptrBool(true),
+				APIVersion: "apps/v1",
 			}},
 		},
 	}
-	newRS := oldRS.DeepCopy()
-	newRS.OwnerReferences = []metav1.OwnerReference{{
-		Kind:       "Deployment",
-		Name:       "web-new",
-		Controller: ptrBool(true),
-	}}
-
 	manager := &Manager{
 		clusterMeta: snapshot.ClusterMeta{ClusterID: "c1", ClusterName: "cluster"},
 		logger:      applog.Noop,
-		podLister:   podListerWith(pod),
-		rsLister:    replicaSetListerWith(newRS),
 		subscribers: make(map[string]map[string]map[uint64]*subscription),
 	}
-	oldSub, err := subscribeForTest(t, manager, domainPods, "workload:default:apps:v1:Deployment:web-old")
+	store := newRacedPodIngestStore(t, manager, racedOwnerPod())
+	manager.podIngest = podIngestStoreAdapter{store: store}
+
+	deploymentSub, err := subscribeForTest(t, manager, domainPods, "workload:default:apps:v1:Deployment:web")
 	require.NoError(t, err)
-	newSub, err := subscribeForTest(t, manager, domainPods, "workload:default:apps:v1:Deployment:web-new")
+	staleSub, err := subscribeForTest(t, manager, domainPods, "workload:default:apps:v1:ReplicaSet:web-12345")
 	require.NoError(t, err)
 	namespaceSub, err := subscribeForTest(t, manager, domainPods, "namespace:default")
 	require.NoError(t, err)
 
-	manager.handleReplicaSetEvent(oldRS, newRS, MessageTypeModified)
+	manager.handleReplicaSetEvent(nil, rs, MessageTypeAdded)
 
-	oldUpdate := requireNextUpdate(t, oldSub)
-	require.Equal(t, MessageTypeDeleted, oldUpdate.Type)
-	require.Equal(t, "pod-1", oldUpdate.Ref.Name)
+	// The stored bundle is healed: serve-side filters now match the Deployment scope.
+	rows := store.List()
+	require.Len(t, rows, 1)
+	healedRow := rows[0].(ingest.Bundle).Table.(snapshot.PodSummary)
+	require.Equal(t, "Deployment", healedRow.OwnerKind)
+	require.Equal(t, "web", healedRow.OwnerName)
 
-	// pods is query-backed: a ReplicaSet owner change still re-notifies the affected
-	// pod on the old/new/namespace scopes (reactive wiring), but carries no row —
-	// the query-backed table refetches and rebuilds the owner columns.
-	newUpdate := requireNextUpdate(t, newSub)
-	require.Equal(t, MessageTypeModified, newUpdate.Type)
-	require.Equal(t, "pod-1", newUpdate.Ref.Name)
+	// Doorbell: the Deployment-scoped window learns its pods changed...
+	deploymentUpdate := requireNextUpdate(t, deploymentSub)
+	require.Equal(t, MessageTypeModified, deploymentUpdate.Type)
+	require.Equal(t, "web-12345-abcde", deploymentUpdate.Ref.Name)
 
+	// ...the stale ReplicaSet fallback scope learns the rows left it...
+	staleUpdate := requireNextUpdate(t, staleSub)
+	require.Equal(t, MessageTypeDeleted, staleUpdate.Type)
+	require.Equal(t, "web-12345-abcde", staleUpdate.Ref.Name)
+
+	// ...and the namespace scope sees the row change like any pod update.
 	namespaceUpdate := requireNextUpdate(t, namespaceSub)
 	require.Equal(t, MessageTypeModified, namespaceUpdate.Type)
-	require.Equal(t, "pod-1", namespaceUpdate.Ref.Name)
+	require.Equal(t, "web-12345-abcde", namespaceUpdate.Ref.Name)
+}
+
+// TestManagerReplicaSetModifiedHealsRacedPodOwnerRows covers the Modified branch:
+// an RS observed without its Deployment owner (or raced the same way) whose owner
+// reference is present on the update heals the raced rows identically.
+func TestManagerReplicaSetModifiedHealsRacedPodOwnerRows(t *testing.T) {
+	oldRS := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "web-12345", Namespace: "default"},
+	}
+	newRS := oldRS.DeepCopy()
+	newRS.OwnerReferences = []metav1.OwnerReference{{
+		Kind:       "Deployment",
+		Name:       "web",
+		Controller: ptrBool(true),
+		APIVersion: "apps/v1",
+	}}
+	manager := &Manager{
+		clusterMeta: snapshot.ClusterMeta{ClusterID: "c1", ClusterName: "cluster"},
+		logger:      applog.Noop,
+		subscribers: make(map[string]map[string]map[uint64]*subscription),
+	}
+	store := newRacedPodIngestStore(t, manager, racedOwnerPod())
+	manager.podIngest = podIngestStoreAdapter{store: store}
+
+	deploymentSub, err := subscribeForTest(t, manager, domainPods, "workload:default:apps:v1:Deployment:web")
+	require.NoError(t, err)
+
+	manager.handleReplicaSetEvent(oldRS, newRS, MessageTypeModified)
+
+	rows := store.List()
+	require.Len(t, rows, 1)
+	require.Equal(t, "Deployment", rows[0].(ingest.Bundle).Table.(snapshot.PodSummary).OwnerKind)
+
+	deploymentUpdate := requireNextUpdate(t, deploymentSub)
+	require.Equal(t, MessageTypeModified, deploymentUpdate.Type)
+	require.Equal(t, "web-12345-abcde", deploymentUpdate.Ref.Name)
+}
+
+// TestManagerReplicaSetAddWithoutDeploymentOwnerDoesNotHeal: a standalone RS's
+// pods correctly keep the ReplicaSet owner — the fallback scope IS their steady
+// state, so the heal must decline and emit nothing.
+func TestManagerReplicaSetAddWithoutDeploymentOwnerDoesNotHeal(t *testing.T) {
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "web-12345", Namespace: "default"},
+	}
+	manager := &Manager{
+		clusterMeta: snapshot.ClusterMeta{ClusterID: "c1", ClusterName: "cluster"},
+		logger:      applog.Noop,
+		subscribers: make(map[string]map[string]map[uint64]*subscription),
+	}
+	store := newRacedPodIngestStore(t, manager, racedOwnerPod())
+	manager.podIngest = podIngestStoreAdapter{store: store}
+
+	rsSub, err := subscribeForTest(t, manager, domainPods, "workload:default:apps:v1:ReplicaSet:web-12345")
+	require.NoError(t, err)
+
+	manager.handleReplicaSetEvent(nil, rs, MessageTypeAdded)
+
+	rows := store.List()
+	require.Len(t, rows, 1)
+	require.Equal(t, "ReplicaSet", rows[0].(ingest.Bundle).Table.(snapshot.PodSummary).OwnerKind)
+	select {
+	case update := <-rsSub.Updates:
+		t.Fatalf("unexpected update on the ReplicaSet scope: %+v", update)
+	default:
+	}
 }
 
 func TestManagerBackpressureTriggersReset(t *testing.T) {
@@ -1419,7 +1531,6 @@ func TestManagerWorkloadUpdateFromPod(t *testing.T) {
 	manager := &Manager{
 		clusterMeta:      snapshot.ClusterMeta{ClusterID: "c1", ClusterName: "cluster"},
 		logger:           applog.Noop,
-		podLister:        podListerWith(pod),
 		deploymentLister: deploymentListerWith(deployment),
 		subscribers:      make(map[string]map[string]map[uint64]*subscription),
 	}
@@ -1469,7 +1580,6 @@ func TestManagerWorkloadUpdateFromCompletedOwnedPod(t *testing.T) {
 	manager := &Manager{
 		clusterMeta:      snapshot.ClusterMeta{ClusterID: "c1", ClusterName: "cluster"},
 		logger:           applog.Noop,
-		podLister:        podListerWith(pod),
 		deploymentLister: deploymentListerWith(deployment),
 		subscribers:      make(map[string]map[string]map[uint64]*subscription),
 	}
@@ -1554,7 +1664,6 @@ func TestManagerNodeUpdateFromPod(t *testing.T) {
 		},
 		Status: corev1.PodStatus{Phase: corev1.PodRunning},
 	}
-	manager.podLister = podListerWith(pod)
 
 	// Ensure pod changes refresh node summaries via the pod-based handler.
 	manager.handlePod(pod, MessageTypeModified)
@@ -1569,16 +1678,6 @@ func TestManagerNodeUpdateFromPod(t *testing.T) {
 	default:
 		t.Fatal("expected node update to be delivered")
 	}
-}
-
-func podListerWith(pods ...*corev1.Pod) corelisters.PodLister {
-	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
-		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
-	})
-	for _, pod := range pods {
-		_ = indexer.Add(pod)
-	}
-	return corelisters.NewPodLister(indexer)
 }
 
 func nodeListerWith(nodes ...*corev1.Node) corelisters.NodeLister {
@@ -1597,16 +1696,6 @@ func deploymentListerWith(items ...*appsv1.Deployment) appslisters.DeploymentLis
 		_ = indexer.Add(item)
 	}
 	return appslisters.NewDeploymentLister(indexer)
-}
-
-func replicaSetListerWith(items ...*appsv1.ReplicaSet) appslisters.ReplicaSetLister {
-	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
-		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
-	})
-	for _, item := range items {
-		_ = indexer.Add(item)
-	}
-	return appslisters.NewReplicaSetLister(indexer)
 }
 
 func customResourceDefinition(

--- a/backend/refresh/resourcestream/manager_test.go
+++ b/backend/refresh/resourcestream/manager_test.go
@@ -1364,29 +1364,33 @@ func TestManagerReplicaSetAddHealsRacedPodOwnerRows(t *testing.T) {
 
 	deploymentSub, err := subscribeForTest(t, manager, domainPods, "workload:default:apps:v1:Deployment:web")
 	require.NoError(t, err)
-	staleSub, err := subscribeForTest(t, manager, domainPods, "workload:default:apps:v1:ReplicaSet:web-12345")
+	rsSub, err := subscribeForTest(t, manager, domainPods, "workload:default:apps:v1:ReplicaSet:web-12345")
 	require.NoError(t, err)
 	namespaceSub, err := subscribeForTest(t, manager, domainPods, "namespace:default")
 	require.NoError(t, err)
 
 	manager.handleReplicaSetEvent(nil, rs, MessageTypeAdded)
 
-	// The stored bundle is healed: serve-side filters now match the Deployment scope.
+	// The stored bundle is healed: the collapsed owner now names the Deployment
+	// while the direct owner keeps the ReplicaSet, so BOTH workload scopes serve it.
 	rows := store.List()
 	require.Len(t, rows, 1)
 	healedRow := rows[0].(ingest.Bundle).Table.(snapshot.PodSummary)
 	require.Equal(t, "Deployment", healedRow.OwnerKind)
 	require.Equal(t, "web", healedRow.OwnerName)
+	require.Equal(t, "ReplicaSet", healedRow.DirectOwnerKind)
+	require.Equal(t, "web-12345", healedRow.DirectOwnerName)
 
 	// Doorbell: the Deployment-scoped window learns its pods changed...
 	deploymentUpdate := requireNextUpdate(t, deploymentSub)
 	require.Equal(t, MessageTypeModified, deploymentUpdate.Type)
 	require.Equal(t, "web-12345-abcde", deploymentUpdate.Ref.Name)
 
-	// ...the stale ReplicaSet fallback scope learns the rows left it...
-	staleUpdate := requireNextUpdate(t, staleSub)
-	require.Equal(t, MessageTypeDeleted, staleUpdate.Type)
-	require.Equal(t, "web-12345-abcde", staleUpdate.Ref.Name)
+	// ...the ReplicaSet-scoped window too — the healed row still belongs to it
+	// through its direct owner...
+	rsUpdate := requireNextUpdate(t, rsSub)
+	require.Equal(t, MessageTypeModified, rsUpdate.Type)
+	require.Equal(t, "web-12345-abcde", rsUpdate.Ref.Name)
 
 	// ...and the namespace scope sees the row change like any pod update.
 	namespaceUpdate := requireNextUpdate(t, namespaceSub)
@@ -1428,6 +1432,55 @@ func TestManagerReplicaSetModifiedHealsRacedPodOwnerRows(t *testing.T) {
 	deploymentUpdate := requireNextUpdate(t, deploymentSub)
 	require.Equal(t, MessageTypeModified, deploymentUpdate.Type)
 	require.Equal(t, "web-12345-abcde", deploymentUpdate.Ref.Name)
+}
+
+// TestManagerPodSignalReachesDirectOwnerScope: a deployment-owned pod's change
+// signal must ring BOTH workload windows — the Deployment scope (collapsed
+// owner) and the ReplicaSet scope (direct owner). The RS panel's Pods tab
+// subscribes to the latter; deriving scopes only from the collapsed owner left
+// it without doorbells.
+func TestManagerPodSignalReachesDirectOwnerScope(t *testing.T) {
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "web-12345",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{{
+				Kind:       "Deployment",
+				Name:       "web",
+				Controller: ptrBool(true),
+				APIVersion: "apps/v1",
+			}},
+		},
+	}
+	manager := &Manager{
+		clusterMeta: snapshot.ClusterMeta{ClusterID: "c1", ClusterName: "cluster"},
+		logger:      applog.Noop,
+		subscribers: make(map[string]map[string]map[uint64]*subscription),
+	}
+	// Resolved projection (RS known at projection time) delivered through the
+	// production notify sink.
+	project := snapshot.NewPodIngestProjector(
+		snapshot.ClusterMeta{ClusterID: "c1", ClusterName: "cluster"},
+		testsupport.NewReplicaSetLister(t, rs),
+	)
+	store := ingest.NewProjectingStore(project)
+	store.SetRetainTable(true)
+	store.AddBundleSink(podNotifyBundleSink{manager: manager})
+
+	deploymentSub, err := subscribeForTest(t, manager, domainPods, "workload:default:apps:v1:Deployment:web")
+	require.NoError(t, err)
+	rsSub, err := subscribeForTest(t, manager, domainPods, "workload:default:apps:v1:ReplicaSet:web-12345")
+	require.NoError(t, err)
+
+	require.NoError(t, store.Add(racedOwnerPod()))
+
+	deploymentUpdate := requireNextUpdate(t, deploymentSub)
+	require.Equal(t, MessageTypeModified, deploymentUpdate.Type)
+	require.Equal(t, "web-12345-abcde", deploymentUpdate.Ref.Name)
+
+	rsUpdate := requireNextUpdate(t, rsSub)
+	require.Equal(t, MessageTypeModified, rsUpdate.Type)
+	require.Equal(t, "web-12345-abcde", rsUpdate.Ref.Name)
 }
 
 // TestManagerReplicaSetAddWithoutDeploymentOwnerDoesNotHeal: a standalone RS's

--- a/backend/refresh/resourcestream/stream_registration_related.go
+++ b/backend/refresh/resourcestream/stream_registration_related.go
@@ -44,10 +44,12 @@ func (m *Manager) registerNodeStreams(factory *informer.Factory, ingestManager *
 // informers are never instantiated, so their signal-only signal comes from the ingest
 // reflector's Catalog-half Sink (registerWorkloadIngestNotify) instead of a shared-informer
 // event handler — identical to the pod path. ReplicaSet is NOT cut: its typed informer stays
-// registered, and its event handler keeps re-broadcasting affected pods, because the pod
-// projector + cluster-overview resolve pod owners through the RS lister. When no ingest
-// manager is wired (a unit test), the workload streams have no live signal; tests drive
-// handleWorkload / the HPA paths directly with a wired typed lister.
+// registered because the pod projector + cluster-overview resolve pod owners through the RS
+// lister, and its event handler heals stored pod bundles whose owner was projected before
+// the RS informer synced (healPodsForReplicaSet — the owned pod reflector starts before this
+// factory, so first-connect pods can land with an unresolved ReplicaSet owner). When no
+// ingest manager is wired (a unit test), the workload streams have no live signal; tests
+// drive handleWorkload / the HPA paths directly with a wired typed lister.
 func (m *Manager) registerWorkloadStreams(factory *informer.Factory, ingestManager *ingest.IngestManager) {
 	shared := factory.SharedInformerFactory()
 	if shared == nil {

--- a/backend/refresh/snapshot/pod_owner_heal.go
+++ b/backend/refresh/snapshot/pod_owner_heal.go
@@ -1,0 +1,81 @@
+/*
+ * backend/refresh/snapshot/pod_owner_heal.go
+ *
+ * Heals a projected pod bundle whose ReplicaSet->Deployment owner could not be
+ * resolved at projection time. The pod projector resolves the owner through the
+ * shared factory's ReplicaSet lister (pod_ingest_projector.go), but the pod
+ * reflector starts before the factory (ingest_hub.go), so pods projected during
+ * the connect window can land with OwnerKind=ReplicaSet. Owned reflectors never
+ * resync, so without this heal those rows would keep the unresolved owner until
+ * the pod's next watch event — leaving the Deployment's workload-scoped pods
+ * query empty and its doorbell silent. The resource-stream manager applies the
+ * heal from the ReplicaSet informer's event handler via
+ * ProjectingStore.RewriteBundlesByIndex.
+ *
+ * The rewrite mirrors, field for field, what a fresh projection with a synced
+ * lister produces: the Table half's owner triple (resolvePodOwner) and the
+ * Aggregate half's WorkloadKind (workloadKindForPod). OwnerKey and the bundle
+ * Indexes use the lister-independent name-suffix collapse, so they are already
+ * correct and stay untouched. Equivalence with a fresh projection is pinned by
+ * pod_owner_heal_test.go.
+ */
+
+package snapshot
+
+import (
+	"github.com/luxury-yacht/app/backend/kind/streamrows"
+	"github.com/luxury-yacht/app/backend/refresh/ingest"
+	deploymentpkg "github.com/luxury-yacht/app/backend/resources/deployment"
+	replicasetpkg "github.com/luxury-yacht/app/backend/resources/replicaset"
+)
+
+// PodOwnerKeyIndexName is the pod bundle secondary index keyed by the row's
+// owner-workload key (podAggregateBundleIndexes), exported so the resource-stream
+// manager can address the pods needing an owner heal without a store scan.
+const PodOwnerKeyIndexName = podOwnerKeyIndexName
+
+// PodOwnerHealIndexValues returns the owner-key index values under which a
+// ReplicaSet's pods may be stored. The projector's OwnerKey applies the
+// name-suffix collapse (ownerKeyForPod): an RS name with a trimmable suffix
+// indexes under the Deployment key, one without (no '-') under the ReplicaSet
+// fallback key — so the heal looks up both.
+func PodOwnerHealIndexValues(namespace, rsName, deploymentName string) []string {
+	return []string{
+		WorkloadOwnerKey(deploymentpkg.Identity.Kind, namespace, deploymentName),
+		WorkloadOwnerKey(replicasetpkg.Identity.Kind, namespace, rsName),
+	}
+}
+
+// HealPodBundleReplicaSetOwner rewrites a stored pod bundle whose owner is the
+// still-unresolved ReplicaSet namespace/rsName, collapsing it to deploymentName
+// exactly as projection with a synced lister would: the Table half's owner
+// triple becomes Deployment/deploymentName/apps-v1 (resolvePodOwner) and the
+// Aggregate half's WorkloadKind becomes Deployment (workloadKindForPod). It
+// declines (returns the bundle unchanged, false) when the bundle is not a pod
+// row owned by that ReplicaSet — including already-resolved rows, which makes
+// the heal idempotent.
+func HealPodBundleReplicaSetOwner(
+	bundle ingest.Bundle,
+	namespace, rsName, deploymentName string,
+) (ingest.Bundle, bool) {
+	table, ok := bundle.Table.(PodSummary)
+	if !ok {
+		return bundle, false
+	}
+	if table.Namespace != namespace ||
+		table.OwnerKind != replicasetpkg.Identity.Kind ||
+		table.OwnerName != rsName {
+		return bundle, false
+	}
+
+	table.OwnerKind = deploymentpkg.Identity.Kind
+	table.OwnerName = deploymentName
+	table.OwnerAPIVersion = deploymentpkg.Identity.Group + "/" + deploymentpkg.Identity.Version
+	bundle.Table = table
+
+	if aggregate, ok := bundle.Aggregate.(streamrows.PodAggregate); ok {
+		aggregate.WorkloadKind = deploymentpkg.Identity.Kind
+		bundle.Aggregate = aggregate
+	}
+	return bundle, true
+}

--- a/backend/refresh/snapshot/pod_owner_heal_test.go
+++ b/backend/refresh/snapshot/pod_owner_heal_test.go
@@ -1,0 +1,128 @@
+/*
+ * backend/refresh/snapshot/pod_owner_heal_test.go
+ *
+ * The pod owner heal must reproduce, on an already-projected bundle, EXACTLY the
+ * bundle a fresh projection with a synced ReplicaSet lister would build — no
+ * drift between resolvePodOwner/workloadKindForPod and the heal's rewrite. The
+ * equivalence test is the load-bearing one: it projects the same pod with an
+ * empty lister (the connect-race state), heals it, and requires byte-equality
+ * with the synced-lister projection.
+ */
+
+package snapshot
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/luxury-yacht/app/backend/refresh/ingest"
+	"github.com/luxury-yacht/app/backend/testsupport"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func healTestReplicaSet() *appsv1.ReplicaSet {
+	return &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "team-a",
+			Name:      "web-7d9c8b6f5",
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "Deployment", Name: "web", Controller: ptrBool(true), APIVersion: "apps/v1"},
+			},
+		},
+	}
+}
+
+func healTestPod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         "team-a",
+			Name:              "web-7d9c8b6f5-abcde",
+			UID:               "uid-1",
+			CreationTimestamp: metav1.Unix(1700000000, 0),
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "ReplicaSet", Name: "web-7d9c8b6f5", Controller: ptrBool(true), APIVersion: "apps/v1"},
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "node-1",
+			Containers: []corev1.Container{
+				{Name: "app", Ports: []corev1.ContainerPort{{ContainerPort: 8080}}},
+			},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+}
+
+func projectPodBundle(t *testing.T, rsObjects ...*appsv1.ReplicaSet) ingest.Bundle {
+	t.Helper()
+	meta := ClusterMeta{ClusterID: "c-1", ClusterName: "prod"}
+	project := NewPodIngestProjector(meta, testsupport.NewReplicaSetLister(t, rsObjects...))
+	projected, err := project(healTestPod())
+	if err != nil {
+		t.Fatalf("project: %v", err)
+	}
+	return projected.(ingest.Bundle)
+}
+
+func TestHealPodBundleReplicaSetOwnerMatchesFreshProjection(t *testing.T) {
+	rs := healTestReplicaSet()
+
+	// The connect-race state: pod projected while the RS lister was empty.
+	raced := projectPodBundle(t)
+	if got := raced.Table.(PodSummary).OwnerKind; got != "ReplicaSet" {
+		t.Fatalf("raced projection owner = %q, want unresolved ReplicaSet", got)
+	}
+
+	healed, changed := HealPodBundleReplicaSetOwner(raced, rs.Namespace, rs.Name, "web")
+	if !changed {
+		t.Fatal("heal declined a raced bundle")
+	}
+
+	want := projectPodBundle(t, rs)
+	if !reflect.DeepEqual(healed, want) {
+		t.Fatalf("healed bundle diverges from fresh synced-lister projection:\nhealed: %#v\nwant:   %#v", healed, want)
+	}
+}
+
+func TestHealPodBundleReplicaSetOwnerDeclinesNonMatches(t *testing.T) {
+	rs := healTestReplicaSet()
+	raced := projectPodBundle(t)
+
+	// Different ReplicaSet name: not this pod's owner.
+	if _, changed := HealPodBundleReplicaSetOwner(raced, rs.Namespace, "other-rs", "web"); changed {
+		t.Fatal("heal accepted a bundle owned by a different ReplicaSet")
+	}
+	// Different namespace: same-named RS elsewhere must not match.
+	if _, changed := HealPodBundleReplicaSetOwner(raced, "team-b", rs.Name, "web"); changed {
+		t.Fatal("heal accepted a bundle from a different namespace")
+	}
+	// Already resolved: healing twice is a no-op.
+	resolved := projectPodBundle(t, rs)
+	if _, changed := HealPodBundleReplicaSetOwner(resolved, rs.Namespace, rs.Name, "web"); changed {
+		t.Fatal("heal accepted an already-resolved bundle")
+	}
+	// Not a pod bundle at all.
+	if _, changed := HealPodBundleReplicaSetOwner(ingest.Bundle{Table: "not-a-pod"}, rs.Namespace, rs.Name, "web"); changed {
+		t.Fatal("heal accepted a non-pod bundle")
+	}
+}
+
+func TestPodOwnerHealIndexValuesCoverBothOwnerKeys(t *testing.T) {
+	values := PodOwnerHealIndexValues("team-a", "web-7d9c8b6f5", "web")
+	want := map[string]bool{
+		// The suffix-collapse OwnerKey the projector normally writes.
+		WorkloadOwnerKey("Deployment", "team-a", "web"): true,
+		// The fallback OwnerKey when the RS name has no collapsible suffix.
+		WorkloadOwnerKey("ReplicaSet", "team-a", "web-7d9c8b6f5"): true,
+	}
+	if len(values) != len(want) {
+		t.Fatalf("index values = %v, want the 2 owner keys %v", values, want)
+	}
+	for _, v := range values {
+		if !want[v] {
+			t.Fatalf("unexpected index value %q (want one of %v)", v, want)
+		}
+	}
+}

--- a/backend/refresh/snapshot/pods.go
+++ b/backend/refresh/snapshot/pods.go
@@ -451,21 +451,31 @@ func filterPodRows(rows []PodSummary, keep func(PodSummary) bool) []PodSummary {
 }
 
 // podRowMatchesWorkload reports whether a stored pod row belongs to the workload
-// scope, reading the row's RESOLVED controlling owner (OwnerKind/OwnerName/
-// OwnerAPIVersion — already collapsed ReplicaSet->Deployment by BuildStreamSummary).
-// This matches matchesWorkload's result: matchesWorkload either matches the pod's
-// direct controlling owner against the scope or resolves an RS owner to its Deployment
-// and matches that — exactly the resolution resolvePodOwner baked into the row.
+// scope, mirroring matchesWorkload exactly: the scope matches the row's DIRECT
+// controlling owner (DirectOwner* — the ownerRef as written on the pod, which is
+// what a ReplicaSet-scoped Pods window names) or its COLLAPSED owner (Owner* —
+// ReplicaSet resolved to its Deployment by BuildStreamSummary, which is what a
+// Deployment-scoped window names). Matching only the collapsed owner left every
+// ReplicaSet-scoped window empty: the collapse erases the RS identity.
 func podRowMatchesWorkload(row PodSummary, scope workloadScope) bool {
-	gv, err := schema.ParseGroupVersion(row.OwnerAPIVersion)
+	if row.Namespace != scope.namespace {
+		return false
+	}
+	return ownerTripleMatchesScope(row.DirectOwnerAPIVersion, row.DirectOwnerKind, row.DirectOwnerName, scope) ||
+		ownerTripleMatchesScope(row.OwnerAPIVersion, row.OwnerKind, row.OwnerName, scope)
+}
+
+// ownerTripleMatchesScope compares one stored owner identity against the scope's
+// full group/version/kind/name (the row-side twin of ownerMatchesWorkloadScope).
+func ownerTripleMatchesScope(apiVersion, kind, name string, scope workloadScope) bool {
+	gv, err := schema.ParseGroupVersion(apiVersion)
 	if err != nil {
 		return false
 	}
 	return gv.Group == scope.group &&
 		gv.Version == scope.version &&
-		row.Namespace == scope.namespace &&
-		row.OwnerKind == scope.kind &&
-		row.OwnerName == scope.name
+		kind == scope.kind &&
+		name == scope.name
 }
 
 // metricSampleValid reports whether a metrics sample may be overlaid onto an object

--- a/backend/refresh/snapshot/pods_store_scope_test.go
+++ b/backend/refresh/snapshot/pods_store_scope_test.go
@@ -79,6 +79,10 @@ func TestPodBuilderStoreServedScopesMatchListPath(t *testing.T) {
 	scopes := []string{
 		"node:node-1",
 		"workload:prod:apps:v1:Deployment:orders",
+		// The ReplicaSet panel's Pods tab scope: the list path matches the pod's
+		// DIRECT controlling owner; the store path must match it identically even
+		// though the row's collapsed owner is the Deployment.
+		"workload:prod:apps:v1:ReplicaSet:orders-7d9c8b6f5",
 		"namespace:prod",
 	}
 	for _, scope := range scopes {

--- a/backend/resources/pods/streamsummary.go
+++ b/backend/resources/pods/streamsummary.go
@@ -44,52 +44,68 @@ func BuildStreamSummaryFromRSMap(meta streamrows.ClusterMeta, pod *corev1.Pod, c
 func buildPodRow(meta streamrows.ClusterMeta, pod *corev1.Pod, cpuUsageMilli, memUsageBytes int64, rsMap map[string]string) streamrows.PodSummary {
 	model := BuildResourceModel(meta.ClusterID, pod)
 	podFacts := BuildFacts(pod)
-	ownerKind, ownerName, ownerAPIVersion := resolvePodOwner(pod, rsMap)
+	owner := resolvePodOwner(pod, rsMap)
 	cpuReq, cpuLim, memReq, memLim := computeResourceTotals(pod)
 	return streamrows.PodSummary{
-		ClusterMeta:          meta,
-		Name:                 pod.Name,
-		Namespace:            pod.Namespace,
-		Node:                 pod.Spec.NodeName,
-		Status:               model.Status.Label,
-		StatusState:          model.Status.State,
-		StatusPresentation:   model.Status.Presentation,
-		StatusReason:         model.Status.Reason,
-		Ready:                fmt.Sprintf("%d/%d", podFacts.ReadyContainers, podFacts.TotalContainers),
-		Restarts:             podFacts.RestartCount,
-		Age:                  streamrows.FormatAge(pod.CreationTimestamp.Time),
-		AgeTimestamp:         streamrows.CreationMillis(pod),
-		OwnerKind:            ownerKind,
-		OwnerName:            ownerName,
-		PortForwardAvailable: common.HasForwardableContainerPorts(pod.Spec.Containers),
-		OwnerAPIVersion:      ownerAPIVersion,
-		CPURequest:           streamrows.FormatCPUMilli(cpuReq),
-		CPULimit:             streamrows.FormatCPUMilli(cpuLim),
-		CPUUsage:             streamrows.FormatCPUMilli(cpuUsageMilli),
-		MemRequest:           streamrows.FormatMemoryBytes(memReq),
-		MemLimit:             streamrows.FormatMemoryBytes(memLim),
-		MemUsage:             streamrows.FormatMemoryBytes(memUsageBytes),
+		ClusterMeta:           meta,
+		Name:                  pod.Name,
+		Namespace:             pod.Namespace,
+		Node:                  pod.Spec.NodeName,
+		Status:                model.Status.Label,
+		StatusState:           model.Status.State,
+		StatusPresentation:    model.Status.Presentation,
+		StatusReason:          model.Status.Reason,
+		Ready:                 fmt.Sprintf("%d/%d", podFacts.ReadyContainers, podFacts.TotalContainers),
+		Restarts:              podFacts.RestartCount,
+		Age:                   streamrows.FormatAge(pod.CreationTimestamp.Time),
+		AgeTimestamp:          streamrows.CreationMillis(pod),
+		OwnerKind:             owner.kind,
+		OwnerName:             owner.name,
+		PortForwardAvailable:  common.HasForwardableContainerPorts(pod.Spec.Containers),
+		OwnerAPIVersion:       owner.apiVersion,
+		DirectOwnerKind:       owner.directKind,
+		DirectOwnerName:       owner.directName,
+		DirectOwnerAPIVersion: owner.directAPIVersion,
+		CPURequest:            streamrows.FormatCPUMilli(cpuReq),
+		CPULimit:              streamrows.FormatCPUMilli(cpuLim),
+		CPUUsage:              streamrows.FormatCPUMilli(cpuUsageMilli),
+		MemRequest:            streamrows.FormatMemoryBytes(memReq),
+		MemLimit:              streamrows.FormatMemoryBytes(memLim),
+		MemUsage:              streamrows.FormatMemoryBytes(memUsageBytes),
 	}
 }
 
-func resolvePodOwner(pod *corev1.Pod, rsMap map[string]string) (string, string, string) {
+// podOwner carries both owner identities a pod row stores: the direct
+// controlling ownerRef as written on the pod, and the collapsed owner with a
+// ReplicaSet resolved to its Deployment (equal to direct for every other kind).
+type podOwner struct {
+	kind, name, apiVersion                   string
+	directKind, directName, directAPIVersion string
+}
+
+func resolvePodOwner(pod *corev1.Pod, rsMap map[string]string) podOwner {
 	for _, owner := range pod.OwnerReferences {
 		if owner.Controller == nil || !*owner.Controller {
 			continue
 		}
-		kind := owner.Kind
-		name := owner.Name
-		apiVersion := owner.APIVersion
+		resolved := podOwner{
+			kind:             owner.Kind,
+			name:             owner.Name,
+			apiVersion:       owner.APIVersion,
+			directKind:       owner.Kind,
+			directName:       owner.Name,
+			directAPIVersion: owner.APIVersion,
+		}
 		if owner.Kind == "ReplicaSet" {
 			if deployment, ok := rsMap[owner.Name]; ok {
-				kind = "Deployment"
-				name = deployment
-				apiVersion = "apps/v1"
+				resolved.kind = "Deployment"
+				resolved.name = deployment
+				resolved.apiVersion = "apps/v1"
 			}
 		}
-		return kind, name, apiVersion
+		return resolved
 	}
-	return "None", "None", ""
+	return podOwner{kind: "None", name: "None"}
 }
 
 func computeResourceTotals(pod *corev1.Pod) (cpuReq, cpuLim, memReq, memLim int64) {

--- a/backend/resources/pods/streamsummary_test.go
+++ b/backend/resources/pods/streamsummary_test.go
@@ -9,8 +9,10 @@ import (
 )
 
 // TestResolvePodOwnerThreadsCRDOwnerAPIVersion guards that the controlling
-// owner's apiVersion is threaded through (CRD owners) and that the
-// ReplicaSet->Deployment collapse hardcodes apps/v1.
+// owner's apiVersion is threaded through (CRD owners), that the
+// ReplicaSet->Deployment collapse hardcodes apps/v1, and that the direct
+// owner always preserves the pod's own ownerRef (equal to the collapsed
+// owner except across the collapse).
 func TestResolvePodOwnerThreadsCRDOwnerAPIVersion(t *testing.T) {
 	owner := func() *bool { b := true; return &b }()
 
@@ -18,37 +20,47 @@ func TestResolvePodOwnerThreadsCRDOwnerAPIVersion(t *testing.T) {
 		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{{
 			APIVersion: "argoproj.io/v1alpha1", Kind: "Rollout", Name: "canary", Controller: owner,
 		}}}}
-		kind, name, apiVersion := resolvePodOwner(pod, map[string]string{})
-		require.Equal(t, "Rollout", kind)
-		require.Equal(t, "canary", name)
-		require.Equal(t, "argoproj.io/v1alpha1", apiVersion)
+		resolved := resolvePodOwner(pod, map[string]string{})
+		require.Equal(t, "Rollout", resolved.kind)
+		require.Equal(t, "canary", resolved.name)
+		require.Equal(t, "argoproj.io/v1alpha1", resolved.apiVersion)
+		require.Equal(t, "Rollout", resolved.directKind)
+		require.Equal(t, "canary", resolved.directName)
+		require.Equal(t, "argoproj.io/v1alpha1", resolved.directAPIVersion)
 	})
 
 	t.Run("KubeVirt VirtualMachineInstance owner", func(t *testing.T) {
 		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{{
 			APIVersion: "kubevirt.io/v1", Kind: "VirtualMachineInstance", Name: "vmi-test", Controller: owner,
 		}}}}
-		kind, name, apiVersion := resolvePodOwner(pod, map[string]string{})
-		require.Equal(t, "VirtualMachineInstance", kind)
-		require.Equal(t, "vmi-test", name)
-		require.Equal(t, "kubevirt.io/v1", apiVersion)
+		resolved := resolvePodOwner(pod, map[string]string{})
+		require.Equal(t, "VirtualMachineInstance", resolved.kind)
+		require.Equal(t, "vmi-test", resolved.name)
+		require.Equal(t, "kubevirt.io/v1", resolved.apiVersion)
 	})
 
-	t.Run("ReplicaSet collapse hardcodes apps/v1", func(t *testing.T) {
+	t.Run("ReplicaSet collapse hardcodes apps/v1 and keeps the direct RS owner", func(t *testing.T) {
 		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{{
-			Kind: "ReplicaSet", Name: "demo-rs", Controller: owner,
+			APIVersion: "apps/v1", Kind: "ReplicaSet", Name: "demo-rs", Controller: owner,
 		}}}}
-		kind, name, apiVersion := resolvePodOwner(pod, map[string]string{"demo-rs": "demo-deploy"})
-		require.Equal(t, "Deployment", kind)
-		require.Equal(t, "demo-deploy", name)
-		require.Equal(t, "apps/v1", apiVersion)
+		resolved := resolvePodOwner(pod, map[string]string{"demo-rs": "demo-deploy"})
+		require.Equal(t, "Deployment", resolved.kind)
+		require.Equal(t, "demo-deploy", resolved.name)
+		require.Equal(t, "apps/v1", resolved.apiVersion)
+		// The collapse must not erase the direct owner: the ReplicaSet-scoped
+		// Pods window matches rows by these fields.
+		require.Equal(t, "ReplicaSet", resolved.directKind)
+		require.Equal(t, "demo-rs", resolved.directName)
+		require.Equal(t, "apps/v1", resolved.directAPIVersion)
 	})
 
 	t.Run("ownerless pod returns empty apiVersion", func(t *testing.T) {
 		pod := &corev1.Pod{}
-		kind, name, apiVersion := resolvePodOwner(pod, map[string]string{})
-		require.Equal(t, "None", kind)
-		require.Equal(t, "None", name)
-		require.Empty(t, apiVersion)
+		resolved := resolvePodOwner(pod, map[string]string{})
+		require.Equal(t, "None", resolved.kind)
+		require.Equal(t, "None", resolved.name)
+		require.Empty(t, resolved.apiVersion)
+		require.Empty(t, resolved.directKind)
+		require.Empty(t, resolved.directName)
 	})
 }

--- a/docs/architecture/data-layer.md
+++ b/docs/architecture/data-layer.md
@@ -78,6 +78,21 @@ the completed `v2` rewrite plan.
   response-cache). Cross-kind-join domains (pods, workloads, network, nodes) use a
   bespoke `RegisterReflector` + **serve-time re-aggregation** (metrics overlay, pod
   aggregates, HPA, Service↔EndpointSlice) — these joins stay at serve by design.
+- **Cross-kind projection inputs must declare a late-arrival story.** A projection may
+  read its OWN object freely; any input read from another kind's cache at projection
+  time is a race against that kind's sync, and owned reflectors never resync — a value
+  baked from an unsynced cache is wrong forever (the empty-Deployment-Pods-tab bug,
+  2026-07-05). Exactly two sanctioned shapes:
+  1. **Don't bake — re-join at serve** (Service↔EndpointSlice endpoint counts, pod
+     aggregates, metrics overlay): correct by construction; right for volatile joins.
+  2. **Bake + heal on the input kind's events** (the pod ReplicaSet→Deployment owner:
+     `snapshot/pod_owner_heal.go` applied via `ingest.ProjectingStore.RewriteBundlesByIndex`
+     from the RS informer handler): right for immutable joins that serve filters and
+     doorbell scope routing need pre-resolved. A heal MUST be pinned by an equivalence
+     test — healed bundle byte-equal to a fresh synced-cache projection
+     (`pod_owner_heal_test.go`) — so the heal and the projector cannot drift.
+  The tell in review: a `New*IngestProjector` signature growing another kind's
+  lister/store without one of these shapes.
 - **Kept-as-typed-informer (documented):** ReplicaSet (pod-owner resolution), CRDs (CR
   discovery), events, gateway-API ×8, HPA, namespaces — each justified in `factory.go`.
 

--- a/docs/release/pending.md
+++ b/docs/release/pending.md
@@ -1,8 +1,5 @@
-### Added
-
-### Changed
-
 ### Fixed
 
-- The Pods tab for a Deployment could show "No pods found" even though pods were running, depending on data-arrival order when connecting to a cluster. Pod ownership is now re-resolved when the missing piece (the ReplicaSet) arrives, so the tab fills in immediately.
-- With several panels of the same kind open at once (for example two Deployments), closing one could silently stop the other's Details and Events from auto-refreshing. Each panel now tracks its refresh independently. This also removes the "Refresher ... is already registered" console warning.
+- The Pods tab for a Deployment could show "No pods found" due to a race condition involving the deployment's replicaset. Pod ownership is now re-resolved if the ReplicaSet arrives after the pods, so the tab fills in correctly.
+- With several panels of the same kind open at once (for example two Deployments), closing one could silently stop the other's Details and Events from auto-refreshing. Each panel now tracks its refresh independently.
+- The Pods tab inside an object panel only received live updates while the app's main view was that namespace's Pods view — on any other view it froze after the first load, eventually showing "Awaiting metrics data...". The panel's pod list now streams updates regardless of which main view is active.

--- a/docs/release/pending.md
+++ b/docs/release/pending.md
@@ -1,5 +1,5 @@
 ### Fixed
 
-- The Pods tab for a Deployment could show "No pods found" due to a race condition involving the deployment's replicaset. Pod ownership is now re-resolved if the ReplicaSet arrives after the pods, so the tab fills in correctly.
+- The Pods tab for a Deployment or ReplicaSet could show "No pods found" due to a race condition involving the deployment's replicaset. Pod ownership is now re-resolved if the ReplicaSet arrives after the pods, so the tab fills in correctly.
 - With several panels of the same kind open at once (for example two Deployments), closing one could silently stop the other's Details and Events from auto-refreshing. Each panel now tracks its refresh independently.
 - The Pods tab inside an object panel only received live updates while the app's main view was that namespace's Pods view — on any other view it froze after the first load, eventually showing "Awaiting metrics data...". The panel's pod list now streams updates regardless of which main view is active.

--- a/docs/release/pending.md
+++ b/docs/release/pending.md
@@ -1,22 +1,8 @@
-**Luxury Yacht 1.10.0 is a large release, and a complete rewrite of some important backend systems.** It contains significant performance improvements, but many thousands of lines of code were changed to accomplish this. While I've done my best to test and make sure this is release-worthy, I can't cover every possible scenario. If you run into any problems, please open an issue.
-
 ### Added
-
-- If your account does not have permission to list namespaces, you can now add/remove the specific namespaces you do have access to, right in the sidebar. If a namespace you added turns out to be off-limits, only that namespace is affected — the rest keep working. A few views that can only read the whole cluster at once (Events, Autoscaling, Helm, and Gateway API) show a "no permission" message instead. ([#243](https://github.com/luxury-yacht/app/issues/243)).
-- Object Age is now calculated by the frontend, so it should update in realtime without requiring any new data from the backend.
-- A clearer message when a sign-in helper is missing. Some clusters use an external helper program to log in. If the app can't run it, it now tells you exactly which program your cluster is asking for and what to do about it.
-- There is now a "Collecting metrics…" note while CPU/memory data is still loading, on the Cluster Overview and other places that show usage.
 
 ### Changed
 
-- The app no longer guesses where cloud sign-in helpers are installed. It used to automatically look in Google Cloud SDK and Homebrew install folders. Now it relies on your system setup and your kubeconfig. ([#240](https://github.com/luxury-yacht/app/issues/240))
-- Faster loading of the namespaces list. We display the namespaces as quickly as possible, then retroactively determine the workload state for namespace dimming (when enabled).
-- The Cluster Overview will now show at least partial data to users with limited permissions instead of failing to load entirely. ([#244](https://github.com/luxury-yacht/app/issues/244)).
-- Clearer resource bars. When usage goes over its limit, the over-limit part of the bar now has a striped pattern, so you can still see where the limit is even on a full red bar.
-- Legend added to the Resource Utilization card on the Cluster Overview page.
-- Friendlier sign-in errors. Login problems now show a plain, readable message (like "The cluster credentials have expired") instead of raw technical output.
-
 ### Fixed
 
-- Screens you don't have permission to see now say so right away — "Insufficient permissions" — instead of spinning forever.
-- The Details panel should now update when an object changes — it could previously keep showing old information for the rest of the session.
+- The Pods tab for a Deployment could show "No pods found" even though pods were running, depending on data-arrival order when connecting to a cluster. Pod ownership is now re-resolved when the missing piece (the ReplicaSet) arrives, so the tab fills in immediately.
+- With several panels of the same kind open at once (for example two Deployments), closing one could silently stop the other's Details and Events from auto-refreshing. Each panel now tracks its refresh independently. This also removes the "Refresher ... is already registered" console warning.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,5 +1,3 @@
-- Embedded pods do not show -- "insufficient permissions for Metrics API". Should show pods w/o metrics
-
 - Build a plugin architecture
   - AI
     - Conversational support to perform functions of the app

--- a/frontend/src/core/contexts/ViewStateContext.tsx
+++ b/frontend/src/core/contexts/ViewStateContext.tsx
@@ -285,9 +285,6 @@ const RefreshSyncProvider: React.FC<{ children: React.ReactNode }> = ({ children
       activeClusterView: activeClusterTab ?? undefined,
       objectPanel: {
         isOpen: showObjectPanel,
-        objectKind: undefined,
-        objectName: undefined,
-        objectNamespace: undefined,
       },
     });
   }, [viewType, activeNamespaceTab, activeClusterTab, showObjectPanel]);

--- a/frontend/src/core/refresh/RefreshManager.test.ts
+++ b/frontend/src/core/refresh/RefreshManager.test.ts
@@ -19,8 +19,6 @@ type UnsafeRefreshManager = {
   startRefresher: (name: RefresherName) => void;
   refreshSingle: (name: RefresherName, isManual: boolean) => Promise<void>;
   getManualRefreshTargets: (previous: RefreshContext, current: RefreshContext) => RefresherName[];
-  didObjectPanelTargetChange: (previous: RefreshContext, current: RefreshContext) => boolean;
-  getObjectPanelRefresherTargets: (context: RefreshContext) => RefresherName[];
   getRefresherTargetsForContext: (context: RefreshContext) => RefresherName[];
   abortRefresher: (name: RefresherName) => void;
   pauseRefresher: (name: RefresherName, instance: unknown) => void;
@@ -437,7 +435,10 @@ describe('RefreshManager global controls', () => {
     expect(refreshManager.getState(CANCEL_NAME)?.status).toBe('cooldown');
   });
 
-  it('triggers manual refreshes for context-driven targets including object panels', async () => {
+  it('triggers manual refreshes for context-driven targets but never object panels', async () => {
+    // Object panels register per-panel refreshers (named by full panel
+    // identity) and refresh themselves; context-driven manual refresh must
+    // not reach into them.
     vi.useFakeTimers();
     const nsSubscriber = vi.fn();
     const objectSubscriber = vi.fn();
@@ -480,21 +481,16 @@ describe('RefreshManager global controls', () => {
       selectedNamespace: 'team-a',
       objectPanel: {
         isOpen: true,
-        objectKind: 'Pod',
-        objectName: 'api',
-        objectNamespace: 'team-a',
       },
     });
 
     await Promise.resolve();
 
     expect(nsSubscriber).toHaveBeenCalledTimes(1);
-    expect(objectSubscriber).toHaveBeenCalledTimes(1);
-    expect(objectEventsSubscriber).toHaveBeenCalledTimes(1);
+    expect(objectSubscriber).not.toHaveBeenCalled();
+    expect(objectEventsSubscriber).not.toHaveBeenCalled();
 
     expect(refreshManager.getState(NAMESPACE_WORKLOADS)?.status).toBe('cooldown');
-    expect(refreshManager.getState(OBJECT_MAIN)?.status).toBe('cooldown');
-    expect(refreshManager.getState(OBJECT_EVENTS)?.status).toBe('cooldown');
   });
 
   it('deduplicates manual refresh targets when triggering multiple refreshes', async () => {
@@ -1020,31 +1016,22 @@ describe('RefreshManager guard paths and helpers', () => {
     expect(manualTargets).toEqual(['cluster-config']);
   });
 
-  it('adds object panel refreshers when the panel target changes', () => {
+  it('produces no manual targets for object panel open/close changes', () => {
+    // Panels self-refresh via their per-panel refreshers; the context cannot
+    // name them (it carries no panel identity), so panel changes contribute
+    // nothing here.
     const previous: RefreshContext = {
       currentView: 'namespace',
       activeNamespaceView: 'workloads',
       selectedNamespace: 'team-a',
-      objectPanel: {
-        isOpen: true,
-        objectKind: 'Pod',
-        objectName: 'api',
-        objectNamespace: 'team-a',
-      },
+      objectPanel: { isOpen: false },
     };
     const current: RefreshContext = {
       ...previous,
-      objectPanel: {
-        isOpen: true,
-        objectKind: 'Deployment',
-        objectName: 'web',
-        objectNamespace: 'team-a',
-      },
+      objectPanel: { isOpen: true },
     };
 
-    const manualTargets = unsafeRefreshManager.getManualRefreshTargets(previous, current);
-
-    expect(manualTargets.sort()).toEqual(['object-deployment', 'object-deployment-events'].sort());
+    expect(unsafeRefreshManager.getManualRefreshTargets(previous, current)).toEqual([]);
   });
 
   it('filters namespace aborts when switching views with object panel changes', async () => {
@@ -1057,12 +1044,7 @@ describe('RefreshManager guard paths and helpers', () => {
       currentView: 'namespace',
       activeNamespaceView: 'workloads',
       selectedNamespace: 'team-a',
-      objectPanel: {
-        isOpen: true,
-        objectKind: 'Pod',
-        objectName: 'api',
-        objectNamespace: 'team-a',
-      },
+      objectPanel: { isOpen: true },
     });
 
     abortSpy.mockClear();
@@ -1071,18 +1053,11 @@ describe('RefreshManager guard paths and helpers', () => {
     refreshManager.updateContext({
       currentView: 'cluster',
       activeClusterView: 'events',
-      objectPanel: {
-        isOpen: true,
-        objectKind: 'Deployment',
-        objectName: 'web',
-        objectNamespace: 'team-a',
-      },
+      objectPanel: { isOpen: true },
     });
 
     expect(abortSpy).not.toHaveBeenCalled();
-    expect(manualSpy).toHaveBeenCalledWith(
-      expect.arrayContaining(['cluster-events', 'object-deployment', 'object-deployment-events'])
-    );
+    expect(manualSpy).toHaveBeenCalledWith(expect.arrayContaining(['cluster-events']));
 
     manualSpy.mockRestore();
     abortSpy.mockRestore();
@@ -1095,149 +1070,18 @@ describe('RefreshManager guard paths and helpers', () => {
     });
   });
 
-  it('tracks object panel target changes across open and closed states', () => {
-    const base: RefreshContext = {
-      currentView: 'namespace',
-      activeNamespaceView: 'network',
-      selectedNamespace: 'team-a',
-      objectPanel: {
-        isOpen: false,
-        objectKind: undefined,
-        objectName: undefined,
-        objectNamespace: undefined,
-      },
-    };
-
-    expect(
-      unsafeRefreshManager.didObjectPanelTargetChange(base, {
-        ...base,
-        objectPanel: { ...base.objectPanel, isOpen: false },
-      })
-    ).toBe(false);
-
-    expect(
-      unsafeRefreshManager.didObjectPanelTargetChange(base, {
-        ...base,
-        objectPanel: {
-          isOpen: true,
-          objectKind: 'Pod',
-          objectName: 'api',
-          objectNamespace: 'team-a',
-        },
-      })
-    ).toBe(true);
-
-    expect(
-      unsafeRefreshManager.didObjectPanelTargetChange(
-        {
-          ...base,
-          objectPanel: {
-            isOpen: true,
-            objectKind: 'Pod',
-            objectName: 'api',
-            objectNamespace: 'team-a',
-          },
-        },
-        {
-          ...base,
-          objectPanel: {
-            isOpen: true,
-            objectKind: 'Pod',
-            objectName: 'api',
-            objectNamespace: 'team-b',
-          },
-        }
-      )
-    ).toBe(true);
-
-    expect(
-      unsafeRefreshManager.didObjectPanelTargetChange(
-        {
-          ...base,
-          objectPanel: {
-            isOpen: true,
-            objectKind: 'Pod',
-            objectName: 'api',
-            objectNamespace: 'team-a',
-          },
-        },
-        {
-          ...base,
-          objectPanel: {
-            isOpen: false,
-            objectKind: undefined,
-            objectName: undefined,
-            objectNamespace: undefined,
-          },
-        }
-      )
-    ).toBe(true);
-
-    expect(
-      unsafeRefreshManager.didObjectPanelTargetChange(
-        {
-          ...base,
-          objectPanel: {
-            isOpen: false,
-            objectKind: 'Service',
-            objectName: 'svc',
-            objectNamespace: 'team-a',
-          },
-        },
-        {
-          ...base,
-          objectPanel: {
-            isOpen: false,
-            objectKind: 'Service',
-            objectName: 'svc',
-            objectNamespace: 'team-a',
-          },
-        }
-      )
-    ).toBe(false);
-  });
-
-  it('derives object panel refresher targets only when the panel is open with a kind', () => {
-    const closed: RefreshContext = {
-      currentView: 'namespace',
-      activeNamespaceView: 'config',
-      selectedNamespace: 'team-a',
-      objectPanel: { isOpen: false },
-    };
-    const open: RefreshContext = {
-      ...closed,
-      objectPanel: {
-        isOpen: true,
-        objectKind: 'Pod',
-        objectName: 'api',
-        objectNamespace: 'team-a',
-      },
-    };
-
-    expect(unsafeRefreshManager.getObjectPanelRefresherTargets(closed)).toEqual([]);
-    expect(unsafeRefreshManager.getObjectPanelRefresherTargets(open)).toEqual([
-      'object-pod',
-      'object-pod-events',
-    ]);
-  });
-
-  it('collects refresher targets across namespace, cluster, overview, and object panel contexts', () => {
+  it('collects refresher targets across namespace, cluster, and overview contexts', () => {
+    // An open object panel contributes nothing: panels self-refresh via their
+    // per-panel refreshers, which the context cannot name.
     const context: RefreshContext = {
       currentView: 'namespace',
       activeNamespaceView: 'workloads',
       activeClusterView: undefined,
       selectedNamespace: 'team-a',
-      objectPanel: {
-        isOpen: true,
-        objectKind: 'Pod',
-        objectName: 'api',
-        objectNamespace: 'team-a',
-      },
+      objectPanel: { isOpen: true },
     };
     const namespaceTargets = unsafeRefreshManager.getRefresherTargetsForContext(context);
-    expect(namespaceTargets.sort()).toEqual(
-      ['workloads', 'object-pod', 'object-pod-events'].sort()
-    );
+    expect(namespaceTargets).toEqual(['workloads']);
 
     const clusterContext: RefreshContext = {
       ...context,
@@ -1245,9 +1089,9 @@ describe('RefreshManager guard paths and helpers', () => {
       activeNamespaceView: undefined,
       activeClusterView: 'events',
     };
-    expect(unsafeRefreshManager.getRefresherTargetsForContext(clusterContext).sort()).toEqual(
-      ['cluster-events', 'object-pod', 'object-pod-events'].sort()
-    );
+    expect(unsafeRefreshManager.getRefresherTargetsForContext(clusterContext)).toEqual([
+      'cluster-events',
+    ]);
 
     const overviewContext: RefreshContext = {
       ...context,
@@ -1255,9 +1099,9 @@ describe('RefreshManager guard paths and helpers', () => {
       activeNamespaceView: undefined,
       activeClusterView: undefined,
     };
-    expect(unsafeRefreshManager.getRefresherTargetsForContext(overviewContext).sort()).toEqual(
-      ['cluster-overview', 'object-pod', 'object-pod-events'].sort()
-    );
+    expect(unsafeRefreshManager.getRefresherTargetsForContext(overviewContext)).toEqual([
+      'cluster-overview',
+    ]);
   });
 
   it('returns null for unknown refresher intervals', () => {

--- a/frontend/src/core/refresh/RefreshManager.ts
+++ b/frontend/src/core/refresh/RefreshManager.ts
@@ -33,11 +33,11 @@ export interface RefreshContext {
   // All open/connected cluster IDs; backgroundRefreshEnabled controls whether inactive tabs do work.
   allConnectedClusterIds?: string[];
   backgroundRefreshEnabled?: boolean;
+  // Object panels register their own per-panel refreshers (named by the panel's
+  // full identity — see getObjectDetailsRefresherName) and refresh themselves;
+  // the context only tracks whether any panel is open.
   objectPanel: {
     isOpen: boolean;
-    objectKind?: string;
-    objectName?: string;
-    objectNamespace?: string;
   };
 }
 
@@ -557,43 +557,7 @@ class RefreshManager {
       targets.add(SYSTEM_REFRESHERS.clusterOverview);
     }
 
-    if (this.didObjectPanelTargetChange(previous, current)) {
-      this.getObjectPanelRefresherTargets(current).forEach((name) => targets.add(name));
-    }
-
     return Array.from(targets);
-  }
-
-  private didObjectPanelTargetChange(previous: RefreshContext, current: RefreshContext): boolean {
-    const prevPanel = previous.objectPanel;
-    const nextPanel = current.objectPanel;
-
-    if (!prevPanel.isOpen && !nextPanel.isOpen) {
-      return false;
-    }
-
-    if (prevPanel.isOpen !== nextPanel.isOpen) {
-      return true;
-    }
-
-    if (!nextPanel.isOpen) {
-      return false;
-    }
-
-    return (
-      prevPanel.objectKind !== nextPanel.objectKind ||
-      prevPanel.objectName !== nextPanel.objectName ||
-      prevPanel.objectNamespace !== nextPanel.objectNamespace
-    );
-  }
-
-  private getObjectPanelRefresherTargets(context: RefreshContext): RefresherName[] {
-    if (!context.objectPanel.isOpen || !context.objectPanel.objectKind) {
-      return [];
-    }
-
-    const kind = context.objectPanel.objectKind.toLowerCase();
-    return [`object-${kind}` as RefresherName, `object-${kind}-events` as RefresherName];
   }
 
   private getRefresherTargetsForContext(context: RefreshContext): RefresherName[] {
@@ -616,8 +580,6 @@ class RefreshManager {
     if (context.currentView === 'overview') {
       targets.add(SYSTEM_REFRESHERS.clusterOverview);
     }
-
-    this.getObjectPanelRefresherTargets(context).forEach((name) => targets.add(name));
 
     return Array.from(targets);
   }

--- a/frontend/src/core/refresh/hooks/useRefreshHooks.test.tsx
+++ b/frontend/src/core/refresh/hooks/useRefreshHooks.test.tsx
@@ -128,9 +128,6 @@ describe('useRefreshContext', () => {
       selectedNamespace: 'test',
       objectPanel: {
         isOpen: true,
-        objectKind: 'Pod',
-        objectName: 'pod-1',
-        objectNamespace: 'test',
       },
     };
 

--- a/frontend/src/core/refresh/orchestrator.test.ts
+++ b/frontend/src/core/refresh/orchestrator.test.ts
@@ -1947,6 +1947,68 @@ describe('refreshOrchestrator', () => {
     expect(refreshManagerMocks.enableMock).not.toHaveBeenCalledWith(CLUSTER_REFRESHERS.browse);
   });
 
+  it('streams a workload-scoped pods window regardless of the active main view', async () => {
+    // The object panel's Pods tab leases a workload-scoped pods window while
+    // ANY main view is active. Gating its stream on the namespace pods view
+    // froze the tab: no doorbells -> the typed query never refetches -> rows
+    // stale + the metrics meta ages into "Awaiting metrics data...".
+    registerStreamingPodsDomain();
+    refreshOrchestrator.updateContext({
+      currentView: 'cluster',
+      activeClusterView: 'nodes',
+      selectedClusterId: 'cluster-a',
+      selectedClusterIds: ['cluster-a'],
+    });
+
+    const scope = buildClusterScope('cluster-a', 'workload:team-a:apps:v1:Deployment:web');
+    refreshOrchestrator.setScopedDomainEnabled('pods', scope, true);
+    await Promise.resolve();
+
+    expect(resourceStreamMocks.start).toHaveBeenCalledWith(scope);
+  });
+
+  it('streams a node-scoped pods window regardless of the active main view', async () => {
+    registerStreamingPodsDomain();
+    refreshOrchestrator.updateContext({
+      currentView: 'namespace',
+      activeNamespaceView: 'workloads',
+      selectedClusterId: 'cluster-a',
+      selectedClusterIds: ['cluster-a'],
+    });
+
+    const scope = buildClusterScope('cluster-a', 'node:node-1');
+    refreshOrchestrator.setScopedDomainEnabled('pods', scope, true);
+    await Promise.resolve();
+
+    expect(resourceStreamMocks.start).toHaveBeenCalledWith(scope);
+  });
+
+  it('keeps the view gate for namespace-shaped pods scopes', async () => {
+    registerStreamingPodsDomain();
+    refreshOrchestrator.updateContext({
+      currentView: 'cluster',
+      activeClusterView: 'nodes',
+      selectedClusterId: 'cluster-a',
+      selectedClusterIds: ['cluster-a'],
+    });
+
+    const scope = buildClusterScope('cluster-a', 'namespace:team-a');
+    refreshOrchestrator.setScopedDomainEnabled('pods', scope, true);
+    await Promise.resolve();
+
+    // Not looking at the namespace pods view: the big namespace scope stays polled-only.
+    expect(resourceStreamMocks.start).not.toHaveBeenCalledWith(scope);
+
+    // Switching to the namespace pods view starts it.
+    refreshOrchestrator.updateContext({
+      currentView: 'namespace',
+      activeNamespaceView: 'pods',
+    });
+    await Promise.resolve();
+
+    expect(resourceStreamMocks.start).toHaveBeenCalledWith(scope);
+  });
+
   it('does not start passive streaming while auto-refresh is disabled', async () => {
     registerStreamingClusterConfigDomain();
     refreshOrchestrator.updateContext({

--- a/frontend/src/core/refresh/orchestrator.test.ts
+++ b/frontend/src/core/refresh/orchestrator.test.ts
@@ -244,23 +244,13 @@ describe('refreshOrchestrator', () => {
     });
   };
 
-  it('normalizes object panel kind casing before updating refresh context', () => {
+  it('passes object panel context through to the refresh manager', () => {
     refreshOrchestrator.updateContext({
-      objectPanel: {
-        isOpen: true,
-        objectKind: 'Pod',
-        objectName: 'demo',
-        objectNamespace: 'default',
-      },
+      objectPanel: { isOpen: true },
     });
 
     expect(refreshManagerMocks.updateContextMock).toHaveBeenCalledWith({
-      objectPanel: {
-        isOpen: true,
-        objectKind: 'pod',
-        objectName: 'demo',
-        objectNamespace: 'default',
-      },
+      objectPanel: { isOpen: true },
     });
   });
 

--- a/frontend/src/core/refresh/orchestrator.ts
+++ b/frontend/src/core/refresh/orchestrator.ts
@@ -666,7 +666,7 @@ class RefreshOrchestrator {
     if (!isResourceStreamDomain(domain)) {
       return true;
     }
-    if (!isResourceStreamViewActive(domain, this.context)) {
+    if (!isResourceStreamViewActive(domain, this.context, trimmed)) {
       return false;
     }
     const parsed = parseClusterScopeList(trimmed);

--- a/frontend/src/core/refresh/orchestrator.ts
+++ b/frontend/src/core/refresh/orchestrator.ts
@@ -236,20 +236,11 @@ class RefreshOrchestrator {
 
   updateContext(context: Partial<RefreshContext>): void {
     const previousContext = this.context;
-    // Normalize object-panel kinds so case-only changes don't thrash refresh targets.
-    const normalizedContext: Partial<RefreshContext> = { ...context };
-    if (context.objectPanel) {
-      const normalizedPanel = { ...context.objectPanel };
-      if (typeof normalizedPanel.objectKind === 'string') {
-        normalizedPanel.objectKind = normalizedPanel.objectKind.toLowerCase();
-      }
-      normalizedContext.objectPanel = normalizedPanel;
-    }
-    this.context = { ...this.context, ...normalizedContext };
-    refreshManager.updateContext(normalizedContext);
+    this.context = { ...this.context, ...context };
+    refreshManager.updateContext(context);
 
-    if (Object.prototype.hasOwnProperty.call(normalizedContext, 'allConnectedClusterIds')) {
-      this.pruneRemovedClusterRuntimes(normalizedContext.allConnectedClusterIds ?? []);
+    if (Object.prototype.hasOwnProperty.call(context, 'allConnectedClusterIds')) {
+      this.pruneRemovedClusterRuntimes(context.allConnectedClusterIds ?? []);
     }
 
     const wasNamespaceActive = this.isNamespaceContextActive(previousContext);

--- a/frontend/src/core/refresh/resourceStreamViews.ts
+++ b/frontend/src/core/refresh/resourceStreamViews.ts
@@ -1,5 +1,6 @@
 import type { RefreshContext } from './RefreshManager';
 import type { RefreshDomain } from './types';
+import { stripClusterScope } from './clusterScope';
 
 export type ResourceStreamRefreshDomain =
   | 'pods'
@@ -42,15 +43,31 @@ export const isResourceStreamDomain = (
   domain: RefreshDomain
 ): domain is ResourceStreamRefreshDomain => RESOURCE_STREAM_DOMAINS.has(domain);
 
+// A pods scope shaped `workload:...` or `node:...` is an object-panel Pods-tab
+// window: those scopes exist only while a panel's Pods tab actively leases them
+// (the lease drops when the tab deactivates), and the panel is visible over ANY
+// main view. The per-view gate below exists to keep the BIG namespace-shaped
+// table scopes from streaming while nobody is looking at them; applying it to
+// panel windows froze the embedded Pods tab — no doorbells, so its query-backed
+// table never refetched and its metrics meta aged into the staleness banner.
+const isPanelPodsScope = (scope?: string): boolean => {
+  const base = stripClusterScope(scope);
+  return base.startsWith('workload:') || base.startsWith('node:');
+};
+
 export const isResourceStreamViewActive = (
   domain: RefreshDomain,
-  context: RefreshContext
+  context: RefreshContext,
+  scope?: string
 ): boolean => {
   if (!isResourceStreamDomain(domain)) {
     return true;
   }
 
   if (domain === 'pods') {
+    if (isPanelPodsScope(scope)) {
+      return true;
+    }
     return context.currentView === 'namespace' && context.activeNamespaceView === 'pods';
   }
 

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Events/EventsTab.test.tsx
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Events/EventsTab.test.tsx
@@ -154,10 +154,11 @@ describe('EventsTab', () => {
   let root: ReactDOM.Root;
   let EventsTab: React.FC<any>;
   let refreshOrchestrator: { setScopedDomainEnabled: any };
+  let refreshManagerMock: { register: any; unregister: any };
 
   beforeAll(async () => {
     ({ default: EventsTab } = await import('./EventsTab'));
-    ({ refreshOrchestrator } = await import('@/core/refresh'));
+    ({ refreshOrchestrator, refreshManager: refreshManagerMock } = await import('@/core/refresh'));
   });
 
   beforeEach(() => {
@@ -165,6 +166,8 @@ describe('EventsTab', () => {
     mockFindCatalogObjectByUID.mockReset();
     mockFetchScopedDomain.mockClear();
     refreshOrchestrator.setScopedDomainEnabled.mockClear();
+    refreshManagerMock.register.mockClear();
+    refreshManagerMock.unregister.mockClear();
     refreshWatcherState.onRefresh = null;
     autoRefreshLoadingState.isPaused = false;
     autoRefreshLoadingState.isManualRefreshActive = false;
@@ -194,6 +197,30 @@ describe('EventsTab', () => {
     clusterName: PARENT_CLUSTER_NAME,
   };
 
+  const PANEL_ID = `obj:${PARENT_CLUSTER_ID}:apps/v1/deployment:default:my-deploy`;
+
+  it('registers the events refresher under the panel-scoped name', async () => {
+    // Same-kind panels must not share an events refresher: a kind-only name
+    // let one panel's unmount unregister the other's refresher + subscribers.
+    hoistedSnapshot.data = { events: [] };
+    hoistedSnapshot.status = 'ready';
+
+    act(() => {
+      root.render(
+        <EventsTab
+          objectData={parentObjectData}
+          panelId={PANEL_ID}
+          isActive={true}
+          eventsScope="parent-cluster|default:apps/v1:Deployment:my-deploy"
+        />
+      );
+    });
+
+    expect(refreshManagerMock.register).toHaveBeenCalledWith(
+      expect.objectContaining({ name: `object-deployment:${PANEL_ID}-events` })
+    );
+  });
+
   it('defaults the visible Age column to newest-event sorting', async () => {
     hoistedSnapshot.data = {
       events: [makeEvent()],
@@ -204,6 +231,7 @@ describe('EventsTab', () => {
       root.render(
         <EventsTab
           objectData={parentObjectData}
+          panelId={PANEL_ID}
           isActive={true}
           eventsScope="parent-cluster|default:apps/v1:Deployment:my-deploy"
         />
@@ -225,6 +253,7 @@ describe('EventsTab', () => {
       root.render(
         <EventsTab
           objectData={parentObjectData}
+          panelId={PANEL_ID}
           isActive={true}
           eventsScope="parent-cluster|default:apps/v1:Deployment:my-deploy"
         />
@@ -262,6 +291,7 @@ describe('EventsTab', () => {
       root.render(
         <EventsTab
           objectData={parentObjectData}
+          panelId={PANEL_ID}
           isActive={true}
           eventsScope="parent-cluster|default:apps/v1:Deployment:my-deploy"
         />
@@ -299,6 +329,7 @@ describe('EventsTab', () => {
       root.render(
         <EventsTab
           objectData={parentObjectData}
+          panelId={PANEL_ID}
           isActive={true}
           eventsScope="parent-cluster|default:apps/v1:Deployment:my-deploy"
         />
@@ -317,6 +348,7 @@ describe('EventsTab', () => {
       root.render(
         <EventsTab
           objectData={parentObjectData}
+          panelId={PANEL_ID}
           isActive={true}
           eventsScope="parent-cluster|default:apps/v1:Deployment:my-deploy"
         />
@@ -351,7 +383,12 @@ describe('EventsTab', () => {
 
     act(() => {
       root.render(
-        <EventsTab objectData={parentObjectData} isActive={true} eventsScope={eventsScope} />
+        <EventsTab
+          objectData={parentObjectData}
+          panelId={PANEL_ID}
+          isActive={true}
+          eventsScope={eventsScope}
+        />
       );
     });
 
@@ -362,10 +399,17 @@ describe('EventsTab', () => {
     );
 
     refreshOrchestrator.setScopedDomainEnabled.mockClear();
+    refreshManagerMock.register.mockClear();
+    refreshManagerMock.unregister.mockClear();
 
     act(() => {
       root.render(
-        <EventsTab objectData={parentObjectData} isActive={false} eventsScope={eventsScope} />
+        <EventsTab
+          objectData={parentObjectData}
+          panelId={PANEL_ID}
+          isActive={false}
+          eventsScope={eventsScope}
+        />
       );
     });
 
@@ -388,6 +432,7 @@ describe('EventsTab', () => {
       root.render(
         <EventsTab
           objectData={parentObjectData}
+          panelId={PANEL_ID}
           isActive={true}
           eventsScope="parent-cluster|default:apps/v1:Deployment:my-deploy"
         />
@@ -410,6 +455,7 @@ describe('EventsTab', () => {
       root.render(
         <EventsTab
           objectData={parentObjectData}
+          panelId={PANEL_ID}
           isActive={true}
           eventsScope="parent-cluster|default:apps/v1:Deployment:my-deploy"
         />
@@ -453,6 +499,7 @@ describe('EventsTab', () => {
       root.render(
         <EventsTab
           objectData={parentObjectData}
+          panelId={PANEL_ID}
           isActive={true}
           eventsScope="parent-cluster|default:apps/v1:Deployment:my-deploy"
         />
@@ -506,6 +553,7 @@ describe('EventsTab', () => {
       root.render(
         <EventsTab
           objectData={parentObjectData}
+          panelId={PANEL_ID}
           isActive={true}
           eventsScope="parent-cluster|default:apps/v1:Deployment:my-deploy"
         />
@@ -550,6 +598,7 @@ describe('EventsTab', () => {
       root.render(
         <EventsTab
           objectData={parentObjectData}
+          panelId={PANEL_ID}
           isActive={true}
           eventsScope="parent-cluster|default:apps/v1:Deployment:my-deploy"
         />
@@ -599,6 +648,7 @@ describe('EventsTab', () => {
       root.render(
         <EventsTab
           objectData={parentObjectData}
+          panelId={PANEL_ID}
           isActive={true}
           eventsScope="parent-cluster|default:apps/v1:Deployment:my-deploy"
         />

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Events/EventsTab.tsx
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Events/EventsTab.tsx
@@ -29,7 +29,6 @@ import { applyPassiveLoadingPolicy } from '@/core/refresh/loadingPolicy';
 import { useRefreshScopedDomain } from '@/core/refresh/store';
 import { useStreamSignalRefetch } from '@/core/refresh/hooks/useStreamSignalRefetch';
 import { useRefreshWatcher } from '@/core/refresh/hooks/useRefreshWatcher';
-import type { ObjectEventsRefresherName } from '@/core/refresh/refresherTypes';
 import { useObjectPanel } from '@modules/object-panel/hooks/useObjectPanel';
 import { useNavigateToView } from '@shared/hooks/useNavigateToView';
 import {
@@ -44,7 +43,7 @@ import {
 } from '@shared/events/eventGridModel';
 import type { ResolvedObjectReference } from '@shared/utils/objectIdentity';
 import type { PanelObjectData } from '../types';
-import { CLUSTER_SCOPE, INACTIVE_SCOPE } from '../constants';
+import { CLUSTER_SCOPE, INACTIVE_SCOPE, getObjectEventsRefresherName } from '../constants';
 import { useObjectPanelScopedDomainLifecycle } from '../hooks/useObjectPanelScopedDomainLifecycle';
 import './EventsTab.css';
 
@@ -56,6 +55,10 @@ interface EventsTabProps {
   // ObjectPanelContent (which handles full-cleanup on panel close)
   // cannot drift apart on the same scope key.
   eventsScope: string | null;
+  // The panel's canonical identity (objectPanelId), scoping the events
+  // refresher name to THIS panel so simultaneously-open same-kind panels
+  // register distinct refreshers (see getObjectEventsRefresherName).
+  panelId: string | null;
 }
 
 function normalizeEventSource(source: ObjectEventSummary['source'] | undefined): string {
@@ -97,7 +100,7 @@ interface EventDisplay {
   clusterName?: string;
 }
 
-const EventsTab: React.FC<EventsTabProps> = ({ objectData, isActive, eventsScope }) => {
+const EventsTab: React.FC<EventsTabProps> = ({ objectData, isActive, eventsScope, panelId }) => {
   const { isPaused, isManualRefreshActive } = useAutoRefreshLoadingState();
   const { openWithObject } = useObjectPanel();
   const { navigateToView } = useNavigateToView();
@@ -150,11 +153,8 @@ const EventsTab: React.FC<EventsTabProps> = ({ objectData, isActive, eventsScope
   }, [fetchEvents, isActive, objectData, eventsScope]);
 
   const eventsRefresherName = useMemo(
-    () =>
-      objectData?.kind
-        ? (`object-${objectData.kind.toLowerCase()}-events` as ObjectEventsRefresherName)
-        : null,
-    [objectData?.kind]
+    () => getObjectEventsRefresherName(objectData?.kind, panelId),
+    [objectData?.kind, panelId]
   );
 
   useEffect(() => {

--- a/frontend/src/modules/object-panel/components/ObjectPanel/ObjectPanel.test.tsx
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/ObjectPanel.test.tsx
@@ -397,13 +397,16 @@ describe('ObjectPanel tab availability', () => {
     });
 
     const detailScope = buildClusterScope(defaultClusterId, 'team-a:/v1:pod:api');
+    // Refresher names are panel-scoped (kind + panelId) so simultaneously-open
+    // same-kind panels register distinct refreshers.
+    const refresherName = `object-pod:${buildPanelId(defaultClusterId, 'Pod', 'team-a', 'api')}`;
 
     expect(mockRefreshManager.register).toHaveBeenCalledWith(
-      expect.objectContaining({ name: 'object-pod', interval: 2000 })
+      expect.objectContaining({ name: refresherName, interval: 2000 })
     );
     expect(mockUseRefreshWatcher).toHaveBeenCalledWith(
       expect.objectContaining({
-        refresherName: 'object-pod',
+        refresherName,
         enabled: true,
       })
     );
@@ -423,7 +426,7 @@ describe('ObjectPanel tab availability', () => {
       ctx.root.unmount();
     });
 
-    expect(mockRefreshManager.unregister).toHaveBeenCalledWith('object-pod');
+    expect(mockRefreshManager.unregister).toHaveBeenCalledWith(refresherName);
     // Tier 1 responsiveness: unmount disables refreshing but preserves
     // the cached snapshot so a remount (cluster switch round-trip)
     // renders instantly. Eviction now lives in

--- a/frontend/src/modules/object-panel/components/ObjectPanel/ObjectPanel.tsx
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/ObjectPanel.tsx
@@ -147,6 +147,7 @@ function ObjectPanel({ panelId, objectRef }: ObjectPanelProps) {
     detailScope,
     objectKind,
     objectData,
+    panelId,
     isOpen: isOpen && isActiveTab,
     resourceDeleted,
   });

--- a/frontend/src/modules/object-panel/components/ObjectPanel/ObjectPanelContent.tsx
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/ObjectPanelContent.tsx
@@ -237,6 +237,7 @@ export function ObjectPanelContent({
             objectData={objectData}
             isActive={isPanelOpen && activeTab === 'events'}
             eventsScope={eventsScope}
+            panelId={panelId}
           />
         </ErrorBoundary>
       )}

--- a/frontend/src/modules/object-panel/components/ObjectPanel/constants.test.ts
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/constants.test.ts
@@ -9,17 +9,30 @@ import {
   INACTIVE_SCOPE,
   RESOURCE_CAPABILITIES,
   getObjectDetailsRefresherName,
+  getObjectEventsRefresherName,
 } from './constants';
 
+const PANEL_ID = 'obj:cluster-a:apps/v1/deployment:team-a:api';
+
 describe('ObjectPanel constants', () => {
-  it('generates refresher names in a case-insensitive manner', () => {
-    expect(getObjectDetailsRefresherName('Deployment')).toBe('object-deployment');
-    expect(getObjectDetailsRefresherName('customResource')).toBe('object-customresource');
+  it('scopes refresher names to the panel identity so same-kind panels never collide', () => {
+    expect(getObjectDetailsRefresherName('Deployment', PANEL_ID)).toBe(
+      `object-deployment:${PANEL_ID}`
+    );
+    expect(getObjectDetailsRefresherName('customResource', PANEL_ID)).toBe(
+      `object-customresource:${PANEL_ID}`
+    );
+    expect(getObjectEventsRefresherName('Deployment', PANEL_ID)).toBe(
+      `object-deployment:${PANEL_ID}-events`
+    );
   });
 
-  it('returns null when no kind is provided', () => {
-    expect(getObjectDetailsRefresherName(undefined)).toBeNull();
-    expect(getObjectDetailsRefresherName(null)).toBeNull();
+  it('returns null when the kind or panel id is missing', () => {
+    expect(getObjectDetailsRefresherName(undefined, PANEL_ID)).toBeNull();
+    expect(getObjectDetailsRefresherName(null, PANEL_ID)).toBeNull();
+    expect(getObjectDetailsRefresherName('Deployment', null)).toBeNull();
+    expect(getObjectEventsRefresherName(undefined, PANEL_ID)).toBeNull();
+    expect(getObjectEventsRefresherName('Deployment', null)).toBeNull();
   });
 
   it('defines capability presets for key resource kinds', () => {

--- a/frontend/src/modules/object-panel/components/ObjectPanel/constants.ts
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/constants.ts
@@ -3,7 +3,10 @@
  */
 
 import type { ResourceCapability } from './types';
-import type { ObjectDetailsRefresherName } from '@/core/refresh/refresherTypes';
+import type {
+  ObjectDetailsRefresherName,
+  ObjectEventsRefresherName,
+} from '@/core/refresh/refresherTypes';
 
 export const CLUSTER_SCOPE = '__cluster__';
 export const INACTIVE_SCOPE = '__inactive__';
@@ -63,13 +66,32 @@ export const RESOURCE_CAPABILITIES: Record<string, ResourceCapability> = {
   helmrelease: { delete: true },
 };
 
+// Object-panel refresher names are scoped to the PANEL, not just the kind: the
+// dockable multi-panel model mounts one ObjectPanel per open object, and a
+// kind-only name made simultaneously-open same-kind panels register the same
+// refresher — the second registration replaced the first and either panel's
+// unmount unregistered the survivor's refresher and subscribers, silently
+// freezing its auto-refresh. panelId is the canonical full object identity
+// (objectPanelId: clusterId + group/version/kind + namespace + name), so the
+// name also carries the clusterId the object-reference rules require.
 export const getObjectDetailsRefresherName = (
-  kind?: string | null
+  kind?: string | null,
+  panelId?: string | null
 ): ObjectDetailsRefresherName | null => {
-  if (!kind) {
+  if (!kind || !panelId) {
     return null;
   }
-  return `object-${kind.toLowerCase()}` as ObjectDetailsRefresherName;
+  return `object-${kind.toLowerCase()}:${panelId}` as ObjectDetailsRefresherName;
+};
+
+export const getObjectEventsRefresherName = (
+  kind?: string | null,
+  panelId?: string | null
+): ObjectEventsRefresherName | null => {
+  if (!kind || !panelId) {
+    return null;
+  }
+  return `object-${kind.toLowerCase()}:${panelId}-events` as ObjectEventsRefresherName;
 };
 
 export const TABS = {

--- a/frontend/src/modules/object-panel/components/ObjectPanel/hooks/useObjectPanelRefresh.test.tsx
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/hooks/useObjectPanelRefresh.test.tsx
@@ -68,6 +68,9 @@ describe('useObjectPanelRefresh', () => {
     namespace: 'team-a',
   };
 
+  const basePanelId = 'obj:cluster-a:apps/v1/deployment:team-a:api';
+  const expectedRefresherName = `object-deployment:${basePanelId}`;
+
   const renderHook = async (
     override: Partial<Parameters<typeof useObjectPanelRefresh>[0]> = {}
   ) => {
@@ -76,6 +79,7 @@ describe('useObjectPanelRefresh', () => {
         detailScope: 'cluster-a|team-a:apps/v1:deployment:api',
         objectKind: 'deployment',
         objectData: baseObjectData,
+        panelId: basePanelId,
         isOpen: true,
         resourceDeleted: false,
         ...override,
@@ -143,10 +147,10 @@ describe('useObjectPanelRefresh', () => {
     await renderHook();
 
     expect(mockRefreshManager.register).toHaveBeenCalledWith(
-      expect.objectContaining({ name: 'object-deployment', interval: 5000 })
+      expect.objectContaining({ name: expectedRefresherName, interval: 5000 })
     );
     expect(mockUseRefreshWatcher).toHaveBeenCalledWith(
-      expect.objectContaining({ refresherName: 'object-deployment', enabled: true })
+      expect.objectContaining({ refresherName: expectedRefresherName, enabled: true })
     );
     expect(mockRefreshOrchestrator.setScopedDomainEnabled).toHaveBeenCalledWith(
       'object-details',
@@ -169,7 +173,7 @@ describe('useObjectPanelRefresh', () => {
       root.unmount();
     });
 
-    expect(mockRefreshManager.unregister).toHaveBeenCalledWith('object-deployment');
+    expect(mockRefreshManager.unregister).toHaveBeenCalledWith(expectedRefresherName);
     // Tier 1 responsiveness: stop refreshing this scope but keep the
     // cached snapshot in place. The cache is only freed via
     // ObjectPanelStateContext.closePanel when the user actually closes
@@ -216,5 +220,61 @@ describe('useObjectPanelRefresh', () => {
 
     expect(getResult().detailsLoading).toBe(false);
     expect(mockRefreshOrchestrator.fetchScopedDomain).not.toHaveBeenCalled();
+  });
+
+  it('registers a distinct refresher per panel so same-kind panels never clobber each other', async () => {
+    // Two simultaneously-open Deployment panels (the dockable multi-panel
+    // model mounts one ObjectPanel per open object). With a kind-only
+    // refresher name the second registration replaced the first and either
+    // panel's unmount unregistered the survivor's refresher + subscribers.
+    const otherPanelId = 'obj:cluster-a:apps/v1/deployment:team-a:web';
+    // Stable per-panel objectData, mirroring production where the panel ref
+    // identity does not change across renders.
+    const panelObjects: Record<string, PanelObjectData> = {
+      api: { ...baseObjectData, name: 'api' },
+      web: { ...baseObjectData, name: 'web' },
+    };
+    const PanelHarness: React.FC<{ panelId: string; name: string }> = ({ panelId, name }) => {
+      useObjectPanelRefresh({
+        detailScope: `cluster-a|team-a:apps/v1:deployment:${name}`,
+        objectKind: 'deployment',
+        objectData: panelObjects[name],
+        panelId,
+        isOpen: true,
+        resourceDeleted: false,
+      });
+      return null;
+    };
+
+    await act(async () => {
+      root.render(
+        <>
+          <PanelHarness key="api" panelId={basePanelId} name="api" />
+          <PanelHarness key="web" panelId={otherPanelId} name="web" />
+        </>
+      );
+      await Promise.resolve();
+    });
+
+    const registeredNames = mockRefreshManager.register.mock.calls.map(
+      (call) => (call[0] as { name: string }).name
+    );
+    expect(registeredNames).toContain(`object-deployment:${basePanelId}`);
+    expect(registeredNames).toContain(`object-deployment:${otherPanelId}`);
+    expect(new Set(registeredNames).size).toBe(registeredNames.length);
+
+    // Unmounting one panel must only unregister ITS refresher.
+    await act(async () => {
+      root.render(
+        <>
+          <PanelHarness key="api" panelId={basePanelId} name="api" />
+        </>
+      );
+      await Promise.resolve();
+    });
+    expect(mockRefreshManager.unregister).toHaveBeenCalledWith(`object-deployment:${otherPanelId}`);
+    expect(mockRefreshManager.unregister).not.toHaveBeenCalledWith(
+      `object-deployment:${basePanelId}`
+    );
   });
 });

--- a/frontend/src/modules/object-panel/components/ObjectPanel/hooks/useObjectPanelRefresh.ts
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/hooks/useObjectPanelRefresh.ts
@@ -22,6 +22,12 @@ interface UseObjectPanelRefreshArgs {
   detailScope: string | null;
   objectKind: string | null;
   objectData: PanelObjectData | null;
+  /**
+   * The panel's canonical identity (objectPanelId). Scopes the refresher name
+   * to THIS panel so simultaneously-open same-kind panels register distinct
+   * refreshers instead of clobbering each other's registration/subscribers.
+   */
+  panelId: string | null;
   isOpen: boolean;
   resourceDeleted: boolean;
 }
@@ -43,6 +49,7 @@ export const useObjectPanelRefresh = ({
   detailScope,
   objectKind,
   objectData,
+  panelId,
   isOpen,
   resourceDeleted,
 }: UseObjectPanelRefreshArgs): ObjectPanelRefreshResult => {
@@ -103,8 +110,8 @@ export const useObjectPanelRefresh = ({
   });
 
   const detailRefresherName = useMemo(
-    () => getObjectDetailsRefresherName(objectKind),
-    [objectKind]
+    () => getObjectDetailsRefresherName(objectKind, panelId),
+    [objectKind, panelId]
   );
 
   useEffect(() => {

--- a/wails.json
+++ b/wails.json
@@ -16,7 +16,7 @@
     "description": "Luxury Yacht is a desktop app for managing Kubernetes clusters. Sail the seas of Kubernetes in style!",
     "companyName": "Luxury Yacht",
     "productName": "Luxury Yacht",
-    "productVersion": "v1.10.0",
+    "productVersion": "v1.10.1",
     "betaExpiryDays": 30
   }
 }


### PR DESCRIPTION
- The Pods tab for a Deployment or ReplicaSet could show "No pods found" due to a race condition involving the deployment's replicaset. Pod ownership is now re-resolved if the ReplicaSet arrives after the pods, so the tab fills in correctly.
- With several panels of the same kind open at once (for example two Deployments), closing one could silently stop the other's Details and Events from auto-refreshing. Each panel now tracks its refresh independently.
- The Pods tab inside an object panel only received live updates while the app's main view was that namespace's Pods view — on any other view it froze after the first load, eventually showing "Awaiting metrics data...". The panel's pod list now streams updates regardless of which main view is active.
