### PR TITLE
cluster tab changes should not cause a reload every time

### DIFF
--- a/docs/architecture/multi-cluster.md
+++ b/docs/architecture/multi-cluster.md
@@ -12,6 +12,10 @@ another cluster.
 - Do not infer a cluster from the active tab after data has crossed a boundary.
 - Treat the active tab as foreground selection only. Open inactive tabs are
   retained workspaces, not disposed views.
+- Foreground activation must finish any backend governor re-warm before the new
+  `clusterId` is published to data consumers. A tab-only switch must not trigger
+  a manual refresh; streaming scope activation fetches only when that
+  cluster-scoped state has no snapshot yet.
 - Refresh domains are single-cluster. Cross-cluster summaries fan out over
   per-cluster state instead of inventing aggregate refresh scopes.
 - Cluster add, close, replace, and clear actions must go through the unified

--- a/docs/release/pending.md
+++ b/docs/release/pending.md
@@ -52,5 +52,7 @@
 
 ### Fixed
 
+- Kept cluster-scoped data in place when switching open cluster tabs instead of
+  triggering a manual refresh or racing the backend foreground re-warm.
 - Refreshed YAML and object maps when versionless snapshot payloads change, so
   deleted or updated objects no longer remain visible from a stale response.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,2 +1,1 @@
-- Switching cluster tabs sometimes reloads data
 - Intermittent "awaiting metrics data", check the thresholds for that

--- a/frontend/src/core/refresh/RefreshManager.test.ts
+++ b/frontend/src/core/refresh/RefreshManager.test.ts
@@ -403,6 +403,29 @@ describe('RefreshManager context updates', () => {
     expect(abortSpy).toHaveBeenCalledWith(NAME);
     expect(manualSpy).toHaveBeenCalledWith(expect.arrayContaining([NAME]));
   });
