### PR TITLE
Cleanup work

### DIFF
--- a/backend/app_refresh_spill.go
+++ b/backend/app_refresh_spill.go
@@ -26,11 +26,11 @@ func (a *App) spillRootDir() (string, error) {
 	if a.spillRoot != "" {
 		return a.spillRoot, nil
 	}
-	cacheDir, err := os.UserCacheDir()
+	base, err := a.cacheDirPath()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(cacheDir, "luxury-yacht", "spill"), nil
+	return filepath.Join(base, "spill"), nil
 }
 
 // clusterSpillDir is the per-cluster spill directory. The clusterID is hashed so an

--- a/backend/app_settings.go
+++ b/backend/app_settings.go
@@ -512,6 +512,19 @@ func (a *App) getSettingsFilePath() (string, error) {
 	return filepath.Join(configDir, "settings.json"), nil
 }
 
+// cacheDirPath returns the app's cache directory (<UserCacheDir>/luxury-yacht):
+// the single home for transient on-disk caches (API discovery, maintained-store
+// spill, diagnostic dumps). It is the cache-tier sibling of the config dir and
+// the one place that defines the cache base, so Factory Reset can clear the
+// whole subtree in one call.
+func (a *App) cacheDirPath() (string, error) {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("could not find cache directory: %w", err)
+	}
+	return filepath.Join(cacheDir, "luxury-yacht"), nil
+}
+
 // loadSettingsFile reads settings.json or returns defaults when missing.
 func (a *App) loadSettingsFile() (*settingsFile, error) {
 	configFile, err := a.getSettingsFilePath()
@@ -847,6 +860,20 @@ func (a *App) ClearAppState() error {
 		persistenceFile, err := a.getPersistenceFilePath()
 		if err == nil {
 			if err := removeFileIfExists(persistenceFile); err != nil {
+				errs = append(errs, err)
+			}
+		} else {
+			errs = append(errs, err)
+		}
+
+		// Clear the transient cache subtree (discovery, spill, diagnostics) so a
+		// Factory Reset restores true fresh-install state, not just deleted config
+		// files. clearKubeconfigSelection above already tore down the refresh
+		// subsystem and disconnected every cluster, so no cache writer is active
+		// here; RemoveAll is a no-op when the tree is already absent.
+		cacheDir, err := a.cacheDirPath()
+		if err == nil {
+			if err := os.RemoveAll(cacheDir); err != nil {
 				errs = append(errs, err)
 			}
 		} else {

--- a/backend/app_settings_test.go
+++ b/backend/app_settings_test.go
@@ -29,7 +29,40 @@ func setTestConfigEnv(t *testing.T) {
 	baseDir := t.TempDir()
 	t.Setenv("HOME", baseDir)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(baseDir, ".config"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(baseDir, ".cache"))
 	t.Setenv("APPDATA", filepath.Join(baseDir, "AppData", "Roaming"))
+}
+
+func TestClearAppStateRemovesCacheDir(t *testing.T) {
+	setTestConfigEnv(t)
+	app := newTestAppWithDefaults(t)
+	app.Ctx = context.Background()
+
+	// The app cache dir lives under the user cache dir (redirected into a temp
+	// dir by setTestConfigEnv). Seed the subdirs the three cache subsystems use
+	// so we can prove Factory Reset removes cached data, not just config files.
+	cacheBase, err := os.UserCacheDir()
+	require.NoError(t, err)
+	cacheDir := filepath.Join(cacheBase, "luxury-yacht")
+	for _, sub := range []string{"discovery", "spill", "diagnostics"} {
+		dir := filepath.Join(cacheDir, sub)
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "cached"), []byte("x"), 0o644))
+	}
+
+	// A sibling under the user cache dir must be left untouched — Factory Reset
+	// only clears this app's cache subtree.
+	sibling := filepath.Join(cacheBase, "other-app")
+	require.NoError(t, os.MkdirAll(sibling, 0o755))
+
+	require.NoError(t, app.ClearAppState())
+
+	_, statErr := os.Stat(cacheDir)
+	require.Truef(t, os.IsNotExist(statErr),
+		"expected app cache dir %q to be removed, stat err=%v", cacheDir, statErr)
+
+	_, siblingErr := os.Stat(sibling)
+	require.NoError(t, siblingErr, "unrelated sibling cache dir must be preserved")
 }
 
 func TestAppLoadWindowSettingsDefaultWhenMissing(t *testing.T) {

--- a/backend/app_update.go
+++ b/backend/app_update.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -19,26 +20,34 @@ import (
 )
 
 const (
-	updateRepoReleaseURL = "https://api.github.com/repos/luxury-yacht/app/releases/latest"
+	updateRepoAPIBase    = "https://api.github.com/repos/luxury-yacht/app"
+	updateRepoReleaseURL = updateRepoAPIBase + "/releases/latest"
 	updateDownloadsURL   = "https://luxury-yacht.app/#downloads"
 	updateUserAgent      = "LuxuryYachtUpdateCheck/1.0"
 )
 
 type UpdateInfo struct {
-	CurrentVersion    string `json:"currentVersion"`
-	LatestVersion     string `json:"latestVersion"`
-	ReleaseURL        string `json:"releaseUrl"`
-	ReleaseName       string `json:"releaseName,omitempty"`
-	PublishedAt       string `json:"publishedAt,omitempty"`
-	CheckedAt         string `json:"checkedAt,omitempty"`
-	IsUpdateAvailable bool   `json:"isUpdateAvailable"`
-	Error             string `json:"error,omitempty"`
+	CurrentVersion string `json:"currentVersion"`
+	LatestVersion  string `json:"latestVersion"`
+	ReleaseURL     string `json:"releaseUrl"`
+	ReleaseName    string `json:"releaseName,omitempty"`
+	PublishedAt    string `json:"publishedAt,omitempty"`
+	// CurrentPublishedAt is the release date of the currently-installed version,
+	// fetched separately by tag (the latest-release response only covers New).
+	CurrentPublishedAt string `json:"currentPublishedAt,omitempty"`
+	CheckedAt          string `json:"checkedAt,omitempty"`
+	IsUpdateAvailable  bool   `json:"isUpdateAvailable"`
+	// ReleaseNotes is the raw release body (markdown) shown as a preview in the
+	// update chip's tooltip; the full rendered notes live at the release tag page.
+	ReleaseNotes string `json:"releaseNotes,omitempty"`
+	Error        string `json:"error,omitempty"`
 }
 
 type githubRelease struct {
 	TagName     string `json:"tag_name"`
 	Name        string `json:"name"`
 	PublishedAt string `json:"published_at"`
+	Body        string `json:"body"`
 }
 
 func (a *App) startUpdateCheck() {
@@ -63,30 +72,79 @@ func (a *App) runUpdateCheck(currentVersion string) {
 		return
 	}
 
+	checkedAt := time.Now().Format(time.RFC3339)
 	release, err := fetchLatestRelease()
-	info := &UpdateInfo{
-		CurrentVersion: currentVersion,
-		CheckedAt:      time.Now().Format(time.RFC3339),
-	}
 	if err != nil {
-		info.Error = err.Error()
-		a.storeUpdateInfo(info)
+		a.storeUpdateInfo(&UpdateInfo{
+			CurrentVersion: currentVersion,
+			CheckedAt:      checkedAt,
+			Error:          err.Error(),
+		})
 		return
 	}
 
-	info.LatestVersion = release.TagName
-	info.ReleaseURL = updateDownloadsURL
-	info.ReleaseName = release.Name
-	info.PublishedAt = release.PublishedAt
+	info := buildReleaseUpdateInfo(currentVersion, checkedAt, release)
+	// The tooltip shows the current version's release date next to the new one.
+	// That date lives in a separate release resource, so fetch it by tag — but
+	// only when an update is available (the only time the tooltip shows), and
+	// never let its absence fail the whole check.
+	if info.IsUpdateAvailable {
+		if currentTag := releaseTagForVersion(currentVersion, release.TagName); currentTag != "" {
+			currentRelease, tagErr := fetchReleaseByTag(currentTag)
+			if tagErr != nil {
+				a.logger.Warn(
+					fmt.Sprintf("update check: could not fetch current release %q: %v", currentTag, tagErr),
+					logsources.UpdateCheck,
+				)
+			} else {
+				info.CurrentPublishedAt = currentRelease.PublishedAt
+			}
+		}
+	}
+	a.storeUpdateInfo(info)
+}
+
+// releaseTagForVersion derives the GitHub tag for a version, matching the prefix
+// convention of a reference tag (the latest release's tag). The build Version
+// format is not guaranteed, so the reference tag is the source of truth: a
+// "v"-prefixed repo yields "vX.Y.Z", a bare repo yields "X.Y.Z". Empty when the
+// version has no usable digits.
+func releaseTagForVersion(version, referenceTag string) string {
+	normalized := strings.TrimSpace(version)
+	normalized = strings.TrimPrefix(normalized, "v")
+	normalized = strings.TrimPrefix(normalized, "V")
+	if normalized == "" {
+		return ""
+	}
+	ref := strings.TrimSpace(referenceTag)
+	if strings.HasPrefix(ref, "v") || strings.HasPrefix(ref, "V") {
+		return "v" + normalized
+	}
+	return normalized
+}
+
+// buildReleaseUpdateInfo maps a fetched GitHub release onto the UpdateInfo the
+// frontend consumes, including the release notes body. Kept pure (no network,
+// no App) so the mapping — especially the release-notes wiring and the
+// update-available comparison — is unit-testable.
+func buildReleaseUpdateInfo(currentVersion, checkedAt string, release *githubRelease) *UpdateInfo {
+	info := &UpdateInfo{
+		CurrentVersion: currentVersion,
+		CheckedAt:      checkedAt,
+		LatestVersion:  release.TagName,
+		ReleaseURL:     updateDownloadsURL,
+		ReleaseName:    release.Name,
+		PublishedAt:    release.PublishedAt,
+		ReleaseNotes:   release.Body,
+	}
 
 	compare, compareErr := compareVersions(currentVersion, release.TagName)
 	if compareErr != nil {
 		info.Error = compareErr.Error()
-		a.storeUpdateInfo(info)
-		return
+		return info
 	}
 	info.IsUpdateAvailable = compare < 0
-	a.storeUpdateInfo(info)
+	return info
 }
 
 func (a *App) storeUpdateInfo(info *UpdateInfo) {
@@ -117,8 +175,17 @@ func (a *App) getUpdateInfo() *UpdateInfo {
 }
 
 func fetchLatestRelease() (*githubRelease, error) {
+	return fetchRelease(updateRepoReleaseURL)
+}
+
+// fetchReleaseByTag fetches a specific release by its git tag.
+func fetchReleaseByTag(tag string) (*githubRelease, error) {
+	return fetchRelease(updateRepoAPIBase + "/releases/tags/" + url.PathEscape(tag))
+}
+
+func fetchRelease(releaseURL string) (*githubRelease, error) {
 	client := &http.Client{Timeout: config.AppUpdateRequestTimeout}
-	req, err := http.NewRequest(http.MethodGet, updateRepoReleaseURL, nil)
+	req, err := http.NewRequest(http.MethodGet, releaseURL, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/app_update_test.go
+++ b/backend/app_update_test.go
@@ -53,3 +53,74 @@ func TestIsDevVersion(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildReleaseUpdateInfo(t *testing.T) {
+	release := &githubRelease{
+		TagName:     "v1.10.1",
+		Name:        "Luxury Yacht 1.10.1",
+		PublishedAt: "2026-07-05T00:00:00Z",
+		Body:        "- Fixed metrics permission notice\n- Moved the update chip",
+	}
+
+	info := buildReleaseUpdateInfo("1.10.0", "2026-07-05T12:00:00Z", release)
+
+	// The release body carries the notes shown in the tooltip — the whole point
+	// of this change; it must be mapped through, not discarded.
+	if info.ReleaseNotes != release.Body {
+		t.Fatalf("ReleaseNotes = %q, want %q", info.ReleaseNotes, release.Body)
+	}
+	if info.LatestVersion != "v1.10.1" {
+		t.Fatalf("LatestVersion = %q, want v1.10.1", info.LatestVersion)
+	}
+	if info.ReleaseName != "Luxury Yacht 1.10.1" {
+		t.Fatalf("ReleaseName = %q", info.ReleaseName)
+	}
+	if info.PublishedAt != "2026-07-05T00:00:00Z" {
+		t.Fatalf("PublishedAt = %q", info.PublishedAt)
+	}
+	if !info.IsUpdateAvailable {
+		t.Fatalf("expected IsUpdateAvailable for 1.10.0 -> v1.10.1")
+	}
+
+	// Same version: no update, notes still mapped.
+	same := buildReleaseUpdateInfo("1.10.1", "2026-07-05T12:00:00Z", release)
+	if same.IsUpdateAvailable {
+		t.Fatalf("expected no update when current == latest")
+	}
+	if same.ReleaseNotes != release.Body {
+		t.Fatalf("ReleaseNotes should map even when up to date")
+	}
+
+	// The New-version release date must map through for the tooltip's
+	// "New: <version> released <date>" row.
+	if info.PublishedAt != release.PublishedAt {
+		t.Fatalf("PublishedAt = %q, want %q", info.PublishedAt, release.PublishedAt)
+	}
+}
+
+func TestReleaseTagForVersion(t *testing.T) {
+	cases := []struct {
+		version      string
+		referenceTag string
+		want         string
+	}{
+		// The reference tag is v-prefixed → the current tag must be too, even when
+		// the build Version has no prefix.
+		{"1.10.0", "v1.10.1", "v1.10.0"},
+		{"v1.10.0", "v1.10.1", "v1.10.0"},
+		{" V1.10.0 ", "v1.10.1", "v1.10.0"},
+		// Bare reference tag → bare current tag.
+		{"1.10.0", "1.10.1", "1.10.0"},
+		{"v1.10.0", "1.10.1", "1.10.0"},
+		// No usable version → empty (caller skips the fetch).
+		{"", "v1.10.1", ""},
+		{"v", "v1.10.1", ""},
+	}
+
+	for _, tc := range cases {
+		if got := releaseTagForVersion(tc.version, tc.referenceTag); got != tc.want {
+			t.Fatalf("releaseTagForVersion(%q, %q) = %q, want %q",
+				tc.version, tc.referenceTag, got, tc.want)
+		}
+	}
+}

--- a/backend/refresh/domainpermissions/spec.go
+++ b/backend/refresh/domainpermissions/spec.go
@@ -440,7 +440,7 @@ var policySpecs = []policySpec{
 		// domain failing outright.
 		Domain: "cluster-overview",
 		Mode:   ModeAny,
-		Reason: "cluster overview requires nodes, pods, or namespaces",
+		Reason: "Cluster Overview requires list and watch on nodes, pods, and namespaces",
 		Runtime: []Resource{
 			fromIdentity(nodes.Identity),
 			fromIdentity(pods.Identity),

--- a/backend/refresh/metrics/disabled.go
+++ b/backend/refresh/metrics/disabled.go
@@ -59,5 +59,6 @@ func (p *DisabledPoller) Metadata() Metadata {
 		LastError:           message,
 		SuccessCount:        0,
 		FailureCount:        0,
+		Disabled:            true,
 	}
 }

--- a/backend/refresh/metrics/poller.go
+++ b/backend/refresh/metrics/poller.go
@@ -47,6 +47,12 @@ type Metadata struct {
 	LastError           string
 	SuccessCount        uint64
 	FailureCount        uint64
+	// Disabled marks a terminal "metrics will never be collected" state (metrics
+	// API forbidden, or metrics-server absent) as distinct from a real poller
+	// whose first collection has simply not completed yet. LastError then holds a
+	// permanent, UI-ready reason that must not be treated as a transient
+	// pre-first-poll error.
+	Disabled bool
 }
 
 var (

--- a/backend/refresh/metrics/poller_test.go
+++ b/backend/refresh/metrics/poller_test.go
@@ -399,9 +399,13 @@ func TestDisabledPollerMetadata(t *testing.T) {
 	require.Equal(t, "metrics polling disabled", meta.LastError)
 	require.Zero(t, meta.FailureCount)
 	require.Zero(t, meta.SuccessCount)
+	// Disabled marks this as a terminal state (not a pre-first-poll window) so the
+	// serve-time grace period never clears LastError.
+	require.True(t, meta.Disabled)
 
 	custom := NewDisabledPoller(nil, "cluster has no metrics API")
 	require.Equal(t, "cluster has no metrics API", custom.Metadata().LastError)
+	require.True(t, custom.Metadata().Disabled)
 }
 
 // Scoped clusters (docs/plans/namespace-scope.md): pod metrics are listed per

--- a/backend/refresh/snapshot/cluster_overview.go
+++ b/backend/refresh/snapshot/cluster_overview.go
@@ -114,6 +114,9 @@ type ClusterOverviewMetrics struct {
 	ConsecutiveFailures int    `json:"consecutiveFailures,omitempty"`
 	SuccessCount        uint64 `json:"successCount"`
 	FailureCount        uint64 `json:"failureCount"`
+	// Disabled marks a terminal "metrics unavailable" state (forbidden, or
+	// metrics-server absent); LastError then carries the permanent reason.
+	Disabled bool `json:"disabled,omitempty"`
 }
 
 // ClusterOverviewPayload mirrors the data needed by the frontend overview cards.
@@ -605,8 +608,11 @@ func buildClusterOverviewSnapshot(
 		meta := provider.Metadata()
 		lastError := meta.LastError
 
-		// Grace period: avoid surfacing a metrics error before any successful poll has completed.
-		if meta.SuccessCount == 0 && meta.CollectedAt.IsZero() && meta.ConsecutiveFailures < 5 {
+		// Grace period: avoid surfacing a metrics error before any successful poll
+		// has completed. A disabled poller is exempt — its LastError is a permanent
+		// reason (forbidden / metrics-server absent), not a transient pre-first-poll
+		// error, so clearing it would strand the UI on "Collecting metrics…".
+		if !meta.Disabled && meta.SuccessCount == 0 && meta.CollectedAt.IsZero() && meta.ConsecutiveFailures < 5 {
 			lastError = ""
 		}
 
@@ -621,6 +627,7 @@ func buildClusterOverviewSnapshot(
 			ConsecutiveFailures: meta.ConsecutiveFailures,
 			SuccessCount:        meta.SuccessCount,
 			FailureCount:        meta.FailureCount,
+			Disabled:            meta.Disabled,
 		}
 		// Zero time must serve as 0/omitted — Unix() of Go's zero time is
 		// -62135596800, which reads as a PRESENT timestamp downstream and

--- a/backend/refresh/snapshot/cluster_overview_test.go
+++ b/backend/refresh/snapshot/cluster_overview_test.go
@@ -1037,3 +1037,32 @@ func TestClusterOverviewSurfacesRepeatedMetricsErrors(t *testing.T) {
 	require.Equal(t, uint64(5), payload.Metrics.FailureCount)
 	require.Equal(t, uint64(0), payload.Metrics.SuccessCount)
 }
+
+func TestClusterOverviewSurfacesDisabledMetricsReason(t *testing.T) {
+	// A DisabledPoller (metrics API forbidden, or metrics-server absent) reports
+	// the SAME counters as the pristine pre-first-poll window: SuccessCount 0, no
+	// failures, zero CollectedAt. Those trip the grace period, which would clear
+	// its LastError and strand the UI on "Collecting metrics…" forever. The
+	// Disabled flag must exempt it so the permanent reason reaches the payload.
+	builder := &ClusterOverviewBuilder{
+		ingest:          newFakePodAggregateSource(nil).withNodes(ClusterMeta{}, ""),
+		namespaceLister: testsupport.NewNamespaceLister(t),
+		metrics: fakeClusterMetrics{
+			meta: metrics.Metadata{
+				Disabled:            true,
+				LastError:           "Insufficient permissions for Metrics API",
+				FailureCount:        0,
+				ConsecutiveFailures: 0,
+				SuccessCount:        0,
+			},
+		},
+	}
+
+	snapshot, err := builder.Build(context.Background(), "")
+	require.NoError(t, err)
+
+	payload, ok := snapshot.Payload.(ClusterOverviewSnapshot)
+	require.True(t, ok)
+	require.Equal(t, "Insufficient permissions for Metrics API", payload.Metrics.LastError)
+	require.True(t, payload.Metrics.Disabled)
+}

--- a/docs/release/pending.md
+++ b/docs/release/pending.md
@@ -1,5 +1,8 @@
-### Fixed
+### Added
 
-- The Pods tab for a Deployment or ReplicaSet could show "No pods found" due to a race condition involving the deployment's replicaset. Pod ownership is now re-resolved if the ReplicaSet arrives after the pods, so the tab fills in correctly.
-- With several panels of the same kind open at once (for example two Deployments), closing one could silently stop the other's Details and Events from auto-refreshing. Each panel now tracks its refresh independently.
-- The Pods tab inside an object panel only received live updates while the app's main view was that namespace's Pods view — on any other view it froze after the first load, eventually showing "Awaiting metrics data...". The panel's pod list now streams updates regardless of which main view is active.
+### Changed
+
+- Factory Reset now clears the app's on-disk cache, so it restores a true fresh-install state instead of leaving cached data behind.
+- Better presentation of Cluster Overview permissions restrictions.
+
+### Fixed

--- a/docs/release/pending.md
+++ b/docs/release/pending.md
@@ -1,8 +1,5 @@
-### Added
-
 ### Changed
 
 - Factory Reset now clears the app's on-disk cache, so it restores a true fresh-install state instead of leaving cached data behind.
 - Better presentation of Cluster Overview permissions restrictions.
-
-### Fixed
+- Update notification moved into the app header for persistent visibility, and now shows release notes for the new version.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -82,6 +82,7 @@ Applies to React/TypeScript code under `frontend/`.
 - All form labels for inputs must have the exact same spacing unless told otherwise.
 - Favor reusing shared styles in `frontend/styles` (the `@styles` alias); otherwise keep CSS close to the source (for example `ContextMenu.tsx` → `ContextMenu.css`).
 - Always tokenize sizes/colors with shared tokens in `frontend/styles/tokens`; colors must support Light and Dark themes.
+- Reuse an existing theme variable whenever one fits, instead of computing colors inline (no ad-hoc `color-mix`/hex) or defining a new one. Semantic theme vars (for example `--color-warning-bg`, `--color-warning-border`) live in `frontend/styles/appearance-modes/{light,dark}.css` and already track Light/Dark. Only add a new token when no existing var fits, and define it in both appearance modes.
 
 ## Project Structure & Module Organization
 

--- a/frontend/src/core/refresh/types.ts
+++ b/frontend/src/core/refresh/types.ts
@@ -252,6 +252,9 @@ export interface ClusterOverviewMetrics {
   consecutiveFailures?: number;
   successCount: number;
   failureCount: number;
+  // Terminal "metrics unavailable" state (metrics API forbidden, or
+  // metrics-server absent); lastError then carries the permanent reason.
+  disabled?: boolean;
 }
 
 export interface WorkloadTypeResourceUsage {

--- a/frontend/src/modules/cluster/components/ClusterOverview.css
+++ b/frontend/src/modules/cluster/components/ClusterOverview.css
@@ -53,51 +53,6 @@
   -webkit-user-select: none;
 }
 
-.overview-update-banner-wrap {
-  display: flex;
-  justify-content: center;
-  margin-bottom: 1rem;
-}
-
-.overview-update-banner {
-  appearance: none;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: center;
-  gap: 0.75rem 1rem;
-  padding: 0.75rem 1rem;
-  margin: 0;
-  background: var(--color-bg-secondary);
-  border: 1px solid var(--color-border);
-  border-radius: var(--border-radius-lg);
-  cursor: pointer;
-  font: inherit;
-  color: inherit;
-}
-
-.overview-update-text {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.35rem;
-  text-align: center;
-}
-
-.overview-update-title {
-  font-weight: 600;
-  color: var(--color-text);
-}
-
-.overview-update-meta {
-  color: var(--color-accent);
-  font-size: 1rem;
-}
-
-.overview-update-banner:hover .overview-update-meta {
-  text-decoration: underline;
-}
-
 .overview-header {
   display: flex;
   flex-direction: column;

--- a/frontend/src/modules/cluster/components/ClusterOverview.css
+++ b/frontend/src/modules/cluster/components/ClusterOverview.css
@@ -763,10 +763,12 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.5rem;
-  color: var(--color-text-secondary);
   text-align: center;
-  max-width: 420px;
+  border: 1px solid var(--metrics-banner-border);
+  border-radius: var(--border-radius-lg);
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+  background: var(--metrics-banner-bg);
 }
 
 .cluster-overview-error .error-icon {
@@ -774,9 +776,8 @@
 }
 
 .cluster-overview-error .error-detail {
-  font-size: 0.85rem;
-  color: var(--color-error);
-  margin-top: 0.5rem;
+  font-size: var(--font-size-normal);
+  /* color: var(--color-error); */
 }
 
 .cluster-overview-loading-inline {

--- a/frontend/src/modules/cluster/components/ClusterOverview.css
+++ b/frontend/src/modules/cluster/components/ClusterOverview.css
@@ -223,11 +223,12 @@
   margin-bottom: 0;
 }
 
-/* Compact header indicators (metrics state, permission gaps): small muted
-   text with a status dot, truncating long messages (the title tooltip
-   carries the full text). */
-.overview-section-header .metrics-warning-banner,
-.overview-section-header .overview-permission-chip {
+/* Compact header indicator (metrics collection state): small muted text with a
+   status dot, truncating long messages (the title tooltip carries the full
+   text). Access restrictions are NOT shown here — they render in the
+   .overview-restriction callout below the header so their reasons stay fully
+   readable. */
+.overview-section-header .metrics-warning-banner {
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
@@ -627,20 +628,56 @@
   padding: 2rem 0;
 }
 
-/* Permission-gated data (issue #244): each affected card explains its own
-   gap in place — a compact header chip for derived values (capacity,
-   requests/limits) and a note where counts would render. */
-.overview-permission-note {
-  color: var(--color-text-secondary);
-  font-size: 0.85rem;
-  padding: 0.5rem 0;
+/* Permission-gated data (issue #244): every affected card explains its own gap
+   with the same standardized callout so the reasons read consistently, draw the
+   eye, and never truncate. Reuses the shared warning tokens (defined per
+   appearance mode) so the tinted surface tracks light/dark automatically —
+   matching the warning surfaces in NsViewRBAC / ObjectMap / Settings. */
+.overview-restriction {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  margin: 0 0 1.2rem 0;
+  padding: 0.65rem 0.8rem;
+  border: 1px solid var(--color-warning-border);
+  border-radius: var(--border-radius-md);
+  background: var(--color-warning-bg);
 }
 
-/* The chip's ⓘ tooltip trigger: keep the icon vertically centered in the
-   chip's flex row instead of sitting on the text baseline. */
-.overview-permission-chip .tooltip-trigger {
-  display: inline-flex;
-  align-items: center;
+/* Each restriction is a two-line row: an icon spanning both lines, a bold
+   headline, and a wrapping detail. The grid keeps the detail left-aligned under
+   the headline (not under the icon) and lets it wrap to as many lines as
+   needed. */
+.overview-restriction__item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 0.5rem;
+  row-gap: 0.15rem;
+  align-items: start;
+}
+
+.overview-restriction__icon {
+  grid-column: 1;
+  grid-row: 1 / span 2;
+  align-self: start;
+  margin-top: 0.1rem;
+  flex: none;
+  color: var(--color-warning);
+}
+
+.overview-restriction__headline {
+  grid-column: 2;
+  font-size: 0.83rem;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--color-text-primary);
+}
+
+.overview-restriction__detail {
+  grid-column: 2;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  color: var(--color-text-secondary);
 }
 
 /* Collapsible legend explaining the utilization bar vocabulary. Swatches
@@ -757,27 +794,6 @@
 .utilization-legend__swatch--limit-marker::after {
   background-color: var(--resourcebar-marker-limit);
   box-shadow: var(--resourcebar-marker-limit-shadow);
-}
-
-.cluster-overview-error {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  border: 1px solid var(--metrics-banner-border);
-  border-radius: var(--border-radius-lg);
-  padding: 0.5rem;
-  margin-bottom: 1rem;
-  background: var(--metrics-banner-bg);
-}
-
-.cluster-overview-error .error-icon {
-  font-size: 1.8rem;
-}
-
-.cluster-overview-error .error-detail {
-  font-size: var(--font-size-normal);
-  /* color: var(--color-error); */
 }
 
 .cluster-overview-loading-inline {

--- a/frontend/src/modules/cluster/components/ClusterOverview.test.tsx
+++ b/frontend/src/modules/cluster/components/ClusterOverview.test.tsx
@@ -315,7 +315,9 @@ describe('ClusterOverview', () => {
     );
     expect(statValueFor(container, 'total')).toBe('—');
     expect(statValueFor(container, 'namespaces')).toBe('—');
-    expect(container.querySelector('.cluster-overview .cluster-overview-error') ?? null).toBeNull();
+    expect(
+      container.querySelector('.cluster-overview .cluster-overview-loading-inline') ?? null
+    ).toBeNull();
   });
 
   it('hydrates with overview data once the domain resolves', async () => {
@@ -707,7 +709,7 @@ describe('ClusterOverview', () => {
     cleanupRoot = cleanup;
     await flushEffects();
 
-    expect(container.textContent).toContain('Failed to load cluster overview');
+    expect(container.textContent).toContain('Failed to load Cluster Overview data');
     expect(container.textContent).toContain('forbidden');
     expect(statValueFor(container, 'total')).toBe('0');
     expect(container.textContent).not.toContain('Loading cluster overview...');
@@ -905,14 +907,15 @@ describe('ClusterOverview', () => {
     rerender();
     await flushEffects();
 
-    // The Nodes card explains the gap instead of rendering misleading zeros.
-    // "list, watch" are the actual RBAC verbs the app needs for node data —
-    // never "view", which is a ClusterRole name, not a permission.
+    // The Nodes card shows the restriction notice above its graph and dashes out
+    // the node counts (the graph is never hidden). "list, watch" are the actual
+    // RBAC verbs the app needs for node data — never "view", which is a
+    // ClusterRole name, not a permission.
     expect(
       container.querySelector('[data-testid="cluster-nodes-permission-note"]')?.textContent
     ).toContain('Node permissions: list, watch');
-    expect(container.querySelector('[data-testid="cluster-nodes-total"]')).toBeNull();
-    expect(statValueFor(container, 'total')).toBe('');
+    expect(container.querySelector('[data-testid="cluster-nodes-total"]')).not.toBeNull();
+    expect(statValueFor(container, 'total')).toBe('—');
 
     // Capacity-derived values have no denominator without nodes: the usage
     // summaries drop the "of <allocatable>" part and the percentages dash out
@@ -925,19 +928,17 @@ describe('ClusterOverview', () => {
       )
     ).toEqual(['—', '—']);
 
-    // The warning lives in the affected card: the Resource Utilization header
-    // carries a capacity chip (no page-level banner).
+    // The warning lives in the affected card: the Resource Utilization card
+    // carries a capacity notice (no page-level banner).
     expect(container.querySelector('[data-testid="overview-permission-banner"]')).toBeNull();
     const capacityChip = container.querySelector(
       '[data-testid="utilization-capacity-permission-chip"]'
     );
     expect(capacityChip?.textContent).toContain('Capacity unavailable');
-    // The explanation is a visible ⓘ-triggered tooltip, not an invisible
-    // title attribute.
+    // The explanation is visible inline text in the standardized notice, not an
+    // invisible title attribute or a hover-only tooltip.
     expect(capacityChip?.getAttribute('title')).toBeNull();
-    expect(capacityChip?.querySelector('[data-testid="tooltip-content"]')?.textContent).toContain(
-      'Node permissions: list, watch'
-    );
+    expect(capacityChip?.textContent).toContain('Node permissions: list, watch');
 
     // Pod and namespace data still render, with no pods/namespaces warnings.
     expect(statValueFor(container, 'pods')).toBe('42');
@@ -976,12 +977,8 @@ describe('ClusterOverview', () => {
     );
     expect(requestsChip?.textContent).toContain('Requests and limits unavailable');
     expect(requestsChip?.getAttribute('title')).toBeNull();
-    expect(requestsChip?.querySelector('[data-testid="tooltip-content"]')?.textContent).toContain(
-      'Pod permissions: list, watch'
-    );
-    expect(requestsChip?.querySelector('[data-testid="tooltip-content"]')?.textContent).toContain(
-      'Only current usage is shown'
-    );
+    expect(requestsChip?.textContent).toContain('Pod permissions: list, watch');
+    expect(requestsChip?.textContent).toContain('Only current usage is shown');
 
     // The Workloads card explains its hidden counts in place.
     expect(
@@ -999,6 +996,46 @@ describe('ClusterOverview', () => {
     expect(statValueFor(container, 'total')).toBe('2');
     expect(container.textContent).toContain('400m of 2 cores');
     expect(container.textContent).toContain('20.0%');
+  });
+
+  it('surfaces disabled metrics as an in-card notice and suppresses the transient pill', async () => {
+    const { container, rerender, cleanup } = renderClusterOverview();
+    cleanupRoot = cleanup;
+
+    domainStateRef.current = {
+      status: 'ready',
+      data: {
+        overview: {
+          ...EMPTY_OVERVIEW_DATA,
+          clusterType: 'Unmanaged',
+          totalNodes: 2,
+          readyNodes: 2,
+        },
+        // A DisabledPoller ships disabled:true with the terminal reason.
+        metrics: {
+          disabled: true,
+          lastError: 'Insufficient permissions for Metrics API',
+          stale: true,
+          successCount: 0,
+          failureCount: 0,
+        },
+      } as any,
+      error: null,
+    };
+
+    rerender();
+    await flushEffects();
+
+    // The permanent state reads as the standardized in-card restriction notice…
+    const metricsNote = container.querySelector(
+      '[data-testid="utilization-metrics-permission-note"]'
+    );
+    expect(metricsNote?.textContent).toContain('Metrics unavailable');
+    expect(metricsNote?.textContent).toContain('Insufficient permissions for Metrics API');
+
+    // …not the transient "Collecting metrics…" header pill (which is suppressed).
+    expect(container.querySelector('.metrics-warning-banner')).toBeNull();
+    expect(container.textContent).not.toContain('Collecting metrics');
   });
 
   it('explains the utilization bar vocabulary in a collapsible legend', async () => {
@@ -1094,7 +1131,7 @@ describe('ClusterOverview', () => {
       { preserveState: true }
     );
     expect(mockRefreshOrchestrator.fetchScopedDomain).not.toHaveBeenCalled();
-    expect(container.textContent).not.toContain('Failed to load cluster overview');
+    expect(container.textContent).not.toContain('Failed to load Cluster Overview data');
     expect(statValueFor(container, 'total')).toBe('—');
   });
 });

--- a/frontend/src/modules/cluster/components/ClusterOverview.test.tsx
+++ b/frontend/src/modules/cluster/components/ClusterOverview.test.tsx
@@ -271,13 +271,6 @@ describe('ClusterOverview', () => {
       secondsUntilRetry: 0,
       errorClass: '' as const,
     };
-    getAppInfoMock.mockResolvedValue({
-      version: '1.0.0',
-      buildTime: 'dev',
-      gitCommit: 'dev',
-      isBeta: false,
-      update: { isUpdateAvailable: false },
-    });
     canResolveEventObjectReferenceMock.mockReturnValue(false);
     resolveEventObjectReferenceMock.mockReset();
     cleanupRoot = null;
@@ -673,32 +666,6 @@ describe('ClusterOverview', () => {
     expect(
       container.querySelector('[data-testid="cluster-workload-usage-memory-job"]')?.textContent
     ).toContain('256.0 Mi');
-  });
-
-  it('renders an update banner when a newer release is available', async () => {
-    getAppInfoMock.mockResolvedValue({
-      version: '1.0.0',
-      buildTime: 'dev',
-      gitCommit: 'dev',
-      isBeta: false,
-      update: {
-        isUpdateAvailable: true,
-        latestVersion: '1.2.0',
-        releaseUrl: 'https://github.com/luxury-yacht/app/releases/latest',
-      },
-    });
-
-    const { container, cleanup } = renderClusterOverview();
-    cleanupRoot = cleanup;
-
-    await act(async () => {
-      await Promise.resolve();
-    });
-
-    const banner = container.querySelector('.overview-update-banner');
-    expect(banner).not.toBeNull();
-    expect(banner?.textContent).toMatch(/update available/i);
-    expect(banner?.textContent).toContain('1.2.0');
   });
 
   it('shows an inline error while retaining the zero skeleton when permissions fail', async () => {

--- a/frontend/src/modules/cluster/components/ClusterOverview.tsx
+++ b/frontend/src/modules/cluster/components/ClusterOverview.tsx
@@ -17,7 +17,6 @@ import {
   formatCpuValue,
   formatMemoryValue,
 } from '@shared/utils/resourceCalculations';
-import { readAppInfo, requestAppState } from '@/core/app-state-access';
 import { requestRefreshDomain, setRefreshDomainEnabled } from '@/core/data-access';
 import { useRefreshScopedDomain } from '@/core/refresh';
 import { useStreamSignalRefetch } from '@/core/refresh/hooks/useStreamSignalRefetch';
@@ -39,9 +38,7 @@ import {
   emitPodsUnhealthySignal,
   type PodsFilterMode,
 } from '@modules/namespace/components/podsFilterSignals';
-import { BrowserOpenURL } from '@wailsjs/runtime/runtime';
 import { useClusterLifecycle } from '@core/contexts/ClusterLifecycleContext';
-import { backend } from '@wailsjs/go/models';
 import { useKubeconfig } from '@modules/kubernetes/config/KubeconfigContext';
 import { useClusterHealthListener } from '@/hooks/useWailsRuntimeEvents';
 import { useActiveClusterAuthState } from '@/core/contexts/AuthErrorContext';
@@ -189,7 +186,6 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
   const [isHydrated, setIsHydrated] = useState(false);
   const [hydratedClusterId, setHydratedClusterId] = useState<string | null>(null);
   const [isSwitching, setIsSwitching] = useState(false);
-  const [updateInfo, setUpdateInfo] = useState<UpdateInfo | null>(null);
   const metricsInfo = useMemo(() => {
     const metricsByCluster = overviewDomain.data?.metricsByCluster;
     if (metricsByCluster) {
@@ -277,46 +273,6 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
       setIsSwitching(true);
     }
   }, [hydratedClusterId, selectedClusterId, selectedOverview]);
-
-  useEffect(() => {
-    let isActive = true;
-    requestAppState({
-      resource: 'app-info',
-      read: () => readAppInfo(),
-    })
-      .then((info) => {
-        if (!isActive) {
-          return;
-        }
-        const withUpdate = info as AppInfoWithUpdate;
-        setUpdateInfo(withUpdate.update ?? null);
-      })
-      .catch(() => {
-        // Silent fallback if update metadata cannot be fetched.
-      });
-    return () => {
-      isActive = false;
-    };
-  }, []);
-
-  useEffect(() => {
-    const runtime = window.runtime;
-    if (!runtime?.EventsOn) {
-      return;
-    }
-    const handleUpdate = (...args: unknown[]) => {
-      const payload = args[0] as UpdateInfo | undefined;
-      if (!payload) {
-        return;
-      }
-      // Event payload is the latest update metadata from the backend.
-      setUpdateInfo(payload);
-    };
-    runtime.EventsOn('app-update', handleUpdate);
-    return () => {
-      runtime.EventsOff?.('app-update', handleUpdate);
-    };
-  }, []);
 
   const isHydratedForCluster = isHydrated && hydratedClusterId === selectedClusterId;
   const displayOverview = isHydratedForCluster ? overviewData : EMPTY_OVERVIEW;
@@ -883,34 +839,13 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
     </div>
   );
 
-  const showUpdateBanner = Boolean(updateInfo?.isUpdateAvailable && updateInfo?.releaseUrl);
   // Before the initial snapshot arrives we don't have real values yet —
   // render a dash placeholder instead of zeros so the UI reads as "loading"
   // without surfacing misleading "0" values.
   const DASH = '—';
-  const handleUpdateClick = useCallback(() => {
-    if (!updateInfo?.releaseUrl) {
-      return;
-    }
-    // Open the update release page when the notice is activated.
-    BrowserOpenURL(updateInfo.releaseUrl);
-  }, [updateInfo]);
 
   return (
     <div className="cluster-overview selectable">
-      {showUpdateBanner && (
-        <div className="overview-update-banner-wrap">
-          <button type="button" className="overview-update-banner" onClick={handleUpdateClick}>
-            <div className="overview-update-text">
-              <span className="overview-update-meta">
-                {updateInfo?.latestVersion ? ` ${updateInfo.latestVersion}` : ''} update available!
-                Click here to go to the downloads page.
-              </span>
-            </div>
-          </button>
-        </div>
-      )}
-
       <div className="overview-top">
         <div className="overview-top__info">
           <h1 className="overview-top__title">{contextLabel}</h1>
@@ -1351,21 +1286,6 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
       </div>
     </div>
   );
-};
-
-type UpdateInfo = {
-  currentVersion: string;
-  latestVersion: string;
-  releaseUrl: string;
-  releaseName?: string;
-  publishedAt?: string;
-  checkedAt?: string;
-  isUpdateAvailable: boolean;
-  error?: string;
-};
-
-type AppInfoWithUpdate = backend.AppInfo & {
-  update?: UpdateInfo | null;
 };
 
 export default ClusterOverview;

--- a/frontend/src/modules/cluster/components/ClusterOverview.tsx
+++ b/frontend/src/modules/cluster/components/ClusterOverview.tsx
@@ -629,7 +629,7 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
       });
       nodesRestrictions.push({
         key: 'nodes',
-        headline: 'Node details hidden',
+        headline: 'Node details unavailable',
         detail:
           'Your account has insufficient access to node data. Requires Node permissions: list, watch.',
         testId: 'cluster-nodes-permission-note',
@@ -644,7 +644,7 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
       });
       workloadsRestrictions.push({
         key: 'pods',
-        headline: 'Pod and container counts hidden',
+        headline: 'Pod and container counts unavailable',
         detail:
           'Your account has insufficient access to pod data. Requires Pod permissions: list, watch.',
         testId: 'workloads-pods-permission-note',
@@ -653,7 +653,7 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
     if (namespacesUnavailable) {
       workloadsRestrictions.push({
         key: 'namespaces',
-        headline: 'Namespace count hidden',
+        headline: 'Namespace count unavailable',
         detail:
           'Your account has insufficient access to namespaces. Requires Namespace permission: list.',
         testId: 'workloads-namespaces-permission-note',
@@ -876,7 +876,9 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
         className={`metric-legend__dot metric-legend__dot--${item.variant}`}
         aria-hidden="true"
       />
-      <span className="metric-legend__count">{showSkeleton ? DASH : item.value}</span>
+      <span className="metric-legend__count">
+        {showSkeleton || nodesUnavailable ? DASH : item.value}
+      </span>
       <span className="metric-legend__label">{item.label}</span>
     </div>
   );
@@ -1119,88 +1121,83 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
 
         <div className="overview-section nodes-summary">
           <h2>Nodes</h2>
-          {nodesRestrictions.length > 0 ? (
-            <ClusterOverviewRestrictionNotice restrictions={nodesRestrictions} />
-          ) : (
-            <>
-              <div className="metric-stats">
-                <div className="metric-stat" data-testid="cluster-nodes-total">
+          <ClusterOverviewRestrictionNotice restrictions={nodesRestrictions} />
+          <div className="metric-stats">
+            <div className="metric-stat" data-testid="cluster-nodes-total">
+              <span className="metric-stat__count">
+                {showSkeleton || nodesUnavailable ? DASH : displayOverview.totalNodes}
+              </span>
+              <span className="metric-stat__label">total</span>
+            </div>
+            {displayOverview.clusterType === 'EKS' && (
+              <>
+                <div className="metric-stat" data-testid="cluster-nodes-ec2">
                   <span className="metric-stat__count">
-                    {showSkeleton ? DASH : displayOverview.totalNodes}
+                    {showSkeleton || nodesUnavailable ? DASH : displayOverview.ec2Nodes}
                   </span>
-                  <span className="metric-stat__label">total</span>
+                  <span className="metric-stat__label">ec2</span>
                 </div>
-                {displayOverview.clusterType === 'EKS' && (
-                  <>
-                    <div className="metric-stat" data-testid="cluster-nodes-ec2">
-                      <span className="metric-stat__count">
-                        {showSkeleton ? DASH : displayOverview.ec2Nodes}
-                      </span>
-                      <span className="metric-stat__label">ec2</span>
-                    </div>
-                    <div className="metric-stat" data-testid="cluster-nodes-fargate">
-                      <span className="metric-stat__count">
-                        {showSkeleton ? DASH : displayOverview.fargateNodes}
-                      </span>
-                      <span className="metric-stat__label">fargate</span>
-                    </div>
-                  </>
-                )}
-                {displayOverview.clusterType === 'AKS' && (
-                  <>
-                    <div className="metric-stat" data-testid="cluster-nodes-vm">
-                      <span className="metric-stat__count">
-                        {showSkeleton ? DASH : displayOverview.vmNodes}
-                      </span>
-                      <span className="metric-stat__label">vm</span>
-                    </div>
-                    <div className="metric-stat" data-testid="cluster-nodes-virtual">
-                      <span className="metric-stat__count">
-                        {showSkeleton ? DASH : displayOverview.virtualNodes}
-                      </span>
-                      <span className="metric-stat__label">virtual</span>
-                    </div>
-                  </>
-                )}
-              </div>
+                <div className="metric-stat" data-testid="cluster-nodes-fargate">
+                  <span className="metric-stat__count">
+                    {showSkeleton || nodesUnavailable ? DASH : displayOverview.fargateNodes}
+                  </span>
+                  <span className="metric-stat__label">fargate</span>
+                </div>
+              </>
+            )}
+            {displayOverview.clusterType === 'AKS' && (
+              <>
+                <div className="metric-stat" data-testid="cluster-nodes-vm">
+                  <span className="metric-stat__count">
+                    {showSkeleton || nodesUnavailable ? DASH : displayOverview.vmNodes}
+                  </span>
+                  <span className="metric-stat__label">vm</span>
+                </div>
+                <div className="metric-stat" data-testid="cluster-nodes-virtual">
+                  <span className="metric-stat__count">
+                    {showSkeleton || nodesUnavailable ? DASH : displayOverview.virtualNodes}
+                  </span>
+                  <span className="metric-stat__label">virtual</span>
+                </div>
+              </>
+            )}
+          </div>
 
-              <div className="node-health">
-                <div className="metric-header">
-                  <h3>Node Health</h3>
-                  <div className="metric-legend__total">
-                    <span className="metric-legend__total-value">
-                      {showSkeleton ? DASH : displayOverview.totalNodes}
-                    </span>
-                    <span className="metric-legend__total-label"> total</span>
-                  </div>
-                </div>
-                <div className="stacked-bar" role="presentation" aria-hidden="true">
-                  {!showSkeleton &&
-                    nodeHealthPhaseItems.map((item) => {
-                      const width = nodeHealthPct(item.value);
-                      if (width <= 0) {
-                        return null;
-                      }
-                      return (
-                        <div
-                          key={item.key}
-                          className={`stacked-bar__segment stacked-bar__segment--${item.variant}`}
-                          style={{ width: `${width}%` }}
-                        />
-                      );
-                    })}
-                </div>
-                <div className="metric-legend">
-                  <div className="metric-legend__items">
-                    {nodeHealthPhaseItems.map((item) => renderNodeHealthLegendItem(item))}
-                  </div>
-                  <div className="metric-legend__items metric-legend__items--restarted">
-                    {renderNodeHealthLegendItem(nodeCordonedItem)}
-                  </div>
-                </div>
+          <div className="node-health">
+            <div className="metric-header">
+              <h3>Node Health</h3>
+              <div className="metric-legend__total">
+                <span className="metric-legend__total-value">
+                  {showSkeleton || nodesUnavailable ? DASH : displayOverview.totalNodes}
+                </span>
+                <span className="metric-legend__total-label"> total</span>
               </div>
-            </>
-          )}
+            </div>
+            <div className="stacked-bar" role="presentation" aria-hidden="true">
+              {!showSkeleton &&
+                nodeHealthPhaseItems.map((item) => {
+                  const width = nodeHealthPct(item.value);
+                  if (width <= 0) {
+                    return null;
+                  }
+                  return (
+                    <div
+                      key={item.key}
+                      className={`stacked-bar__segment stacked-bar__segment--${item.variant}`}
+                      style={{ width: `${width}%` }}
+                    />
+                  );
+                })}
+            </div>
+            <div className="metric-legend">
+              <div className="metric-legend__items">
+                {nodeHealthPhaseItems.map((item) => renderNodeHealthLegendItem(item))}
+              </div>
+              <div className="metric-legend__items metric-legend__items--restarted">
+                {renderNodeHealthLegendItem(nodeCordonedItem)}
+              </div>
+            </div>
+          </div>
         </div>
 
         <div className="overview-section workloads-summary">

--- a/frontend/src/modules/cluster/components/ClusterOverview.tsx
+++ b/frontend/src/modules/cluster/components/ClusterOverview.tsx
@@ -64,6 +64,9 @@ import {
   clusterOverviewResourceMetrics,
   clusterWorkloadUsageValue,
 } from '@/core/resource-metrics';
+import ClusterOverviewRestrictionNotice, {
+  type OverviewRestriction,
+} from './ClusterOverviewRestrictionNotice';
 
 interface ClusterOverviewProps {
   clusterContext: string;
@@ -603,6 +606,56 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
   const podsUnavailable = unavailableResources.includes('core/pods');
   const namespacesUnavailable = unavailableResources.includes('core/namespaces');
 
+  // Standardized access-restriction notices: each affected card renders the
+  // same callout (ClusterOverviewRestrictionNotice) so the reasons read
+  // consistently and never truncate. Gated on !showSkeleton so restrictions
+  // never flash while the first snapshot is still loading.
+  const utilizationRestrictions: OverviewRestriction[] = [];
+  const nodesRestrictions: OverviewRestriction[] = [];
+  const workloadsRestrictions: OverviewRestriction[] = [];
+  if (!showSkeleton) {
+    if (nodesUnavailable) {
+      utilizationRestrictions.push({
+        key: 'capacity',
+        headline: 'Capacity unavailable',
+        detail:
+          'Cluster capacity is unavailable, so utilization is measured against requests and limits. Requires Node permissions: list, watch.',
+        testId: 'utilization-capacity-permission-chip',
+      });
+      nodesRestrictions.push({
+        key: 'nodes',
+        headline: 'Node details hidden',
+        detail:
+          'Your account has insufficient access to node data. Requires Node permissions: list, watch.',
+        testId: 'cluster-nodes-permission-note',
+      });
+    }
+    if (podsUnavailable) {
+      utilizationRestrictions.push({
+        key: 'requests-limits',
+        headline: 'Requests and limits unavailable',
+        detail: 'Only current usage is shown. Requires Pod permissions: list, watch.',
+        testId: 'utilization-requests-permission-chip',
+      });
+      workloadsRestrictions.push({
+        key: 'pods',
+        headline: 'Pod and container counts hidden',
+        detail:
+          'Your account has insufficient access to pod data. Requires Pod permissions: list, watch.',
+        testId: 'workloads-pods-permission-note',
+      });
+    }
+    if (namespacesUnavailable) {
+      workloadsRestrictions.push({
+        key: 'namespaces',
+        headline: 'Namespace count hidden',
+        detail:
+          'Your account has insufficient access to namespaces. Requires Namespace permission: list.',
+        testId: 'workloads-namespaces-permission-note',
+      });
+    }
+  }
+
   const overviewResourceMetrics = clusterOverviewResourceMetrics(displayOverview, metricsInfo);
   const memoryResourceMetrics = calculateResourceMetrics(
     overviewResourceMetrics.memory ?? {},
@@ -874,17 +927,24 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
 
       {errorMessage && (
         <div className="cluster-overview-loading-inline">
-          <div className="cluster-overview-error">
-            <div className="error-detail">Failed to load Cluster Overview data: {errorMessage}</div>
-          </div>
+          <ClusterOverviewRestrictionNotice
+            restrictions={[
+              {
+                key: 'load-error',
+                headline: 'Failed to load Cluster Overview data',
+                detail: errorMessage,
+              },
+            ]}
+          />
         </div>
       )}
 
       <div className="overview-grid">
         <div className="overview-section resource-usage">
-          {/* Header row: the metrics/permission indicators sit in the card's
-              upper right so their presence never shifts the utilization
-              content below. */}
+          {/* Header row: the transient metrics-collection indicator sits in the
+              card's upper right so its presence never shifts the utilization
+              content below. Access restrictions render in the standardized
+              notice beneath the header instead. */}
           <div className="overview-section-header">
             <h2>Resource Utilization</h2>
             {metricsBanner && !errorMessage && (
@@ -893,35 +953,9 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
                 <span className="metrics-warning-banner__text">{metricsBanner.message}</span>
               </div>
             )}
-            {nodesUnavailable && !showSkeleton && (
-              <div
-                className="overview-permission-chip"
-                data-testid="utilization-capacity-permission-chip"
-              >
-                <span className="metrics-warning-banner__dot" />
-                <span className="metrics-warning-banner__text">Capacity unavailable</span>
-                <Tooltip
-                  content="Cluster capacity data is unavailable. Your account is missing required Node permissions: list, watch."
-                  maxWidth={320}
-                />
-              </div>
-            )}
-            {podsUnavailable && !showSkeleton && (
-              <div
-                className="overview-permission-chip"
-                data-testid="utilization-requests-permission-chip"
-              >
-                <span className="metrics-warning-banner__dot" />
-                <span className="metrics-warning-banner__text">
-                  Requests and limits unavailable
-                </span>
-                <Tooltip
-                  content="Pod requests and limits data is unavailable. Only current usage is shown. Your account is missing required Pod permissions: list, watch."
-                  maxWidth={320}
-                />
-              </div>
-            )}
           </div>
+
+          <ClusterOverviewRestrictionNotice restrictions={utilizationRestrictions} />
 
           <div className="resource-group">
             <div className="metric-header metric-header--usage">
@@ -1069,11 +1103,8 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
 
         <div className="overview-section nodes-summary">
           <h2>Nodes</h2>
-          {nodesUnavailable && !showSkeleton ? (
-            <div className="overview-permission-note" data-testid="cluster-nodes-permission-note">
-              Node details are hidden. Your account has insufficient access (requires Node
-              permissions: list, watch).
-            </div>
+          {nodesRestrictions.length > 0 ? (
+            <ClusterOverviewRestrictionNotice restrictions={nodesRestrictions} />
           ) : (
             <>
               <div className="metric-stats">
@@ -1158,21 +1189,7 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
 
         <div className="overview-section workloads-summary">
           <h2>Workloads</h2>
-          {podsUnavailable && !showSkeleton && (
-            <div className="overview-permission-note" data-testid="workloads-pods-permission-note">
-              Pod and container counts are hidden. Your account has insufficient access (requires
-              Pod permissions: list, watch).
-            </div>
-          )}
-          {namespacesUnavailable && !showSkeleton && (
-            <div
-              className="overview-permission-note"
-              data-testid="workloads-namespaces-permission-note"
-            >
-              The namespace count is hidden. Your account has insufficient access (requires
-              Namespace permission: list).
-            </div>
-          )}
+          <ClusterOverviewRestrictionNotice restrictions={workloadsRestrictions} />
           <div className="metric-stats">
             <div className="metric-stat" data-testid="cluster-workloads-namespaces">
               <span className="metric-stat__count">

--- a/frontend/src/modules/cluster/components/ClusterOverview.tsx
+++ b/frontend/src/modules/cluster/components/ClusterOverview.tsx
@@ -875,9 +875,7 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
       {errorMessage && (
         <div className="cluster-overview-loading-inline">
           <div className="cluster-overview-error">
-            <span className="error-icon">⚠️</span>
-            <div>Failed to load cluster overview</div>
-            <div className="error-detail">{errorMessage}</div>
+            <div className="error-detail">Failed to load Cluster Overview data: {errorMessage}</div>
           </div>
         </div>
       )}

--- a/frontend/src/modules/cluster/components/ClusterOverview.tsx
+++ b/frontend/src/modules/cluster/components/ClusterOverview.tsx
@@ -606,6 +606,11 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
   const podsUnavailable = unavailableResources.includes('core/pods');
   const namespacesUnavailable = unavailableResources.includes('core/namespaces');
 
+  // Metrics are permanently unavailable (metrics API forbidden, or metrics-server
+  // absent) rather than merely still collecting. This is a restriction, so it
+  // renders as an in-card notice below and suppresses the transient metrics pill.
+  const metricsDisabled = !!metricsInfo?.disabled;
+
   // Standardized access-restriction notices: each affected card renders the
   // same callout (ClusterOverviewRestrictionNotice) so the reasons read
   // consistently and never truncate. Gated on !showSkeleton so restrictions
@@ -652,6 +657,17 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
         detail:
           'Your account has insufficient access to namespaces. Requires Namespace permission: list.',
         testId: 'workloads-namespaces-permission-note',
+      });
+    }
+    if (metricsDisabled) {
+      const metricsReason = metricsInfo?.lastError?.trim();
+      utilizationRestrictions.push({
+        key: 'metrics',
+        headline: 'Metrics unavailable',
+        detail: metricsReason
+          ? `Live CPU and memory usage cannot be shown. ${metricsReason}`
+          : 'Live CPU and memory usage cannot be shown.',
+        testId: 'utilization-metrics-permission-note',
       });
     }
   }
@@ -947,7 +963,7 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
               notice beneath the header instead. */}
           <div className="overview-section-header">
             <h2>Resource Utilization</h2>
-            {metricsBanner && !errorMessage && (
+            {metricsBanner && !errorMessage && !metricsDisabled && (
               <div className="metrics-warning-banner" title={metricsBanner.tooltip}>
                 <span className="metrics-warning-banner__dot" />
                 <span className="metrics-warning-banner__text">{metricsBanner.message}</span>

--- a/frontend/src/modules/cluster/components/ClusterOverviewRestrictionNotice.tsx
+++ b/frontend/src/modules/cluster/components/ClusterOverviewRestrictionNotice.tsx
@@ -1,0 +1,61 @@
+/**
+ * frontend/src/modules/cluster/components/ClusterOverviewRestrictionNotice.tsx
+ *
+ * Standardized presentation for cluster-overview access restrictions. Every card
+ * that must hide data because the current identity lacks the required Kubernetes
+ * permissions renders this notice in the same place and style, so the reasons
+ * read consistently, draw attention, and never truncate.
+ */
+import React from 'react';
+import { WarningOutlineIcon } from '@shared/components/icons/SharedIcons';
+
+export interface OverviewRestriction {
+  /** Stable key for list rendering. */
+  key: string;
+  /** What is hidden or unavailable, e.g. "Capacity unavailable". */
+  headline: string;
+  /** Why it is hidden / what access is required. Wraps freely — no truncation. */
+  detail: string;
+  /** Optional test hook for the individual restriction row. */
+  testId?: string;
+}
+
+interface ClusterOverviewRestrictionNoticeProps {
+  restrictions: OverviewRestriction[];
+}
+
+/**
+ * Renders one attention-drawing callout listing every access restriction that
+ * applies to a card. Returns null when there are none so callers can render it
+ * unconditionally.
+ */
+const ClusterOverviewRestrictionNotice: React.FC<ClusterOverviewRestrictionNoticeProps> = ({
+  restrictions,
+}) => {
+  if (restrictions.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="overview-restriction" role="note" data-testid="cluster-overview-restriction">
+      {restrictions.map((restriction) => (
+        <div
+          key={restriction.key}
+          className="overview-restriction__item"
+          data-testid={restriction.testId}
+        >
+          <WarningOutlineIcon
+            width={15}
+            height={15}
+            className="overview-restriction__icon"
+            ariaHidden
+          />
+          <span className="overview-restriction__headline">{restriction.headline}</span>
+          <span className="overview-restriction__detail">{restriction.detail}</span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ClusterOverviewRestrictionNotice;

--- a/frontend/src/modules/cluster/components/ClusterOverviewRestrictionNotice.tsx
+++ b/frontend/src/modules/cluster/components/ClusterOverviewRestrictionNotice.tsx
@@ -7,7 +7,7 @@
  * read consistently, draw attention, and never truncate.
  */
 import React from 'react';
-import { WarningOutlineIcon } from '@shared/components/icons/SharedIcons';
+import { WarningIcon } from '@shared/components/icons/SharedIcons';
 
 export interface OverviewRestriction {
   /** Stable key for list rendering. */
@@ -44,12 +44,7 @@ const ClusterOverviewRestrictionNotice: React.FC<ClusterOverviewRestrictionNotic
           className="overview-restriction__item"
           data-testid={restriction.testId}
         >
-          <WarningOutlineIcon
-            width={15}
-            height={15}
-            className="overview-restriction__icon"
-            ariaHidden
-          />
+          <WarningIcon width={16} height={16} className="overview-restriction__icon" ariaHidden />
           <span className="overview-restriction__headline">{restriction.headline}</span>
           <span className="overview-restriction__detail">{restriction.detail}</span>
         </div>

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Details/DetailsTab.tsx
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Details/DetailsTab.tsx
@@ -8,7 +8,7 @@ import Utilization from '@modules/object-panel/components/ObjectPanel/Details/De
 import Containers from '@modules/object-panel/components/ObjectPanel/Details/DetailsTabContainers';
 import RBACRules from '@modules/object-panel/components/ObjectPanel/Details/DetailsTabRBACRules';
 import DataSection from '@modules/object-panel/components/ObjectPanel/Details/DetailsTabData';
-import { WarningOutlineIcon } from '@shared/components/icons/SharedIcons';
+import { WarningIcon } from '@shared/components/icons/SharedIcons';
 import './DetailsTab.css';
 import './DetailsTabData.css';
 
@@ -55,7 +55,7 @@ const DetailsTabContent: React.FC<DetailsTabProps> = ({
       {/* Deleted Resource Warning */}
       {resourceDeleted && (
         <div className="resource-deleted-warning">
-          <WarningOutlineIcon />
+          <WarningIcon />
           <span>
             {deletedResourceName || 'Resource'} no longer exists. Please select another resource.
           </span>

--- a/frontend/src/shared/components/icons/SharedIcons.tsx
+++ b/frontend/src/shared/components/icons/SharedIcons.tsx
@@ -600,9 +600,10 @@ export const WarningTriangleIcon: React.FC<IconProps> = ({
   </svg>
 );
 
-export const WarningOutlineIcon: React.FC<IconProps> = ({
+export const WarningIcon: React.FC<IconProps> = ({
   width = 24,
   height = 24,
+  fill = 'currentColor',
   className,
   ariaHidden,
 }) => (
@@ -611,15 +612,11 @@ export const WarningOutlineIcon: React.FC<IconProps> = ({
     width={width}
     height={height}
     viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
+    fill={fill}
     className={className}
     aria-hidden={ariaHidden}
   >
-    <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
-    <line x1="12" y1="9" x2="12" y2="13" />
-    <line x1="12" y1="17" x2="12.01" y2="17" />
+    <path d="M9.138 3.707c1.228-2.276 4.494-2.276 5.721 0l6.743 12.502c1.168 2.165-.4 4.792-2.86 4.793H5.255c-2.46 0-4.028-2.628-2.86-4.793zm4.4.712c-.66-1.225-2.419-1.225-3.08 0L3.715 16.921a1.75 1.75 0 0 0 1.54 2.581h13.487a1.75 1.75 0 0 0 1.54-2.581zM12 15a1 1 0 1 1 0 2a1 1 0 0 1 0-2m0-7.5a.75.75 0 0 1 .75.75v4.5a.75.75 0 0 1-1.5 0v-4.5A.75.75 0 0 1 12 7.5" />
   </svg>
 );
 

--- a/frontend/src/shared/utils/metricsAvailability.test.ts
+++ b/frontend/src/shared/utils/metricsAvailability.test.ts
@@ -39,6 +39,27 @@ describe('getMetricsBannerInfo', () => {
     expect(bannerWithZeroTime?.message).toBe('Collecting metrics…');
   });
 
+  it('surfaces the terminal reason for a disabled poller instead of "Collecting metrics"', () => {
+    // Regression: a DisabledPoller (no metrics permission, or metrics-server
+    // absent) reports successCount 0 / no failures / zero collectedAt — the same
+    // counters as the pristine window — but carries a permanent reason in
+    // lastError. Without the disabled flag it was mistaken for "collecting" and
+    // the app silently stuck there forever. The flag must short-circuit to the
+    // reason verbatim — this uses a reason the keyword branches do NOT special-
+    // case, so the assertion fails unless the disabled branch handles it.
+    const banner = getMetricsBannerInfo({
+      disabled: true,
+      lastError: 'Metrics API not found (metrics-server)',
+      successCount: 0,
+      failureCount: 0,
+      consecutiveFailures: 0,
+    });
+    expect(banner).toEqual({
+      message: 'Metrics API not found (metrics-server)',
+      tooltip: 'Metrics API not found (metrics-server)',
+    });
+  });
+
   it('returns awaiting message during initial transient failures', () => {
     const banner = getMetricsBannerInfo({
       lastError: 'metrics API unavailable (pods.metrics.k8s.io)',

--- a/frontend/src/shared/utils/metricsAvailability.ts
+++ b/frontend/src/shared/utils/metricsAvailability.ts
@@ -9,6 +9,10 @@ export interface MetricsAvailability {
   stale?: boolean;
   lastError?: string | null;
   collectedAt?: number;
+  // Terminal "metrics unavailable" state (metrics API forbidden, or
+  // metrics-server absent). When set, lastError holds a permanent, UI-ready
+  // reason that must never be treated as a transient pre-first-poll error.
+  disabled?: boolean;
   // Staleness threshold (seconds) shipped by the serve-time-join payloads so
   // the banner can flip client-side: the poller rings no doorbell on failure,
   // so nothing refetches to refresh a server-computed stale flag. Absent on
@@ -55,6 +59,18 @@ export const getMetricsBannerInfo = (
 ): MetricsBannerInfo | null => {
   if (!metrics) {
     return null;
+  }
+
+  // A permanently disabled poller (metrics API forbidden, or metrics-server
+  // absent) carries a terminal, UI-ready reason in lastError. Surface it
+  // directly — this is not a transient "collecting" state and must never fall
+  // through to the pristine/awaiting branches below.
+  if (metrics.disabled) {
+    const reason = metrics.lastError?.trim();
+    return {
+      message: reason || 'Metrics unavailable',
+      tooltip: reason || 'Metrics collection is unavailable for this cluster.',
+    };
   }
 
   const successCount = metrics.successCount ?? 0;

--- a/frontend/src/ui/layout/AppHeader.css
+++ b/frontend/src/ui/layout/AppHeader.css
@@ -56,6 +56,7 @@
   align-items: center;
   gap: 8px;
   flex-shrink: 0;
+  margin-left: 0.5rem;
   --wails-draggable: none;
 }
 

--- a/frontend/src/ui/layout/AppHeader.tsx
+++ b/frontend/src/ui/layout/AppHeader.tsx
@@ -10,6 +10,7 @@ import KubeconfigSelector from '@shared/components/KubeconfigSelector';
 import ConnectivityStatus from '@ui/status/ConnectivityStatus';
 import MetricsStatus from '@ui/status/MetricsStatus';
 import SessionsStatus from '@ui/status/SessionsStatus';
+import UpdateStatus from '@ui/status/UpdateStatus';
 import FavMenuDropdown from '@ui/favorites/FavMenuDropdown';
 import { useViewState } from '@core/contexts/ViewStateContext';
 import { WindowToggleMaximise } from '@wailsjs/runtime/runtime';
@@ -74,6 +75,7 @@ const AppHeader: React.FC<AppHeaderProps> = ({ contentTitle }) => {
       </div>
 
       <div className="app-header-controls" onDoubleClick={(e) => e.stopPropagation()}>
+        <UpdateStatus />
         <div className="status-indicators">
           <ConnectivityStatus />
           <MetricsStatus />

--- a/frontend/src/ui/layout/Sidebar.tsx
+++ b/frontend/src/ui/layout/Sidebar.tsx
@@ -19,7 +19,7 @@ import {
   ClusterResourcesIcon,
   CategoryIcon,
   CloseIcon,
-  WarningOutlineIcon,
+  WarningIcon,
   NamespaceIcon,
   NamespaceOpenIcon,
 } from '@shared/components/icons/SharedIcons';
@@ -502,7 +502,7 @@ function Sidebar() {
                                   : 'Insufficient permissions to access this namespace (or it does not exist).'
                               }
                             >
-                              <WarningOutlineIcon width={12} height={12} />
+                              <WarningIcon width={16} height={16} />
                             </span>
                           ) : null}
                           {namespaceScope.scope.includes(namespace.name) &&

--- a/frontend/src/ui/status/MetricsStatus.test.tsx
+++ b/frontend/src/ui/status/MetricsStatus.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * frontend/src/ui/status/MetricsStatus.test.tsx
+ *
+ * Verifies the header metrics indicator maps availability state to the right
+ * StatusIndicator severity/message — in particular that a permanently disabled
+ * poller reads as amber (degraded) with its reason, not a stuck "collecting".
+ */
+import ReactDOM from 'react-dom/client';
+import { act } from 'react';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import type { MetricsAvailability, MetricsBannerInfo } from '@shared/utils/metricsAvailability';
+
+let mockMetricsInfo: MetricsAvailability | null = null;
+let mockBannerInfo: MetricsBannerInfo | null = null;
+
+vi.mock('@/core/refresh/hooks/useMetricsAvailability', () => ({
+  useClusterMetricsAvailability: () => mockMetricsInfo,
+}));
+
+vi.mock('@shared/hooks/useMetricsBannerInfo', () => ({
+  useMetricsBannerInfo: () => mockBannerInfo,
+}));
+
+vi.mock('@shared/components/status/StatusIndicator', () => ({
+  __esModule: true,
+  default: ({ status, message }: { status: string; message: ReactNode }) => (
+    <div data-testid="indicator" data-status={status}>
+      {message}
+    </div>
+  ),
+}));
+
+import MetricsStatus from './MetricsStatus';
+
+describe('MetricsStatus', () => {
+  let container: HTMLDivElement;
+  let root: ReactDOM.Root;
+
+  beforeAll(() => {
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = ReactDOM.createRoot(container);
+    mockMetricsInfo = null;
+    mockBannerInfo = null;
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  const render = () => {
+    act(() => {
+      root.render(<MetricsStatus />);
+    });
+    return container.querySelector('[data-testid="indicator"]');
+  };
+
+  it('shows amber (degraded) with the reason when metrics are disabled', () => {
+    // A DisabledPoller (no metrics permission / metrics-server absent) is a
+    // restriction, not an app fault: amber, not alarming red — and never a stuck
+    // "Collecting metrics…".
+    mockMetricsInfo = {
+      disabled: true,
+      lastError: 'Insufficient permissions for Metrics API',
+      stale: true,
+      successCount: 0,
+      failureCount: 0,
+    };
+    mockBannerInfo = {
+      message: 'Insufficient permissions for Metrics API',
+      tooltip: 'Insufficient permissions for Metrics API',
+    };
+
+    const indicator = render();
+    expect(indicator?.getAttribute('data-status')).toBe('degraded');
+    expect(indicator?.textContent).toContain('Insufficient permissions for Metrics API');
+  });
+
+  it('is healthy when there is no banner info', () => {
+    mockMetricsInfo = { stale: false, successCount: 3, failureCount: 0 };
+    mockBannerInfo = null;
+
+    const indicator = render();
+    expect(indicator?.getAttribute('data-status')).toBe('healthy');
+  });
+
+  it('is inactive when no metrics payload has arrived', () => {
+    mockMetricsInfo = null;
+    mockBannerInfo = null;
+
+    const indicator = render();
+    expect(indicator?.getAttribute('data-status')).toBe('inactive');
+  });
+});

--- a/frontend/src/ui/status/MetricsStatus.tsx
+++ b/frontend/src/ui/status/MetricsStatus.tsx
@@ -24,6 +24,11 @@ const MetricsStatus: React.FC = () => {
     // No banner info means metrics are healthy.
     if (!bannerInfo) return 'healthy';
 
+    // Metrics permanently unavailable (no permission / metrics-server absent) is
+    // a restriction, not an app fault — show amber (degraded), matching the
+    // in-card restriction notices, not alarming red.
+    if (metricsInfo.disabled) return 'degraded';
+
     // Has an error — distinguish degraded (stale/intermittent) vs unhealthy (unavailable).
     if (metricsInfo.lastError) return 'unhealthy';
 

--- a/frontend/src/ui/status/UpdateStatus.css
+++ b/frontend/src/ui/status/UpdateStatus.css
@@ -1,0 +1,98 @@
+/* UpdateStatus — clickable "update available" info chip in the app header.
+   Reuses the shared info-chip palette (--badge-blue-*) so it reads as the same
+   info style as StatusChip variant="info", but renders as a button (clickable,
+   opens the release page) with a hover Tooltip carrying the version details. */
+.update-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 2px 8px;
+  border-radius: var(--border-radius-round);
+  /* Matches StatusChip variant="info" for a consistent info-chip outline. */
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  background: var(--badge-blue-bg);
+  color: var(--badge-blue-text);
+  font-family: inherit;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-badge);
+  line-height: 1.4;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+  transition: filter 0.15s ease;
+}
+
+.update-chip:hover {
+  filter: brightness(1.08);
+}
+
+.update-chip:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 1px;
+}
+
+/* Tooltip body: a compact version/release detail block. */
+.update-status__tooltip {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  text-align: left;
+}
+
+/* New / Current rows: a 2-col grid so the labels and version+date values line
+   up in their own columns. */
+.update-status__tooltip-rows {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 0.6rem;
+  row-gap: 0.2rem;
+}
+
+.update-status__tooltip-label {
+  color: var(--color-text-secondary);
+}
+
+.update-status__tooltip-date {
+  color: var(--color-text-secondary);
+}
+
+.update-status__tooltip-divider {
+  height: 1px;
+  margin: 0.15rem 0;
+  background: var(--color-border);
+}
+
+/* Release-notes body: the full notes, never truncated. Height is capped so a
+   long release scrolls within the (interactive) tooltip instead of running off
+   the viewport; all content stays reachable. */
+.update-status__tooltip-notes {
+  white-space: pre-wrap;
+  max-height: 50vh;
+  overflow-y: auto;
+  color: var(--color-text-secondary);
+  line-height: 1.35;
+}
+
+.update-status__tooltip-link {
+  align-self: flex-start;
+  margin-top: 0.15rem;
+  padding: 0;
+  background: none;
+  border: none;
+  font: inherit;
+  font-size: var(--font-size-xs);
+  color: var(--color-accent);
+  cursor: pointer;
+}
+
+.update-status__tooltip-link:hover {
+  text-decoration: underline;
+}
+
+.update-status__tooltip-link:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 1px;
+}

--- a/frontend/src/ui/status/UpdateStatus.test.tsx
+++ b/frontend/src/ui/status/UpdateStatus.test.tsx
@@ -102,6 +102,8 @@ describe('UpdateStatus', () => {
     expect(tooltip?.textContent).toContain('(2026-06-20)');
     const notes = container.querySelector('[data-testid="update-status-notes"]');
     expect(notes?.textContent).toContain('Fixed metrics permission notice');
+    // The markdown stripper is applied: bullets render as • (not raw "- ").
+    expect(notes?.textContent).toContain('•');
 
     // Clicking the chip opens the release/downloads page.
     act(() => {

--- a/frontend/src/ui/status/UpdateStatus.test.tsx
+++ b/frontend/src/ui/status/UpdateStatus.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * frontend/src/ui/status/UpdateStatus.test.tsx
+ *
+ * Covers the header update chip: it appears only when an update is available,
+ * opens the release URL on click, and wires version/release details into the
+ * hover tooltip. The shared Tooltip is mocked to expose its `content` so the
+ * test asserts THIS component's wiring, not Tooltip's hover/portal internals.
+ */
+import ReactDOM from 'react-dom/client';
+import { act } from 'react';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+
+const { readAppInfoMock, browserOpenURLMock } = vi.hoisted(() => ({
+  readAppInfoMock: vi.fn(),
+  browserOpenURLMock: vi.fn(),
+}));
+
+vi.mock('@/core/app-state-access', () => ({
+  requestAppState: ({ read }: { read: () => unknown }) => Promise.resolve(read()),
+  readAppInfo: () => readAppInfoMock(),
+}));
+
+vi.mock('@wailsjs/runtime/runtime', () => ({
+  BrowserOpenURL: (...args: unknown[]) => browserOpenURLMock(...args),
+}));
+
+vi.mock('@wailsjs/go/models', () => ({ backend: {} }));
+
+vi.mock('@shared/components/Tooltip', () => ({
+  __esModule: true,
+  default: ({ content, children }: { content: ReactNode; children: ReactNode }) => (
+    <span data-testid="tooltip">
+      {children}
+      <span data-testid="tooltip-content">{content}</span>
+    </span>
+  ),
+}));
+
+import UpdateStatus from './UpdateStatus';
+
+describe('UpdateStatus', () => {
+  let container: HTMLDivElement;
+  let root: ReactDOM.Root;
+
+  beforeAll(() => {
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = ReactDOM.createRoot(container);
+    readAppInfoMock.mockReset();
+    browserOpenURLMock.mockReset();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  const renderAndSettle = async () => {
+    await act(async () => {
+      root.render(<UpdateStatus />);
+    });
+    // Flush the app-info promise + the resulting state update.
+    await act(async () => {
+      await Promise.resolve();
+    });
+  };
+
+  it('renders a clickable info chip with version + release notes, and links to the notes page', async () => {
+    readAppInfoMock.mockResolvedValue({
+      update: {
+        currentVersion: '1.10.0',
+        latestVersion: '1.10.1',
+        publishedAt: '2026-07-05T12:00:00Z',
+        currentPublishedAt: '2026-06-20T12:00:00Z',
+        releaseUrl: 'https://example.com/releases/v1.10.1',
+        releaseNotes: '- Fixed metrics permission notice\n- Moved the update chip to the header',
+        isUpdateAvailable: true,
+      },
+    });
+
+    await renderAndSettle();
+
+    const chip = container.querySelector(
+      '[data-testid="update-status-chip"]'
+    ) as HTMLButtonElement | null;
+    expect(chip).not.toBeNull();
+    expect(chip?.textContent).toContain('Update available');
+
+    // Tooltip shows New/Current rows, each "<version> (YYYY-MM-DD)", plus the
+    // release notes preview. Dates format from UTC, so they're timezone-stable.
+    const tooltip = container.querySelector('[data-testid="tooltip-content"]');
+    expect(tooltip?.textContent).toContain('New');
+    expect(tooltip?.textContent).toContain('Current');
+    expect(tooltip?.textContent).toContain('1.10.1');
+    expect(tooltip?.textContent).toContain('1.10.0');
+    expect(tooltip?.textContent).toContain('(2026-07-05)');
+    expect(tooltip?.textContent).toContain('(2026-06-20)');
+    const notes = container.querySelector('[data-testid="update-status-notes"]');
+    expect(notes?.textContent).toContain('Fixed metrics permission notice');
+
+    // Clicking the chip opens the release/downloads page.
+    act(() => {
+      chip?.click();
+    });
+    expect(browserOpenURLMock).toHaveBeenCalledWith('https://example.com/releases/v1.10.1');
+
+    // The "Full release notes" link opens the version's tag page.
+    const notesLink = container.querySelector(
+      '[data-testid="update-status-notes-link"]'
+    ) as HTMLButtonElement | null;
+    act(() => {
+      notesLink?.click();
+    });
+    expect(browserOpenURLMock).toHaveBeenCalledWith(
+      'https://github.com/luxury-yacht/app/releases/tag/1.10.1'
+    );
+  });
+
+  it('renders nothing when no update is available', async () => {
+    readAppInfoMock.mockResolvedValue({ update: { isUpdateAvailable: false } });
+
+    await renderAndSettle();
+
+    expect(container.querySelector('[data-testid="update-status-chip"]')).toBeNull();
+  });
+
+  it('renders nothing when the update has no release URL', async () => {
+    readAppInfoMock.mockResolvedValue({
+      update: { isUpdateAvailable: true, latestVersion: '1.10.1', releaseUrl: '' },
+    });
+
+    await renderAndSettle();
+
+    expect(container.querySelector('[data-testid="update-status-chip"]')).toBeNull();
+  });
+});

--- a/frontend/src/ui/status/UpdateStatus.tsx
+++ b/frontend/src/ui/status/UpdateStatus.tsx
@@ -1,0 +1,157 @@
+/**
+ * frontend/src/ui/status/UpdateStatus.tsx
+ *
+ * Header info chip shown when a newer app release is available. Clickable to open
+ * the release page; hover reveals version + release details via the shared
+ * Tooltip. Owns the app-info fetch and the `app-update` runtime event (previously
+ * embedded in ClusterOverview).
+ */
+import React, { useCallback, useEffect, useState } from 'react';
+import Tooltip from '@shared/components/Tooltip';
+import { readAppInfo, requestAppState } from '@/core/app-state-access';
+import { BrowserOpenURL } from '@wailsjs/runtime/runtime';
+import { backend } from '@wailsjs/go/models';
+import './UpdateStatus.css';
+
+interface UpdateInfo {
+  currentVersion: string;
+  latestVersion: string;
+  releaseUrl: string;
+  releaseName?: string;
+  publishedAt?: string;
+  currentPublishedAt?: string;
+  checkedAt?: string;
+  isUpdateAvailable: boolean;
+  releaseNotes?: string;
+  error?: string;
+}
+
+type AppInfoWithUpdate = backend.AppInfo & {
+  update?: UpdateInfo | null;
+};
+
+// Full rendered release notes live on the version's GitHub release page.
+const RELEASE_NOTES_TAG_BASE = 'https://github.com/luxury-yacht/app/releases/tag/';
+
+// Render the ISO publish date as YYYY-MM-DD from its UTC components (matches
+// GitHub's UTC published_at and is timezone-stable); null when absent or
+// unparseable so the tooltip simply omits the date.
+const formatPublished = (iso?: string): string | null => {
+  if (!iso) {
+    return null;
+  }
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+const UpdateStatus: React.FC = () => {
+  const [updateInfo, setUpdateInfo] = useState<UpdateInfo | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    requestAppState({ resource: 'app-info', read: () => readAppInfo() })
+      .then((info) => {
+        if (active) {
+          setUpdateInfo((info as AppInfoWithUpdate).update ?? null);
+        }
+      })
+      .catch(() => {
+        // Update metadata is best-effort; stay silent if it can't be read.
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    const runtime = window.runtime;
+    if (!runtime?.EventsOn) {
+      return;
+    }
+    const handleUpdate = (...args: unknown[]) => {
+      const payload = args[0] as UpdateInfo | undefined;
+      if (payload) {
+        setUpdateInfo(payload);
+      }
+    };
+    runtime.EventsOn('app-update', handleUpdate);
+    return () => {
+      runtime.EventsOff?.('app-update', handleUpdate);
+    };
+  }, []);
+
+  const handleClick = useCallback(() => {
+    if (updateInfo?.releaseUrl) {
+      BrowserOpenURL(updateInfo.releaseUrl);
+    }
+  }, [updateInfo]);
+
+  if (!updateInfo?.isUpdateAvailable || !updateInfo.releaseUrl) {
+    return null;
+  }
+
+  const newDate = formatPublished(updateInfo.publishedAt);
+  const currentDate = formatPublished(updateInfo.currentPublishedAt);
+  const notes = updateInfo.releaseNotes?.trim();
+  const notesUrl = `${RELEASE_NOTES_TAG_BASE}${encodeURIComponent(updateInfo.latestVersion)}`;
+  const openNotes = () => BrowserOpenURL(notesUrl);
+  const renderVersion = (version: string, date: string | null) => (
+    <span>
+      {version}
+      {date && <span className="update-status__tooltip-date"> ({date})</span>}
+    </span>
+  );
+
+  const tooltip = (
+    <div className="update-status__tooltip">
+      <div className="update-status__tooltip-rows">
+        <span className="update-status__tooltip-label">New:</span>
+        {renderVersion(updateInfo.latestVersion, newDate)}
+        {updateInfo.currentVersion && (
+          <>
+            <span className="update-status__tooltip-label">Current:</span>
+            {renderVersion(updateInfo.currentVersion, currentDate)}
+          </>
+        )}
+      </div>
+      {notes && (
+        <>
+          <div className="update-status__tooltip-divider" />
+          <div className="update-status__tooltip-notes" data-testid="update-status-notes">
+            {notes}
+          </div>
+        </>
+      )}
+      <button
+        type="button"
+        className="update-status__tooltip-link"
+        onClick={openNotes}
+        data-testid="update-status-notes-link"
+      >
+        Full release notes ↗
+      </button>
+    </div>
+  );
+
+  return (
+    <Tooltip content={tooltip} className="update-status-tooltip" interactive maxWidth={360}>
+      <button
+        type="button"
+        className="update-chip"
+        onClick={handleClick}
+        aria-label={`Version ${updateInfo.latestVersion} available — open release page`}
+        data-testid="update-status-chip"
+      >
+        Update available
+      </button>
+    </Tooltip>
+  );
+};
+
+export default React.memo(UpdateStatus);

--- a/frontend/src/ui/status/UpdateStatus.tsx
+++ b/frontend/src/ui/status/UpdateStatus.tsx
@@ -11,6 +11,7 @@ import Tooltip from '@shared/components/Tooltip';
 import { readAppInfo, requestAppState } from '@/core/app-state-access';
 import { BrowserOpenURL } from '@wailsjs/runtime/runtime';
 import { backend } from '@wailsjs/go/models';
+import { toPlainReleaseNotes } from './releaseNotesText';
 import './UpdateStatus.css';
 
 interface UpdateInfo {
@@ -98,7 +99,7 @@ const UpdateStatus: React.FC = () => {
 
   const newDate = formatPublished(updateInfo.publishedAt);
   const currentDate = formatPublished(updateInfo.currentPublishedAt);
-  const notes = updateInfo.releaseNotes?.trim();
+  const notes = toPlainReleaseNotes(updateInfo.releaseNotes ?? '');
   const notesUrl = `${RELEASE_NOTES_TAG_BASE}${encodeURIComponent(updateInfo.latestVersion)}`;
   const openNotes = () => BrowserOpenURL(notesUrl);
   const renderVersion = (version: string, date: string | null) => (

--- a/frontend/src/ui/status/releaseNotesText.test.ts
+++ b/frontend/src/ui/status/releaseNotesText.test.ts
@@ -1,0 +1,47 @@
+/**
+ * frontend/src/ui/status/releaseNotesText.test.ts
+ *
+ * Verifies the release-notes markdown stripper produces clean plain text for the
+ * update tooltip preview.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { toPlainReleaseNotes } from './releaseNotesText';
+
+describe('toPlainReleaseNotes', () => {
+  it('returns empty string for empty input', () => {
+    expect(toPlainReleaseNotes('')).toBe('');
+  });
+
+  it('strips heading markers, keeping the text', () => {
+    expect(toPlainReleaseNotes('## Highlights')).toBe('Highlights');
+    expect(toPlainReleaseNotes('#### Deep heading')).toBe('Deep heading');
+  });
+
+  it('removes bold, inline code, and strikethrough markers', () => {
+    expect(toPlainReleaseNotes('**bold** and `code` and ~~gone~~')).toBe('bold and code and gone');
+    expect(toPlainReleaseNotes('__also bold__')).toBe('also bold');
+  });
+
+  it('reduces links to their text and drops images', () => {
+    expect(toPlainReleaseNotes('see [the docs](https://example.com/docs)')).toBe('see the docs');
+    expect(toPlainReleaseNotes('![screenshot](https://example.com/s.png)')).toBe('');
+  });
+
+  it('normalizes list bullets to • and preserves indentation', () => {
+    expect(toPlainReleaseNotes('- one\n* two\n+ three')).toBe('• one\n• two\n• three');
+    expect(toPlainReleaseNotes('  - nested')).toBe('  • nested');
+  });
+
+  it('drops horizontal rules and blockquote markers', () => {
+    expect(toPlainReleaseNotes('above\n---\nbelow')).toBe('above\n\nbelow');
+    expect(toPlainReleaseNotes('> a quoted note')).toBe('a quoted note');
+  });
+
+  it('handles a combined release body', () => {
+    const md = ['## What changed', '', '- Fixed [the bug](https://x)', '- **Improved** perf'].join(
+      '\n'
+    );
+    expect(toPlainReleaseNotes(md)).toBe('What changed\n\n• Fixed the bug\n• Improved perf');
+  });
+});

--- a/frontend/src/ui/status/releaseNotesText.ts
+++ b/frontend/src/ui/status/releaseNotesText.ts
@@ -1,0 +1,43 @@
+/**
+ * frontend/src/ui/status/releaseNotesText.ts
+ *
+ * Converts a GitHub release body (markdown) into clean plain text for the update
+ * tooltip preview: strips the common markers (headings, bold, inline code,
+ * strikethrough, links, images), drops horizontal rules, and normalizes list
+ * bullets to "•". Intentionally lightweight — not a markdown parser; the fully
+ * rendered notes are one click away on the release page. No HTML is produced.
+ */
+export const toPlainReleaseNotes = (markdown: string): string => {
+  if (!markdown) {
+    return '';
+  }
+
+  const lines = markdown.replace(/\r\n/g, '\n').split('\n');
+  const transformed = lines.map((line) => {
+    let text = line;
+    // Images have no place in a text preview — drop them entirely.
+    text = text.replace(/!\[[^\]]*\]\([^)]*\)/g, '');
+    // Links [text](url) -> text.
+    text = text.replace(/\[([^\]]*)\]\([^)]*\)/g, '$1');
+    // Horizontal rules (---, ***, ___) become a blank line.
+    if (/^\s*([-*_])\1{2,}\s*$/.test(text)) {
+      return '';
+    }
+    // Leading list marker (-, *, +) -> bullet, preserving indentation.
+    text = text.replace(/^(\s*)[-*+]\s+/, '$1• ');
+    // Leading heading (#…) / blockquote (>) markers -> drop marker, keep text.
+    text = text.replace(/^\s*#{1,6}\s+/, '');
+    text = text.replace(/^\s*>\s?/, '');
+    // Inline emphasis / code / strikethrough markers.
+    text = text.replace(/\*\*|__|~~|`/g, '');
+    return text.replace(/\s+$/, '');
+  });
+
+  // Collapse runs of blank lines so stripped headings/rules don't leave gaps,
+  // then drop leading/trailing blank lines (but keep the first line's indentation
+  // so a leading nested bullet stays nested).
+  return transformed
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/^\n+|\n+$/g, '');
+};

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -399,8 +399,10 @@ export namespace backend {
 	    releaseUrl: string;
 	    releaseName?: string;
 	    publishedAt?: string;
+	    currentPublishedAt?: string;
 	    checkedAt?: string;
 	    isUpdateAvailable: boolean;
+	    releaseNotes?: string;
 	    error?: string;
 	
 	    static createFrom(source: any = {}) {
@@ -414,8 +416,10 @@ export namespace backend {
 	        this.releaseUrl = source["releaseUrl"];
 	        this.releaseName = source["releaseName"];
 	        this.publishedAt = source["publishedAt"];
+	        this.currentPublishedAt = source["currentPublishedAt"];
 	        this.checkedAt = source["checkedAt"];
 	        this.isUpdateAvailable = source["isUpdateAvailable"];
+	        this.releaseNotes = source["releaseNotes"];
 	        this.error = source["error"];
 	    }
 	}


### PR DESCRIPTION
- Factory Reset now clears the app's on-disk cache, so it restores a true fresh-install state instead of leaving cached data behind.
- Better presentation of Cluster Overview permissions restrictions.
- Update notification moved into the app header for persistent visibility, and now shows release notes for the new version.