### PR TITLE
Fix: interactive OIDC exec credential plugins time out during preflight/recovery

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -17,7 +17,11 @@ const (
 	KubernetesClientBurst = 500
 
 	// KubernetesClientPreflightTimeout bounds the credential preflight check during client construction.
-	KubernetesClientPreflightTimeout = 8 * time.Second
+	// Must accommodate interactive exec credential plugins (e.g. kubectl-oidc_login/kubelogin) whose
+	// browser-based authcode flow can take well over a minute on first login or token expiry. kubelogin's
+	// own default authentication timeout is 180s, so we allow the same headroom here; otherwise the app
+	// would abort the login before the user can complete SSO in the browser.
+	KubernetesClientPreflightTimeout = 3 * time.Minute
 )
 
 // Refresh subsystem settings.
@@ -510,7 +514,10 @@ const (
 	ClusterAuthConnectivityRetryInterval = 15 * time.Second
 
 	// ClusterAuthRecoveryProbeTimeout bounds a single auth recovery probe request.
-	ClusterAuthRecoveryProbeTimeout = 10 * time.Second
+	// Sized to match the preflight timeout so an interactive exec credential plugin
+	// (e.g. kubectl-oidc_login/kubelogin) has time to complete its browser-based login
+	// during recovery instead of being killed mid-flow.
+	ClusterAuthRecoveryProbeTimeout = 3 * time.Minute
 
 	// ClusterAuthSteadyRetryInterval is the delay between recovery probes after
 	// the auth verdict has settled to invalid. The recovery loop never stops,


### PR DESCRIPTION
## Fix: interactive OIDC exec credential plugins time out during preflight/recovery

### Problem

Clusters that authenticate via an interactive exec credential plugin (e.g. `kubectl-oidc_login` / [kubelogin](https://github.com/int128/kubelogin)) fail to connect whenever a fresh browser login is required (first use, or after the cached ID/refresh token expires).

The kubeconfig is valid and works fine with `kubectl` and `k9s`. The exec block looks like this:

```yaml
exec:
  apiVersion: client.authentication.k8s.io/v1beta1
  command: /abs/path/to/kubectl-oidc_login
  args:
    - get-token
    - --oidc-issuer-url=https://...
    - --oidc-client-id=...
  interactiveMode: IfAvailable
```

### Root cause

The credential preflight and auth-recovery probes are bounded by short timeouts:

- `KubernetesClientPreflightTimeout = 8s`
- `ClusterAuthRecoveryProbeTimeout = 10s`

These deadlines also cover the exec credential fetch. When the plugin has to run its browser-based authorization-code flow, the user needs time to complete SSO in the browser — this routinely takes 30–60s+ (Email + Password + OTP). The app cancels the request after 8s (preflight) / 10s (recovery), tearing the login down before it can finish. Because the recovery probe uses the same short bound, the cluster stays stuck in a retry loop that can never complete an interactive login.

When a valid cached token exists, the plugin returns almost instantly and everything works — which is why the failure only appears once a real browser login is needed.

### Fix

Issue: #240 

Raise both timeouts to `3m`, matching kubelogin's own default `--authentication-timeout-sec=180`, so the app can wait for the interactive login instead of aborting it:

- `KubernetesClientPreflightTimeout`: `8s → 3m`
- `ClusterAuthRecoveryProbeTimeout`: `10s → 3m`

No behavior change for non-interactive auth (cached tokens, static tokens, client certs, etc.) — those resolve well within the window.

### Trade-off

An unreachable cluster now takes up to 3m to surface a connectivity error during preflight/recovery, instead of ~8s. This seemed an acceptable cost for supporting interactive OIDC; happy to discuss a more targeted approach (e.g. a separate, longer timeout only when `config.ExecProvider != nil`, or making it user-configurable) if you'd prefer to keep the fast fail path for non-exec clusters.

### Testing

- `go build ./backend/...` passes.