+
+  it('does not turn a foreground cluster-tab switch into a manual data refresh', async () => {
+    const manualSpy = vi.spyOn(refreshManager, 'triggerManualRefreshMany').mockResolvedValue();
+
+    refreshManager.updateContext({
+      currentView: 'cluster',
+      activeClusterView: 'config',
+      selectedClusterId: 'cluster-a',
+      selectedClusterIds: ['cluster-a'],
+      allConnectedClusterIds: ['cluster-a', 'cluster-b'],
+      backgroundRefreshEnabled: false,
+      objectPanel: { isOpen: false },
+    });
+    manualSpy.mockClear();
+
+    refreshManager.updateContext({
+      selectedClusterId: 'cluster-b',
+      selectedClusterIds: ['cluster-b'],
+    });
+
+    await Promise.resolve();
+    expect(manualSpy).not.toHaveBeenCalled();
+  });
 });
 
 describe('RefreshManager global controls', () => {
@@ -972,7 +995,7 @@ describe('RefreshManager guard paths and helpers', () => {
     expect(manualTargets).toEqual([]);
   });
 
-  it('refreshes cluster manual targets on tab switch when background refresh is disabled', () => {
+  it('does not create cluster manual targets from a tab switch when background refresh is disabled', () => {
     const previous: RefreshContext = {
       currentView: 'cluster',
       activeClusterView: 'config',
@@ -990,7 +1013,7 @@ describe('RefreshManager guard paths and helpers', () => {
 
     const manualTargets = unsafeRefreshManager.getManualRefreshTargets(previous, current);
 
-    expect(manualTargets).toEqual(['cluster-config']);
+    expect(manualTargets).toEqual([]);
   });
 
   it('refreshes the active cluster view when the selected cluster set changes', () => {

--- a/frontend/src/core/refresh/RefreshManager.ts
+++ b/frontend/src/core/refresh/RefreshManager.ts
@@ -506,17 +506,13 @@ class RefreshManager {
       }
       return true;
     };
-    // Switching active clusters should refresh the active view even if the view type is unchanged.
-    const clusterChanged = previous.selectedClusterId !== current.selectedClusterId;
     const connectedClusterSelectionChanged = !hasSameClusterSelection(
       previous.allConnectedClusterIds ?? previous.selectedClusterIds,
       current.allConnectedClusterIds ?? current.selectedClusterIds
     );
-    const connectedClusterIds = normalizeClusterIds(
-      current.allConnectedClusterIds ?? current.selectedClusterIds
-    );
-    const backgroundRefreshCoversTabs =
-      Boolean(current.backgroundRefreshEnabled) && connectedClusterIds.length > 1;
+    // Foreground identity is intentionally absent from this decision. Switching
+    // an already-open tab retains its cluster-scoped state; the mounted scope's
+    // stream lifecycle reconciles only when that scope has no snapshot yet.
 
     // Namespace scope changes include the cluster identity tied to the selection.
     const namespaceChanged =
@@ -543,16 +539,6 @@ class RefreshManager {
       }
     }
 
-    // Avoid forced refreshes on cluster switches when background refresh already covers open tabs.
-    if (clusterChanged && current.currentView === 'cluster' && !backgroundRefreshCoversTabs) {
-      const clusterRefresher = current.activeClusterView
-        ? clusterViewToRefresher[current.activeClusterView]
-        : null;
-      if (clusterRefresher) {
-        targets.add(clusterRefresher);
-      }
-    }
-
     if (connectedClusterSelectionChanged && current.currentView === 'cluster') {
       const clusterRefresher = current.activeClusterView
         ? clusterViewToRefresher[current.activeClusterView]
@@ -560,10 +546,6 @@ class RefreshManager {
       if (clusterRefresher) {
         targets.add(clusterRefresher);
       }
-    }
-
-    if (clusterChanged && current.currentView === 'overview' && !backgroundRefreshCoversTabs) {
-      targets.add(SYSTEM_REFRESHERS.clusterOverview);
     }
 
     return Array.from(targets);

--- a/frontend/src/modules/cluster/components/ClusterOverview.test.tsx
+++ b/frontend/src/modules/cluster/components/ClusterOverview.test.tsx
@@ -289,11 +289,6 @@ describe('ClusterOverview', () => {
     cleanupRoot = cleanup;
     await flushEffects();
 
-    expect(mockRefreshOrchestrator.fetchScopedDomain).toHaveBeenCalledWith(
-      'cluster-overview',
-      'cluster-1|',
-      expect.objectContaining({ isManual: false })
-    );
     expect(mockRefreshOrchestrator.setScopedDomainEnabled).toHaveBeenCalledWith(
       'cluster-overview',
       'cluster-1|',
@@ -302,6 +297,7 @@ describe('ClusterOverview', () => {
       // resets scoped state without it, blanking the overview per switch.
       { preserveState: true }
     );
+    expect(mockRefreshOrchestrator.fetchScopedDomain).not.toHaveBeenCalled();
     expect(container.querySelector('.cluster-overview')?.classList.contains('selectable')).toBe(
       true
     );
@@ -495,11 +491,43 @@ describe('ClusterOverview', () => {
       // resets scoped state without it, blanking the overview per switch.
       { preserveState: true }
     );
-    expect(mockRefreshOrchestrator.fetchScopedDomain).toHaveBeenCalledWith(
-      'cluster-overview',
-      'cluster-1|',
-      expect.objectContaining({ isManual: false })
-    );
+    expect(mockRefreshOrchestrator.fetchScopedDomain).not.toHaveBeenCalled();
+  });
+
+  it('repaints cached overview data on a cluster-tab switch without requesting a reload', async () => {
+    domainStateRef.current = createDomainState('ready', {
+      clusterId: 'cluster-1',
+      overview: {
+        ...EMPTY_OVERVIEW_DATA,
+        totalNodes: 3,
+      },
+    });
+    const { container, rerender, cleanup } = renderClusterOverview();
+    cleanupRoot = cleanup;
+    await flushEffects();
+    mockRefreshOrchestrator.fetchScopedDomain.mockClear();
+
+    kubeconfigStateRef.current = {
+      ...kubeconfigStateRef.current,
+      selectedKubeconfigs: ['cluster-1', 'cluster-2'],
+      selectedKubeconfig: 'cluster-2',
+      selectedClusterId: 'cluster-2',
+      selectedClusterName: 'cluster-2',
+      selectedClusterIds: ['cluster-1', 'cluster-2'],
+    };
+    domainStateRef.current = createDomainState('ready', {
+      clusterId: 'cluster-2',
+      overview: {
+        ...EMPTY_OVERVIEW_DATA,
+        totalNodes: 9,
+      },
+    });
+
+    rerender();
+    await flushEffects();
+
+    expect(statValueFor(container, 'total')).toBe('9');
+    expect(mockRefreshOrchestrator.fetchScopedDomain).not.toHaveBeenCalled();
   });
 
   it('stays empty and paused on a new cluster tab even if overview data exists for another cluster', async () => {
@@ -1257,7 +1285,7 @@ function statValueFor(container: HTMLElement, label: string): string {
 
 function createDomainState(
   status: 'loading' | 'idle' | 'ready' | 'updating' | 'error',
-  overrides: Partial<{ overview: ClusterOverviewPayload; error: string }> = {}
+  overrides: Partial<{ clusterId: string; overview: ClusterOverviewPayload; error: string }> = {}
 ): {
   status: 'loading' | 'idle' | 'ready' | 'updating' | 'error';
   data:
@@ -1271,7 +1299,7 @@ function createDomainState(
     }
     return {
       status,
-      data: { overview: overrides.overview },
+      data: { clusterId: overrides.clusterId, overview: overrides.overview },
       error: null,
     };
   }

--- a/frontend/src/modules/cluster/components/ClusterOverview.tsx
+++ b/frontend/src/modules/cluster/components/ClusterOverview.tsx
@@ -22,7 +22,7 @@ import {
   formatMemoryValue,
 } from '@shared/utils/resourceCalculations';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { requestRefreshDomain, setRefreshDomainEnabled } from '@/core/data-access';
+import { setRefreshDomainEnabled } from '@/core/data-access';
 import { eventBus } from '@/core/events';
 import { useRefreshScopedDomain } from '@/core/refresh';
 import {
@@ -330,18 +330,6 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
         enabled: canActivateOverviewRefresh,
         preserveState: true,
       });
-      if (!canActivateOverviewRefresh) {
-        return;
-      }
-      requestRefreshDomain({
-        domain: 'cluster-overview',
-        scope: overviewScope,
-        reason: 'startup',
-      }).catch(() => {
-        setOverviewData(EMPTY_OVERVIEW);
-        setIsHydrated(false);
-        setIsSwitching(true);
-      });
     };
 
     // Clear local component state without touching the domain lifecycle.
@@ -369,15 +357,10 @@ const ClusterOverview: React.FC<ClusterOverviewProps> = ({ clusterContext }) => 
       const unsubChanged = eventBus.on('kubeconfig:changed', handleKubeconfigChanged);
 
       return () => {
-        clearLocalState();
         unsubChanging();
         unsubChanged();
       };
     }
-
-    return () => {
-      clearLocalState();
-    };
   }, [canActivateOverviewRefresh, overviewScope]);
 
   const handlePodStatusNavigate = useCallback(

--- a/frontend/src/modules/kubernetes/config/KubeconfigContext.test.tsx
+++ b/frontend/src/modules/kubernetes/config/KubeconfigContext.test.tsx
@@ -16,24 +16,30 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { eventBus } from '@/core/events';
 import { KubeconfigProvider, useKubeconfig } from './KubeconfigContext';
 
-const { getKubeconfigsMock, getSelectedKubeconfigsMock, setSelectedKubeconfigsMock, mocks } =
-  vi.hoisted(() => ({
-    getKubeconfigsMock: vi.fn(),
-    getSelectedKubeconfigsMock: vi.fn(),
-    setSelectedKubeconfigsMock: vi.fn(),
-    mocks: {
-      refreshOrchestrator: {
-        updateContext: vi.fn(),
-      },
-      backgroundRefreshState: { enabled: true },
+const {
+  getKubeconfigsMock,
+  getSelectedKubeconfigsMock,
+  setSelectedKubeconfigsMock,
+  setVisibleClusterMock,
+  mocks,
+} = vi.hoisted(() => ({
+  getKubeconfigsMock: vi.fn(),
+  getSelectedKubeconfigsMock: vi.fn(),
+  setSelectedKubeconfigsMock: vi.fn(),
+  setVisibleClusterMock: vi.fn(),
+  mocks: {
+    refreshOrchestrator: {
+      updateContext: vi.fn(),
     },
-  }));
+    backgroundRefreshState: { enabled: true },
+  },
+}));
 
 vi.mock('@wailsjs/go/backend/App', () => ({
   GetKubeconfigs: () => getKubeconfigsMock(),
   GetSelectedKubeconfigs: () => getSelectedKubeconfigsMock(),
   SetSelectedKubeconfigs: (configs: string[]) => setSelectedKubeconfigsMock(configs),
-  SetVisibleCluster: () => Promise.resolve(),
+  SetVisibleCluster: (clusterId: string) => setVisibleClusterMock(clusterId),
 }));
 
 vi.mock('@/core/refresh', () => ({
@@ -97,6 +103,8 @@ describe('KubeconfigContext', () => {
     getSelectedKubeconfigsMock.mockReset();
     setSelectedKubeconfigsMock.mockReset();
     setSelectedKubeconfigsMock.mockResolvedValue(undefined);
+    setVisibleClusterMock.mockReset();
+    setVisibleClusterMock.mockResolvedValue(undefined);
     mocks.backgroundRefreshState.enabled = true;
     resetClusterTabOrderCacheForTesting();
   });
@@ -180,7 +188,7 @@ describe('KubeconfigContext', () => {
     unmount();
   });
 
-  it('updates cluster-data identity immediately when activating an already committed tab', async () => {
+  it('updates cluster-data identity after activating an already committed tab', async () => {
     const kubeconfigs: types.KubeconfigInfo[] = [
       {
         name: 'alpha',
@@ -210,9 +218,117 @@ describe('KubeconfigContext', () => {
       getContext().setActiveKubeconfig('/kube/beta:prod');
     });
 
+    await act(async () => {
+      await flushPromises();
+    });
+
     expect(getContext().selectedKubeconfig).toBe('/kube/beta:prod');
     expect(getContext().selectedClusterId).toBe('beta:prod');
     expect(getContext().selectedClusterIds).toEqual(['alpha:dev', 'beta:prod']);
+
+    unmount();
+  });
+
+  it('publishes a switched tab to refresh consumers only after backend foreground activation', async () => {
+    const kubeconfigs: types.KubeconfigInfo[] = [
+      {
+        name: 'alpha',
+        path: '/kube/alpha',
+        context: 'dev',
+        isDefault: false,
+        isCurrentContext: false,
+        invalid: false,
+        invalidReason: '',
+      },
+      {
+        name: 'beta',
+        path: '/kube/beta',
+        context: 'prod',
+        isDefault: false,
+        isCurrentContext: false,
+        invalid: false,
+        invalidReason: '',
+      },
+    ];
+    getKubeconfigsMock.mockResolvedValue(kubeconfigs);
+    getSelectedKubeconfigsMock.mockResolvedValue(['/kube/alpha:dev', '/kube/beta:prod']);
+
+    const { getContext, unmount } = await renderProvider();
+    mocks.refreshOrchestrator.updateContext.mockClear();
+    setVisibleClusterMock.mockClear();
+    let resolveActivation!: () => void;
+    setVisibleClusterMock.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveActivation = resolve;
+      })
+    );
+
+    act(() => {
+      getContext().setActiveKubeconfig('/kube/beta:prod');
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(setVisibleClusterMock).toHaveBeenCalledWith('beta:prod');
+    expect(getContext().selectedKubeconfig).toBe('/kube/beta:prod');
+    expect(getContext().selectedClusterId).toBe('alpha:dev');
+    expect(mocks.refreshOrchestrator.updateContext).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveActivation();
+      await flushPromises();
+    });
+
+    expect(mocks.refreshOrchestrator.updateContext).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        selectedClusterId: 'beta:prod',
+        selectedClusterIds: ['beta:prod'],
+        allConnectedClusterIds: ['alpha:dev', 'beta:prod'],
+      })
+    );
+
+    unmount();
+  });
+
+  it('restores the committed tab when backend foreground activation fails', async () => {
+    const kubeconfigs: types.KubeconfigInfo[] = [
+      {
+        name: 'alpha',
+        path: '/kube/alpha',
+        context: 'dev',
+        isDefault: false,
+        isCurrentContext: false,
+        invalid: false,
+        invalidReason: '',
+      },
+      {
+        name: 'beta',
+        path: '/kube/beta',
+        context: 'prod',
+        isDefault: false,
+        isCurrentContext: false,
+        invalid: false,
+        invalidReason: '',
+      },
+    ];
+    getKubeconfigsMock.mockResolvedValue(kubeconfigs);
+    getSelectedKubeconfigsMock.mockResolvedValue(['/kube/alpha:dev', '/kube/beta:prod']);
+
+    const { getContext, unmount } = await renderProvider();
+    mocks.refreshOrchestrator.updateContext.mockClear();
+    setVisibleClusterMock.mockRejectedValueOnce(new Error('binding unavailable'));
+
+    act(() => {
+      getContext().setActiveKubeconfig('/kube/beta:prod');
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(getContext().selectedKubeconfig).toBe('/kube/alpha:dev');
+    expect(getContext().selectedClusterId).toBe('alpha:dev');
+    expect(mocks.refreshOrchestrator.updateContext).not.toHaveBeenCalled();
 
     unmount();
   });
@@ -400,7 +516,7 @@ describe('KubeconfigContext', () => {
     unmount();
   });
 
-  it('exposes the pending active tab identity while keeping refresh context committed until activation completes', async () => {
+  it('keeps cluster-data identity committed while exposing a pending active tab', async () => {
     const kubeconfigs: types.KubeconfigInfo[] = [
       {
         name: 'alpha',
@@ -440,8 +556,8 @@ describe('KubeconfigContext', () => {
 
     expect(getContext().selectedKubeconfig).toBe('/kube/beta:prod');
     expect(getContext().selectedKubeconfigs).toEqual(['/kube/alpha:dev', '/kube/beta:prod']);
-    expect(getContext().selectedClusterId).toBe('beta:prod');
-    expect(getContext().selectedClusterIds).toEqual(['alpha:dev', 'beta:prod']);
+    expect(getContext().selectedClusterId).toBe('alpha:dev');
+    expect(getContext().selectedClusterIds).toEqual(['alpha:dev']);
     expect(mocks.refreshOrchestrator.updateContext).toHaveBeenLastCalledWith({
       selectedClusterId: 'alpha:dev',
       selectedClusterName: 'dev',

--- a/frontend/src/modules/kubernetes/config/KubeconfigContext.tsx
+++ b/frontend/src/modules/kubernetes/config/KubeconfigContext.tsx
@@ -116,6 +116,7 @@ export const KubeconfigProvider: React.FC<KubeconfigProviderProps> = ({ children
   const committedSelectionsRef = useRef<string[]>([]);
   const committedActiveRef = useRef<string>('');
   const latestSelectionRequestIdRef = useRef(0);
+  const latestForegroundActivationRequestIdRef = useRef(0);
   // Prevent refresh context churn until the backend confirms selection updates.
   const selectionPendingRef = useRef(false);
 
@@ -147,13 +148,8 @@ export const KubeconfigProvider: React.FC<KubeconfigProviderProps> = ({ children
     return { id: `${filename}:${context}`, name: context };
   }, []);
 
-  // Public selection follows the active tab immediately; refresh context below
-  // stays on committed backend selections until cluster activation completes.
-  const selectedClusterMeta = useMemo(
-    () => resolveClusterMeta(selectedKubeconfig, kubeconfigs),
-    [resolveClusterMeta, selectedKubeconfig, kubeconfigs]
-  );
-
+  // The selection strings can move optimistically for tab chrome, while the
+  // cluster-data identity below remains committed to backend-ready state.
   const committedSelectedClusterMeta = useMemo(
     () => resolveClusterMeta(committedSelectedKubeconfig, kubeconfigs),
     [resolveClusterMeta, committedSelectedKubeconfig, kubeconfigs]
@@ -225,14 +221,6 @@ export const KubeconfigProvider: React.FC<KubeconfigProviderProps> = ({ children
     (meta: { id: string; name: string }, clusterIds: string[]) => {
       // Foreground view-specific domains only refresh for the active cluster.
       const foregroundClusterIds = meta.id ? [meta.id] : [];
-      // Tell the backend resource governor which cluster is now visible so it can
-      // keep that cluster (plus a small warm set) running fully and cool the rest
-      // to bound RAM. Fire-and-forget: tiering is best-effort orchestration.
-      if (meta.id) {
-        void SetVisibleCluster(meta.id).catch(() => {
-          // Governor signalling is non-critical; ignore transient binding errors.
-        });
-      }
       refreshOrchestrator.updateContext({
         selectedClusterId: meta.id || undefined,
         selectedClusterName: meta.name || undefined,
@@ -296,20 +284,6 @@ export const KubeconfigProvider: React.FC<KubeconfigProviderProps> = ({ children
       setKubeconfigsLoading(false);
     }
   }, [normalizeSelections]);
-
-  const buildClusterIdList = useCallback(
-    (selections: string[]) => {
-      const ids = new Set<string>();
-      selections.forEach((selection) => {
-        const meta = resolveClusterMeta(selection, kubeconfigsRef.current);
-        if (meta.id) {
-          ids.add(meta.id);
-        }
-      });
-      return Array.from(ids);
-    },
-    [resolveClusterMeta]
-  );
 
   const resolveNextActiveSelection = useCallback(
     (
@@ -381,9 +355,10 @@ export const KubeconfigProvider: React.FC<KubeconfigProviderProps> = ({ children
       const shouldEmitChanged = !willBeEmpty && wasEmpty;
       const shouldEmitSelectionChanged = selectionChanged && !willBeEmpty;
       const nextMeta = resolveClusterMeta(nextActive, kubeconfigsRef.current);
-      const nextClusterIds = buildClusterIdList(normalizedSelections);
 
       try {
+        // Any selection-set mutation supersedes an in-flight tab-only activation.
+        latestForegroundActivationRequestIdRef.current += 1;
         selectionPendingRef.current = true;
         // Keep refs in sync immediately so superseding requests read the latest state.
         selectedKubeconfigsRef.current = normalizedSelections;
@@ -408,6 +383,16 @@ export const KubeconfigProvider: React.FC<KubeconfigProviderProps> = ({ children
           return;
         }
 
+        // SetSelectedKubeconfigs makes the cluster open; SetVisibleCluster then
+        // completes any governor re-warm before its identity reaches data consumers.
+        if (nextMeta.id) {
+          await SetVisibleCluster(nextMeta.id);
+        }
+
+        if (requestId !== latestSelectionRequestIdRef.current) {
+          return;
+        }
+
         // Emit after backend updates to avoid refreshing with inactive clusters.
         if (shouldEmitSelectionChanged) {
           eventBus.emit('kubeconfig:selection-changed');
@@ -419,7 +404,6 @@ export const KubeconfigProvider: React.FC<KubeconfigProviderProps> = ({ children
         committedActiveRef.current = nextActive;
         setCommittedSelectedKubeconfigs(normalizedSelections);
         setCommittedSelectedKubeconfig(nextActive);
-        updateRefreshContext(nextMeta, nextClusterIds);
 
         // 4. Perform a manual refresh (will be triggered by kubeconfig:changed event).
         if (shouldEmitChanged) {
@@ -468,13 +452,7 @@ export const KubeconfigProvider: React.FC<KubeconfigProviderProps> = ({ children
         throw error;
       }
     },
-    [
-      buildClusterIdList,
-      normalizeSelections,
-      resolveClusterMeta,
-      resolveNextActiveSelection,
-      updateRefreshContext,
-    ]
+    [normalizeSelections, resolveClusterMeta, resolveNextActiveSelection]
   );
 
   const setSelectedKubeconfigs = useCallback(
@@ -557,11 +535,42 @@ export const KubeconfigProvider: React.FC<KubeconfigProviderProps> = ({ children
       selectedKubeconfigRef.current = config;
       setSelectedKubeconfigState(config);
       if (committedSelectionsRef.current.includes(config)) {
-        committedActiveRef.current = config;
-        setCommittedSelectedKubeconfig(config);
+        const activationRequestId = latestForegroundActivationRequestIdRef.current + 1;
+        latestForegroundActivationRequestIdRef.current = activationRequestId;
+        const meta = resolveClusterMeta(config, kubeconfigsRef.current);
+        void (async () => {
+          if (meta.id) {
+            try {
+              // A Cold cluster is rebuilt by this call. Do not expose its identity
+              // to refresh consumers until the backend has finished re-warming it.
+              await SetVisibleCluster(meta.id);
+            } catch {
+              // The backend method has no application-level error result. If the
+              // binding itself is temporarily unavailable, restore the committed
+              // tab and data identity instead of leaving the UI split across clusters.
+              if (
+                activationRequestId === latestForegroundActivationRequestIdRef.current &&
+                selectedKubeconfigRef.current === config
+              ) {
+                selectedKubeconfigRef.current = committedActiveRef.current;
+                setSelectedKubeconfigState(committedActiveRef.current);
+              }
+              return;
+            }
+          }
+          if (
+            activationRequestId !== latestForegroundActivationRequestIdRef.current ||
+            selectedKubeconfigRef.current !== config ||
+            !committedSelectionsRef.current.includes(config)
+          ) {
+            return;
+          }
+          committedActiveRef.current = config;
+          setCommittedSelectedKubeconfig(config);
+        })();
       }
     },
-    [selectedKubeconfig, selectedKubeconfigs]
+    [resolveClusterMeta, selectedKubeconfig, selectedKubeconfigs]
   );
 
   // Load kubeconfigs on mount
@@ -625,9 +634,12 @@ export const KubeconfigProvider: React.FC<KubeconfigProviderProps> = ({ children
       kubeconfigs,
       selectedKubeconfigs,
       selectedKubeconfig,
-      selectedClusterId: selectedClusterMeta.id,
-      selectedClusterName: selectedClusterMeta.name,
-      selectedClusterIds,
+      // Kubeconfig strings drive the optimistic tab chrome. Cluster-data identity
+      // stays on the backend-confirmed foreground/open set so a tab click cannot
+      // race reads against a governor re-warm or a selection mutation.
+      selectedClusterId: committedSelectedClusterMeta.id,
+      selectedClusterName: committedSelectedClusterMeta.name,
+      selectedClusterIds: committedSelectedClusterIds,
       kubeconfigsLoading,
       setSelectedKubeconfigs,
       openKubeconfig,
@@ -640,9 +652,9 @@ export const KubeconfigProvider: React.FC<KubeconfigProviderProps> = ({ children
       kubeconfigs,
       selectedKubeconfigs,
       selectedKubeconfig,
-      selectedClusterMeta.id,
-      selectedClusterMeta.name,
-      selectedClusterIds,
+      committedSelectedClusterMeta.id,
+      committedSelectedClusterMeta.name,
+      committedSelectedClusterIds,
       kubeconfigsLoading,
       setSelectedKubeconfigs,
       openKubeconfig,


### PR DESCRIPTION
Cluster tab switching is now "show the data we have" instead of "immediately reload this cluster". This trades instant cluster visibility for slightly stale data. As long as background refresh is not disabled, data should be no more than 15 seconds old.