### PR TITLE
fix log scrolling

### DIFF
--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.css
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.css
@@ -282,8 +282,16 @@
   height: 18px;
 }
 
+.logs-viewer-content-frame {
+  flex: 1;
+  min-height: 0;
+  position: relative;
+  display: flex;
+}
+
 .logs-viewer-content {
   flex: 1;
+  min-height: 0;
   overflow: auto;
   background-color: var(--log-surface-bg);
   --terminal-theme-background: var(--log-surface-bg);
@@ -299,6 +307,32 @@
   position: relative;
   user-select: text;
   -webkit-user-select: text;
+}
+
+.logs-viewer-resume-scrolling {
+  position: absolute;
+  left: 50%;
+  bottom: var(--spacing-sm);
+  z-index: 2;
+  transform: translateX(-50%);
+  padding: var(--spacing-xs) var(--spacing-md);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  background: var(--button-generic-bg);
+  color: var(--button-generic-text);
+  box-shadow: var(--dropdown-menu-shadow);
+  cursor: pointer;
+  font: inherit;
+  white-space: nowrap;
+}
+
+.logs-viewer-resume-scrolling:hover {
+  background: var(--button-generic-hover);
+}
+
+.logs-viewer-resume-scrolling:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }
 
 .logs-viewer-content * {

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.test.tsx
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.test.tsx
@@ -1010,6 +1010,96 @@ describe('LogViewer active pod synchronisation', () => {
     expect(container.textContent).not.toContain('log line 200');
   });
 
+  it('freezes visible log rows while paused and resumes from a bottom overlay', async () => {
+    const originalScrollHeight = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'scrollHeight'
+    );
+    const originalClientHeight = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'clientHeight'
+    );
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get() {
+        return this.classList.contains('logs-viewer-content') ? 400 : 0;
+      },
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      get() {
+        return this.classList.contains('logs-viewer-content') ? 100 : 0;
+      },
+    });
+
+    const entry = (sequence: number): ContainerLogsEntry => ({
+      _seq: sequence,
+      pod: 'web-1',
+      container: 'app',
+      line: `anchored line ${sequence}`,
+      timestamp: `2024-05-01T10:00:0${sequence}Z`,
+      isInit: false,
+    });
+
+    try {
+      seedLogSnapshot([entry(1), entry(2), entry(3)]);
+      await renderViewer({ activePodNames: ['web-1'] });
+      await flushAsync();
+
+      const content = await waitForElement(() =>
+        container.querySelector<HTMLDivElement>('.logs-viewer-content')
+      );
+      content.scrollTop = 100;
+
+      await act(async () => {
+        seedLogSnapshot([entry(2), entry(3), entry(4)]);
+        await Promise.resolve();
+      });
+
+      expect(container.textContent).toContain('anchored line 1');
+      expect(container.textContent).toContain('anchored line 4');
+      expect(content.scrollTop).toBe(100);
+
+      let resumeButton = container.querySelector<HTMLButtonElement>(
+        'button[aria-label="Resume scrolling"]'
+      );
+      expect(resumeButton).not.toBeNull();
+
+      await act(async () => {
+        content.scrollTop = 300;
+        content.dispatchEvent(new Event('scroll'));
+      });
+      expect(
+        container.querySelector<HTMLButtonElement>('button[aria-label="Resume scrolling"]')
+      ).toBeNull();
+      expect(container.textContent).not.toContain('anchored line 1');
+
+      await act(async () => {
+        content.scrollTop = 100;
+        content.dispatchEvent(new Event('scroll'));
+      });
+      resumeButton = container.querySelector<HTMLButtonElement>(
+        'button[aria-label="Resume scrolling"]'
+      );
+      expect(resumeButton).not.toBeNull();
+      await act(async () => {
+        resumeButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        await Promise.resolve();
+      });
+
+      expect(container.textContent).not.toContain('anchored line 1');
+      expect(container.textContent).toContain('anchored line 4');
+      expect(content.scrollTop).toBe(400);
+    } finally {
+      if (originalScrollHeight) {
+        Object.defineProperty(HTMLElement.prototype, 'scrollHeight', originalScrollHeight);
+      }
+      if (originalClientHeight) {
+        Object.defineProperty(HTMLElement.prototype, 'clientHeight', originalClientHeight);
+      }
+    }
+  });
+
   it('colors API timestamps and container metadata only when showing all containers', async () => {
     (GetContainerLogsScopeContainers as unknown as ViMock).mockResolvedValue(['app', 'sidecar']);
     seedLogSnapshot(

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.test.tsx
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.test.tsx
@@ -1082,11 +1082,20 @@ describe('LogViewer active pod synchronisation', () => {
         'button[aria-label="Resume scrolling"]'
       );
       expect(resumeButton).not.toBeNull();
+      const autoRefreshButton = container.querySelector<HTMLButtonElement>(
+        'button[aria-label="Toggle auto-refresh"]'
+      );
+      expect(autoRefreshButton?.getAttribute('aria-pressed')).toBe('true');
+      await act(async () => {
+        autoRefreshButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+      expect(autoRefreshButton?.getAttribute('aria-pressed')).toBe('false');
       await act(async () => {
         resumeButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
         await Promise.resolve();
       });
 
+      expect(autoRefreshButton?.getAttribute('aria-pressed')).toBe('true');
       expect(container.textContent).not.toContain('anchored line 1');
       expect(container.textContent).toContain('anchored line 4');
       expect(content.scrollTop).toBe(400);

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.tsx
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.tsx
@@ -68,7 +68,8 @@ import {
 import { INACTIVE_SCOPE } from '../constants';
 import { containsAnsi, parseAnsiTextSegments, stripAnsi } from './ansi';
 import { setContainerLogsStreamScopeParams } from './containerLogsStreamScopeParamsCache';
-import { useLogScrollRestoration } from './hooks/useLogScrollRestoration';
+import { useAnchoredLogEntries } from './hooks/useAnchoredLogEntries';
+import { isLogScrollAtBottom, useLogScrollRestoration } from './hooks/useLogScrollRestoration';
 import { useTerminalTheme } from './hooks/useTerminalTheme';
 import { buildCsv } from './logExport';
 import {
@@ -387,6 +388,7 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
   const [apiTimestampUseLocalTimeZone, setApiTimestampUseLocalTimeZoneState] =
     React.useState<boolean>(() => getObjPanelLogsApiTimestampUseLocalTimeZone());
   const [isObjPanelLogsSettingsOpen, setIsObjPanelLogsSettingsOpen] = React.useState(false);
+  const [isTailFollowing, setIsTailFollowing] = React.useState(true);
 
   // Destructure commonly used state for readability
   const {
@@ -551,15 +553,33 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
   const payloadEntries = containerLogsScope ? logSnapshot.data?.entries : undefined;
   const rawLogEntries: ContainerLogsEntry[] = useMemo(() => payloadEntries ?? [], [payloadEntries]);
 
-  // ContainerLogsStreamManager already caps rawLogEntries at the user-configured
-  // buffer size, so we can use it directly. The old stable-list merge
-  // logic existed to keep the viewport anchored while reading in place
-  // with autoScroll off, but now that tail-following is derived from
-  // scroll position (see the smart auto-scroll effect below), the
-  // stable list is unnecessary — new entries arrive at the bottom,
-  // buffer rotation drops the oldest, and the smart-scroll effect only
-  // tail-follows when the user is already at the bottom anyway.
-  const logEntries: ContainerLogsEntry[] = rawLogEntries;
+  const anchoredLogSourceKey = useMemo(
+    () =>
+      JSON.stringify([
+        resolvedClusterId,
+        containerLogsScope,
+        backendLogSelection.selectedFilters,
+        backendLogSelection.matchNone,
+        showPreviousContainerLogs,
+      ]),
+    [
+      backendLogSelection.matchNone,
+      backendLogSelection.selectedFilters,
+      containerLogsScope,
+      resolvedClusterId,
+      showPreviousContainerLogs,
+    ]
+  );
+  const activeScrollContainer = isParsedView
+    ? logsContentRef.current?.querySelector<HTMLElement>('.gridtable-wrapper')
+    : logsContentRef.current;
+  const shouldFollowTailForCurrentRender =
+    isTailFollowing && (!activeScrollContainer || isLogScrollAtBottom(activeScrollContainer));
+  const logEntries = useAnchoredLogEntries(
+    rawLogEntries,
+    shouldFollowTailForCurrentRender,
+    anchoredLogSourceKey
+  );
   const snapshotStatus = containerLogsScope ? logSnapshot.status : 'idle';
   const snapshotError = containerLogsScope ? logSnapshot.error : null;
   // sequence 1 = connected event, sequence >= 2 = initial logs received (may be empty)
@@ -1682,7 +1702,7 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
     };
   }, [isWorkload, containerLogsScope, resolvedClusterId]);
 
-  useLogScrollRestoration({
+  const { resumeTailFollowing } = useLogScrollRestoration({
     rootRef: logsContentRef,
     isParsedView,
     rowCount: isParsedView ? parsedContainerLogs.length : logEntries.length,
@@ -1690,6 +1710,7 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
     cacheKey: panelId,
     getScrollTop: getLogViewerScrollTop,
     setScrollTop: setLogViewerScrollTop,
+    onTailFollowingChange: setIsTailFollowing,
   });
 
   const derivedFieldKeys = useMemo(
@@ -2250,27 +2271,39 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
             </div>
           )}
 
-          <div className="logs-viewer-content selectable" ref={logsContentRef} tabIndex={-1}>
-            {isParsedView ? (
-              <ParsedLogTable
-                rows={parsedContainerLogs}
-                columns={tableColumns}
-                expandedRows={expandedRows}
-                onToggleRow={handleToggleParsedRow}
-              />
-            ) : displayLogs ? (
-              <RawLogViewer
-                rows={renderedDisplayRows}
-                scrollContainerRef={logsContentRef}
-                wrapText={wrapText}
-                renderRow={renderRawLogRow}
-                virtualizationThreshold={RAW_LOG_VIRTUALIZATION_THRESHOLD}
-                virtualizationOverscan={RAW_LOG_VIRTUALIZATION_OVERSCAN}
-                estimateRowHeight={RAW_LOG_ESTIMATE_ROW_HEIGHT}
-                verticalPaddingPx={RAW_LOG_VERTICAL_PADDING_PX}
-              />
-            ) : (
-              emptyStateMessage
+          <div className="logs-viewer-content-frame">
+            <div className="logs-viewer-content selectable" ref={logsContentRef} tabIndex={-1}>
+              {isParsedView ? (
+                <ParsedLogTable
+                  rows={parsedContainerLogs}
+                  columns={tableColumns}
+                  expandedRows={expandedRows}
+                  onToggleRow={handleToggleParsedRow}
+                />
+              ) : displayLogs ? (
+                <RawLogViewer
+                  rows={renderedDisplayRows}
+                  scrollContainerRef={logsContentRef}
+                  wrapText={wrapText}
+                  renderRow={renderRawLogRow}
+                  virtualizationThreshold={RAW_LOG_VIRTUALIZATION_THRESHOLD}
+                  virtualizationOverscan={RAW_LOG_VIRTUALIZATION_OVERSCAN}
+                  estimateRowHeight={RAW_LOG_ESTIMATE_ROW_HEIGHT}
+                  verticalPaddingPx={RAW_LOG_VERTICAL_PADDING_PX}
+                />
+              ) : (
+                emptyStateMessage
+              )}
+            </div>
+            {!isTailFollowing && (
+              <button
+                type="button"
+                className="logs-viewer-resume-scrolling"
+                aria-label="Resume scrolling"
+                onClick={resumeTailFollowing}
+              >
+                Resume scrolling
+              </button>
             )}
           </div>
         </div>

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.tsx
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.tsx
@@ -1712,6 +1712,12 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
     setScrollTop: setLogViewerScrollTop,
     onTailFollowingChange: setIsTailFollowing,
   });
+  const handleResumeScrolling = useCallback(() => {
+    if (!autoRefresh) {
+      dispatch({ type: 'TOGGLE_AUTO_REFRESH' });
+    }
+    resumeTailFollowing();
+  }, [autoRefresh, resumeTailFollowing]);
 
   const derivedFieldKeys = useMemo(
     () => deriveParsedLogFieldKeys(parsedContainerLogs),
@@ -2300,7 +2306,7 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
                 type="button"
                 className="logs-viewer-resume-scrolling"
                 aria-label="Resume scrolling"
-                onClick={resumeTailFollowing}
+                onClick={handleResumeScrolling}
               >
                 Resume scrolling
               </button>

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewerStyles.test.ts
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewerStyles.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const styles = readFileSync(
+  resolve(process.cwd(), 'src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.css'),
+  'utf8'
+);
+
+const ruleBody = (selector: string): string | undefined =>
+  styles.match(new RegExp(`${selector.replace(/\./g, '\\.')}\\s*\\{([^}]*)\\}`))?.[1];
+
+describe('LogViewer styles', () => {
+  it('presents the resume-scrolling overlay as a neutral control', () => {
+    const baseRule = ruleBody('.logs-viewer-resume-scrolling');
+    const hoverRule = ruleBody('.logs-viewer-resume-scrolling:hover');
+
+    expect(baseRule, 'Missing resume-scrolling base rule').toBeDefined();
+    expect(hoverRule, 'Missing resume-scrolling hover rule').toBeDefined();
+    expect(baseRule).toContain('var(--button-generic-bg)');
+    expect(baseRule).toContain('var(--button-generic-text)');
+    expect(hoverRule).toContain('var(--button-generic-hover)');
+    expect(`${baseRule}${hoverRule}`).not.toMatch(/button-(?:action|warning)-/);
+  });
+});

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/hooks/useAnchoredLogEntries.test.ts
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/hooks/useAnchoredLogEntries.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import type { ContainerLogsEntry } from '@/core/refresh/types';
+import { mergeAnchoredLogEntries } from './useAnchoredLogEntries';
+
+const entry = (sequence: number, lineNumber = sequence): ContainerLogsEntry => ({
+  _seq: sequence,
+  timestamp: `2024-05-01T10:00:${String(lineNumber).padStart(2, '0')}Z`,
+  pod: 'web-1',
+  container: 'app',
+  line: `line ${lineNumber}`,
+  isInit: false,
+});
+
+describe('mergeAnchoredLogEntries', () => {
+  it('retains trimmed head entries and appends the new tail', () => {
+    const current = [entry(1), entry(2), entry(3)];
+    const incoming = [entry(2), entry(3), entry(4)];
+
+    expect(mergeAnchoredLogEntries(current, incoming).map(({ line }) => line)).toEqual([
+      'line 1',
+      'line 2',
+      'line 3',
+      'line 4',
+    ]);
+  });
+
+  it('recognizes fallback snapshot overlap when sequence keys are regenerated', () => {
+    const current = [entry(1, 1), entry(2, 2), entry(3, 3)];
+    const incoming = [entry(101, 1), entry(102, 2), entry(103, 3), entry(104, 4)];
+
+    expect(mergeAnchoredLogEntries(current, incoming).map(({ line }) => line)).toEqual([
+      'line 1',
+      'line 2',
+      'line 3',
+      'line 4',
+    ]);
+  });
+
+  it('keeps the anchored snapshot when an incoming snapshot is already represented', () => {
+    const current = [entry(1), entry(2), entry(3), entry(4)];
+    const incoming = [entry(2), entry(3), entry(4)];
+
+    expect(mergeAnchoredLogEntries(current, incoming)).toBe(current);
+  });
+});

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/hooks/useAnchoredLogEntries.ts
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/hooks/useAnchoredLogEntries.ts
@@ -1,0 +1,94 @@
+import { useLayoutEffect, useMemo, useRef } from 'react';
+import type { ContainerLogsEntry } from '@/core/refresh/types';
+
+const entryContentKey = (entry: ContainerLogsEntry): string =>
+  JSON.stringify([
+    entry.timestamp,
+    entry.pod,
+    entry.container,
+    entry.line,
+    entry.isInit,
+    Boolean(entry.isEphemeral),
+  ]);
+
+const longestSuffixPrefixOverlap = (
+  currentEntries: ContainerLogsEntry[],
+  incomingEntries: ContainerLogsEntry[]
+): number => {
+  if (currentEntries.length === 0 || incomingEntries.length === 0) {
+    return 0;
+  }
+
+  const pattern = incomingEntries.map(entryContentKey);
+  const prefixLengths = new Uint32Array(pattern.length);
+  // Build a prefix table so a rolling buffer can be matched in linear time,
+  // even when fallback refreshes regenerate the entries' render sequences.
+  for (let index = 1, matched = 0; index < pattern.length; index += 1) {
+    while (matched > 0 && pattern[index] !== pattern[matched]) {
+      matched = prefixLengths[matched - 1];
+    }
+    if (pattern[index] === pattern[matched]) {
+      matched += 1;
+    }
+    prefixLengths[index] = matched;
+  }
+
+  let matched = 0;
+  const comparisonStart = Math.max(0, currentEntries.length - incomingEntries.length);
+  for (let index = comparisonStart; index < currentEntries.length; index += 1) {
+    const key = entryContentKey(currentEntries[index]);
+    while (matched > 0 && key !== pattern[matched]) {
+      matched = prefixLengths[matched - 1];
+    }
+    if (key === pattern[matched]) {
+      matched += 1;
+    }
+    if (matched === pattern.length && index < currentEntries.length - 1) {
+      matched = prefixLengths[matched - 1];
+    }
+  }
+
+  return matched;
+};
+
+export const mergeAnchoredLogEntries = (
+  currentEntries: ContainerLogsEntry[],
+  incomingEntries: ContainerLogsEntry[]
+): ContainerLogsEntry[] => {
+  if (currentEntries.length === 0) {
+    return incomingEntries;
+  }
+  if (incomingEntries.length === 0) {
+    return currentEntries;
+  }
+
+  const overlap = longestSuffixPrefixOverlap(currentEntries, incomingEntries);
+  if (overlap === incomingEntries.length) {
+    return currentEntries;
+  }
+  return [...currentEntries, ...incomingEntries.slice(overlap)];
+};
+
+export const useAnchoredLogEntries = (
+  entries: ContainerLogsEntry[],
+  isTailFollowing: boolean,
+  sourceKey: string
+): ContainerLogsEntry[] => {
+  const anchoredEntriesRef = useRef(entries);
+  const sourceKeyRef = useRef(sourceKey);
+
+  const displayEntries = useMemo(() => {
+    if (sourceKeyRef.current !== sourceKey || isTailFollowing) {
+      return entries;
+    }
+
+    return mergeAnchoredLogEntries(anchoredEntriesRef.current, entries);
+  }, [entries, isTailFollowing, sourceKey]);
+
+  useLayoutEffect(() => {
+    sourceKeyRef.current = sourceKey;
+    anchoredEntriesRef.current = displayEntries;
+  }, [displayEntries, sourceKey]);
+
+  return displayEntries;
+};

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/hooks/useLogScrollRestoration.test.tsx
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/hooks/useLogScrollRestoration.test.tsx
@@ -1,0 +1,237 @@
+import { act, useRef, useState } from 'react';
+import * as ReactDOM from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useLogScrollRestoration } from './useLogScrollRestoration';
+
+const getScrollTop = vi.fn(() => undefined);
+const setScrollTop = vi.fn();
+
+interface HarnessProps {
+  rowCount: number;
+  tailFollowSignal: number;
+  isParsedView?: boolean;
+  scrollHeight?: number;
+  showScrollContainer?: boolean;
+}
+
+const setScrollMetrics = (node: HTMLDivElement, scrollHeight: number) => {
+  Object.defineProperty(node, 'scrollHeight', { configurable: true, value: scrollHeight });
+  Object.defineProperty(node, 'clientHeight', { configurable: true, value: 100 });
+};
+
+const Harness = ({
+  rowCount,
+  tailFollowSignal,
+  isParsedView = false,
+  scrollHeight = 1_000,
+  showScrollContainer = true,
+}: HarnessProps) => {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [isTailFollowing, setIsTailFollowing] = useState(true);
+  useLogScrollRestoration({
+    rootRef,
+    isParsedView,
+    rowCount,
+    tailFollowSignal,
+    cacheKey: 'panel-a',
+    getScrollTop,
+    setScrollTop,
+    onTailFollowingChange: setIsTailFollowing,
+  });
+
+  return (
+    <>
+      {showScrollContainer ? (
+        <div
+          ref={(node) => {
+            rootRef.current = node;
+            if (node && !isParsedView) {
+              setScrollMetrics(node, scrollHeight);
+            }
+          }}
+        >
+          {isParsedView ? (
+            <div
+              className="gridtable-wrapper"
+              ref={(node) => {
+                if (node) {
+                  setScrollMetrics(node, scrollHeight);
+                }
+              }}
+            />
+          ) : null}
+        </div>
+      ) : null}
+      <output data-testid="tail-follow-state">{isTailFollowing ? 'following' : 'paused'}</output>
+    </>
+  );
+};
+
+describe('useLogScrollRestoration', () => {
+  let container: HTMLDivElement;
+  let root: ReactDOM.Root;
+  let nextFrameId = 1;
+  let frames = new Map<number, FrameRequestCallback>();
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = ReactDOM.createRoot(container);
+    frames = new Map();
+    nextFrameId = 1;
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      const id = nextFrameId++;
+      frames.set(id, callback);
+      return id;
+    });
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+      frames.delete(id);
+    });
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  const flushFrames = () => {
+    const pending = [...frames.values()];
+    frames.clear();
+    for (const callback of pending) {
+      callback(0);
+    }
+  };
+
+  it('preserves a manual scroll that interrupts queued tail-following', async () => {
+    await act(async () => {
+      root.render(<Harness rowCount={1} tailFollowSignal={1} />);
+    });
+    act(flushFrames);
+
+    const scrollElement = container.firstElementChild as HTMLDivElement;
+    expect(scrollElement.scrollTop).toBe(1_000);
+
+    await act(async () => {
+      root.render(<Harness rowCount={2} tailFollowSignal={2} />);
+    });
+
+    scrollElement.scrollTop = 300;
+    scrollElement.dispatchEvent(new Event('scroll'));
+    act(flushFrames);
+
+    expect(scrollElement.scrollTop).toBe(300);
+  });
+
+  it('preserves a manual scroll when refresh renders before the browser scroll event', async () => {
+    await act(async () => {
+      root.render(<Harness rowCount={1} tailFollowSignal={1} />);
+    });
+    act(flushFrames);
+
+    const scrollElement = container.firstElementChild as HTMLDivElement;
+    expect(scrollElement.scrollTop).toBe(1_000);
+
+    scrollElement.scrollTop = 300;
+    await act(async () => {
+      root.render(<Harness rowCount={2} tailFollowSignal={2} />);
+    });
+    act(flushFrames);
+
+    expect(scrollElement.scrollTop).toBe(300);
+  });
+
+  it('continues tail-following when refresh changes content without manual scrolling', async () => {
+    await act(async () => {
+      root.render(<Harness rowCount={1} tailFollowSignal={1} />);
+    });
+    act(flushFrames);
+
+    const scrollElement = container.firstElementChild as HTMLDivElement;
+    expect(scrollElement.scrollTop).toBe(1_000);
+
+    await act(async () => {
+      root.render(<Harness rowCount={2} tailFollowSignal={2} scrollHeight={1_200} />);
+    });
+    act(flushFrames);
+
+    expect(scrollElement.scrollTop).toBe(1_200);
+  });
+
+  it('resumes when the user reaches the prior bottom before refresh extends it', async () => {
+    await act(async () => {
+      root.render(<Harness rowCount={1} tailFollowSignal={1} />);
+    });
+    act(flushFrames);
+
+    const scrollElement = container.firstElementChild as HTMLDivElement;
+    const tailFollowState = () =>
+      container.querySelector<HTMLOutputElement>('[data-testid="tail-follow-state"]')?.textContent;
+
+    await act(async () => {
+      scrollElement.scrollTop = 300;
+      scrollElement.dispatchEvent(new Event('scroll'));
+    });
+    expect(tailFollowState()).toBe('paused');
+
+    scrollElement.scrollTop = 900;
+    await act(async () => {
+      root.render(<Harness rowCount={2} tailFollowSignal={2} scrollHeight={1_200} />);
+    });
+    await act(async () => {
+      scrollElement.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(tailFollowState()).toBe('following');
+  });
+
+  it('pauses immediately when the viewport mounts after loading and no more logs arrive', async () => {
+    await act(async () => {
+      root.render(<Harness rowCount={0} tailFollowSignal={0} showScrollContainer={false} />);
+    });
+    await act(async () => {
+      root.render(<Harness rowCount={1} tailFollowSignal={1} />);
+    });
+    act(flushFrames);
+
+    const scrollElement = container.firstElementChild as HTMLDivElement;
+    await act(async () => {
+      scrollElement.scrollTop = 300;
+      scrollElement.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(
+      container.querySelector<HTMLOutputElement>('[data-testid="tail-follow-state"]')?.textContent
+    ).toBe('paused');
+  });
+
+  it('stops parsed-view layout retries when manual scrolling interrupts tail-following', async () => {
+    await act(async () => {
+      root.render(<Harness rowCount={1} tailFollowSignal={1} isParsedView />);
+    });
+    act(flushFrames);
+    act(flushFrames);
+
+    await act(async () => {
+      root.render(<Harness rowCount={2} tailFollowSignal={2} isParsedView scrollHeight={100} />);
+    });
+    act(flushFrames);
+
+    await act(async () => {
+      root.render(<Harness rowCount={2} tailFollowSignal={2} isParsedView scrollHeight={1_000} />);
+    });
+    const scrollElement = container.querySelector<HTMLDivElement>('.gridtable-wrapper');
+    expect(scrollElement).not.toBeNull();
+    if (!scrollElement) {
+      return;
+    }
+
+    scrollElement.scrollTop = 300;
+    scrollElement.dispatchEvent(new Event('scroll'));
+    act(flushFrames);
+
+    expect(frames.size).toBe(0);
+    expect(scrollElement.scrollTop).toBe(300);
+  });
+});

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/hooks/useLogScrollRestoration.ts
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/hooks/useLogScrollRestoration.ts
@@ -9,9 +9,35 @@ interface LogScrollRestorationOptions {
   getScrollTop: (cacheKey: string) => number | undefined;
   setScrollTop: (cacheKey: string, scrollTop: number) => void;
   forceTailOnNextRestore?: boolean;
+  onTailFollowingChange?: (isTailFollowing: boolean) => void;
 }
 
 const AT_BOTTOM_THRESHOLD_PX = 16;
+
+interface KnownScrollPosition {
+  element: HTMLElement;
+  scrollTop: number;
+  scrollHeight: number;
+}
+
+export const isLogScrollAtBottom = (scrollElement: HTMLElement): boolean =>
+  scrollElement.scrollTop + scrollElement.clientHeight >=
+  scrollElement.scrollHeight - AT_BOTTOM_THRESHOLD_PX;
+
+const captureScrollPosition = (scrollElement: HTMLElement): KnownScrollPosition => ({
+  element: scrollElement,
+  scrollTop: scrollElement.scrollTop,
+  scrollHeight: scrollElement.scrollHeight,
+});
+
+const reachedKnownBottom = (
+  scrollElement: HTMLElement,
+  knownPosition: KnownScrollPosition | null
+): boolean =>
+  knownPosition?.element === scrollElement &&
+  scrollElement.scrollTop > knownPosition.scrollTop &&
+  scrollElement.scrollTop + scrollElement.clientHeight >=
+    knownPosition.scrollHeight - AT_BOTTOM_THRESHOLD_PX;
 
 export const useLogScrollRestoration = ({
   rootRef,
@@ -22,17 +48,34 @@ export const useLogScrollRestoration = ({
   getScrollTop,
   setScrollTop,
   forceTailOnNextRestore = false,
+  onTailFollowingChange,
 }: LogScrollRestorationOptions) => {
   const scrollRestoredRef = useRef(false);
   const wasAtBottomRef = useRef(true);
+  const knownScrollPositionRef = useRef<KnownScrollPosition | null>(null);
   const forceTailRestoreRef = useRef(forceTailOnNextRestore);
   const previousCacheKeyRef = useRef(cacheKey);
 
-  const resetScrollRestoration = useCallback((options: { forceTail?: boolean } = {}) => {
-    scrollRestoredRef.current = false;
-    wasAtBottomRef.current = true;
-    forceTailRestoreRef.current = Boolean(options.forceTail);
-  }, []);
+  const setTailFollowing = useCallback(
+    (isTailFollowing: boolean) => {
+      if (wasAtBottomRef.current === isTailFollowing) {
+        return;
+      }
+      wasAtBottomRef.current = isTailFollowing;
+      onTailFollowingChange?.(isTailFollowing);
+    },
+    [onTailFollowingChange]
+  );
+
+  const resetScrollRestoration = useCallback(
+    (options: { forceTail?: boolean } = {}) => {
+      scrollRestoredRef.current = false;
+      setTailFollowing(true);
+      knownScrollPositionRef.current = null;
+      forceTailRestoreRef.current = Boolean(options.forceTail);
+    },
+    [setTailFollowing]
+  );
 
   useEffect(() => {
     if (previousCacheKeyRef.current === cacheKey) {
@@ -54,15 +97,24 @@ export const useLogScrollRestoration = ({
   }, [isParsedView, rootRef]);
 
   useEffect(() => {
+    // The scroll container is conditionally mounted after loading. Re-check it
+    // when rows arrive so scrolling does not depend on a later refresh.
+    void rowCount;
     const scrollEl = getScrollContainer();
     if (!scrollEl) {
       return;
     }
 
     const handler = () => {
-      wasAtBottomRef.current =
-        scrollEl.scrollTop + scrollEl.clientHeight >=
-        scrollEl.scrollHeight - AT_BOTTOM_THRESHOLD_PX;
+      const knownPosition = knownScrollPositionRef.current;
+      const shouldFollowTail =
+        isLogScrollAtBottom(scrollEl) ||
+        reachedKnownBottom(scrollEl, knownPosition) ||
+        (wasAtBottomRef.current &&
+          knownPosition?.element === scrollEl &&
+          knownPosition.scrollTop === scrollEl.scrollTop);
+      knownScrollPositionRef.current = captureScrollPosition(scrollEl);
+      setTailFollowing(shouldFollowTail);
       if (!scrollRestoredRef.current) {
         return;
       }
@@ -73,7 +125,7 @@ export const useLogScrollRestoration = ({
     return () => {
       scrollEl.removeEventListener('scroll', handler);
     };
-  }, [cacheKey, getScrollContainer, setScrollTop]);
+  }, [cacheKey, getScrollContainer, rowCount, setScrollTop, setTailFollowing]);
 
   useEffect(() => {
     if (scrollRestoredRef.current || rowCount === 0) {
@@ -93,14 +145,34 @@ export const useLogScrollRestoration = ({
         : maxScrollTop;
 
     scrollEl.scrollTop = targetScrollTop;
+    knownScrollPositionRef.current = captureScrollPosition(scrollEl);
+    setTailFollowing(isLogScrollAtBottom(scrollEl));
     scrollRestoredRef.current = true;
     forceTailRestoreRef.current = false;
-  }, [cacheKey, getScrollContainer, getScrollTop, rowCount]);
+  }, [cacheKey, getScrollContainer, getScrollTop, rowCount, setTailFollowing]);
 
   useEffect(() => {
     void rowCount;
     void tailFollowSignal;
-    if (!wasAtBottomRef.current || !scrollRestoredRef.current) {
+    const shouldFollowTail = () => {
+      const element = getScrollContainer();
+      if (!element || !scrollRestoredRef.current) {
+        return false;
+      }
+
+      // A scrollbar drag or wheel update can change scrollTop before the browser
+      // dispatches its scroll event. Compare the live DOM position with the last
+      // position we observed so a refresh cannot overtake that manual movement.
+      const knownPosition = knownScrollPositionRef.current;
+      if (knownPosition?.element === element && knownPosition.scrollTop !== element.scrollTop) {
+        setTailFollowing(
+          isLogScrollAtBottom(element) || reachedKnownBottom(element, knownPosition)
+        );
+      }
+      knownScrollPositionRef.current = captureScrollPosition(element);
+      return wasAtBottomRef.current;
+    };
+    if (!shouldFollowTail()) {
       return;
     }
 
@@ -111,17 +183,24 @@ export const useLogScrollRestoration = ({
 
     let rafId: number | undefined;
     const scrollToBottom = () => {
+      if (!shouldFollowTail()) {
+        return;
+      }
       const element = getScrollContainer();
       if (!element) {
         return;
       }
       element.scrollTop = element.scrollHeight;
+      knownScrollPositionRef.current = captureScrollPosition(element);
     };
 
     if (isParsedView) {
       let attempts = 0;
       const maxAttempts = 20;
       const checkAndScroll = () => {
+        if (!shouldFollowTail()) {
+          return;
+        }
         const element = getScrollContainer();
         if (element && element.scrollHeight > element.clientHeight) {
           rafId = requestAnimationFrame(scrollToBottom);
@@ -140,7 +219,19 @@ export const useLogScrollRestoration = ({
         cancelAnimationFrame(rafId);
       }
     };
-  }, [getScrollContainer, isParsedView, tailFollowSignal, rowCount]);
+  }, [getScrollContainer, isParsedView, tailFollowSignal, rowCount, setTailFollowing]);
 
-  return { getScrollContainer, resetScrollRestoration };
+  const resumeTailFollowing = useCallback(() => {
+    const scrollEl = getScrollContainer();
+    if (!scrollEl) {
+      return;
+    }
+    scrollEl.scrollTop = scrollEl.scrollHeight;
+    knownScrollPositionRef.current = captureScrollPosition(scrollEl);
+    scrollRestoredRef.current = true;
+    setScrollTop(cacheKey, scrollEl.scrollTop);
+    setTailFollowing(true);
+  }, [cacheKey, getScrollContainer, setScrollTop, setTailFollowing]);
+
+  return { getScrollContainer, resetScrollRestoration, resumeTailFollowing };
 };


### PR DESCRIPTION
Fix container log scrolling behavior. When user scrolls, the logs remain fixed in the viewport, while continuing to buffer in the background. A `resume scrolling` button appears to jump to the bottom of the logs and resume scrolling.