### PR TITLE
Cluster loading

### DIFF
--- a/.agents/context/lessons.md
+++ b/.agents/context/lessons.md
@@ -111,3 +111,9 @@ sessions. Keep it short, durable, and tied to code contracts.
   automated generation is unreliable in the local environment, manually verify
   `frontend/wailsjs/go/models.ts` against the Go shape and run frontend
   typecheck.
+
+## Local Development
+
+- If the Wails development server is not running, start it with `mage dev`,
+  wait for the command to report its active URL, and use that URL for rendered
+  UI diagnosis.

--- a/.agents/skills/refresh-subsystem/SKILL.md
+++ b/.agents/skills/refresh-subsystem/SKILL.md
@@ -186,12 +186,16 @@ checklist when touching anything they name.
        may record newer visible-cluster intent while another call is cooling,
        but executor actions cannot overlap. Otherwise `ensureRunning` can observe
        the interval after feeds stop and before `Cooled` is published, accept it
-       as live, and leave every refresh domain without producers.
+       as live, and leave every refresh domain without producers. Publish the desired
+       tier to the planned map before executor work, but update the applied map only
+       after the executor reaches that tier; the two maps encode different contracts.
    13. **Cold clusters do not start object catalogs**:
-       `startObjectCatalogForTarget` gates on the serialized governor tier before
+       `startObjectCatalogForTarget` gates on the serialized governor **planned** tier before
        discovery or capability work. A Cold subsystem's ingest and informer feeds
        are stopped, so starting its catalog creates API traffic and an endless
-       all-ingest-kinds-unsynced retry loop.
+       all-ingest-kinds-unsynced retry loop. Re-warm publishes a live plan before
+       rebuilding, and `ensureRunning` must not report the live tier reached until the
+       catalog exists; reading the last-applied tier reverses both ordering guarantees.
    14. **Foreground activation replays lifecycle truth**: after serialized governor
        reconciliation, `SetVisibleCluster` emits the cluster's current lifecycle
        state even if it is unchanged. The Wails relay must reach both React state and
@@ -210,7 +214,13 @@ checklist when touching anything they name.
        subsystem generation's `NamespaceNotifier.WorkloadsReady()` as proof of the
        namespace baseline. The generation-local check is required because lifecycle
        Ready may be retained across re-warm. Do not poll namespace snapshots from Cold
-       preparation (scoped builds may issue per-namespace API probes).
+       preparation (scoped builds may issue per-namespace API probes). The preparation
+       context belongs to the subsystem generation: replacement/teardown cancels it, and
+       the retry loop checks that its subsystem is still current before every attempt.
+       The sole exception is sustained memory pressure after the bounded preparation
+       grace: re-drive reconciliation on every over-budget sample, then use the normal
+       full teardown so available stores spill and heap is reclaimed. Do not mmap or
+       serve the unsettled baseline; backend data stays unavailable until re-warm.
 10. **Stream health = connected + server-confirmed synchronized**, not
     recently-delivered (`computeSubscriptionHealth`;
     `markSubscriptionSynchronized` only after the mux confirms the subscribe).

--- a/.agents/skills/refresh-subsystem/SKILL.md
+++ b/.agents/skills/refresh-subsystem/SKILL.md
@@ -202,6 +202,15 @@ checklist when touching anything they name.
        but never the read key or rendered retained rows. When an open cluster becomes
        temporarily ineligible, disable its scope with `preserveState: true`; clear the
        scope only when the cluster is actually removed.
+   16. **Cold entry requires a retained baseline**: never stop a subsystem's producers
+       before server-owned `namespaces` readiness and the exact per-cluster
+       `cluster-overview` snapshot have built. A deferred transition must remain at its
+       actual live applied tier, then reconcile again when preparation succeeds. Use
+       both the aggregate service's server-owned Ready transition and the current
+       subsystem generation's `NamespaceNotifier.WorkloadsReady()` as proof of the
+       namespace baseline. The generation-local check is required because lifecycle
+       Ready may be retained across re-warm. Do not poll namespace snapshots from Cold
+       preparation (scoped builds may issue per-namespace API probes).
 10. **Stream health = connected + server-confirmed synchronized**, not
     recently-delivered (`computeSubscriptionHealth`;
     `markSubscriptionSynchronized` only after the mux confirms the subscribe).

--- a/.agents/skills/refresh-subsystem/SKILL.md
+++ b/.agents/skills/refresh-subsystem/SKILL.md
@@ -182,6 +182,26 @@ checklist when touching anything they name.
        clusters through the build chokepoint on tab switch;
        `transitionClusterToLoading` keeps an already-ready cluster ready
        (re-warm serving is continuous).
+   12. **Governor tier application is serialized**: `reconcileGovernorWith`
+       may record newer visible-cluster intent while another call is cooling,
+       but executor actions cannot overlap. Otherwise `ensureRunning` can observe
+       the interval after feeds stop and before `Cooled` is published, accept it
+       as live, and leave every refresh domain without producers.
+   13. **Cold clusters do not start object catalogs**:
+       `startObjectCatalogForTarget` gates on the serialized governor tier before
+       discovery or capability work. A Cold subsystem's ingest and informer feeds
+       are stopped, so starting its catalog creates API traffic and an endless
+       all-ingest-kinds-unsynced retry loop.
+   14. **Foreground activation replays lifecycle truth**: after serialized governor
+       reconciliation, `SetVisibleCluster` emits the cluster's current lifecycle
+       state even if it is unchanged. The Wails relay must reach both React state and
+       `eventBus` refresh-readiness consumers; otherwise a missed earlier edge leaves
+       the tab permanently behind its serving gate.
+   15. **Read scope is not refresh eligibility**: derive retained-data reads from the
+       selected cluster identity. Lifecycle may gate signals, leases, and requests,
+       but never the read key or rendered retained rows. When an open cluster becomes
+       temporarily ineligible, disable its scope with `preserveState: true`; clear the
+       scope only when the cluster is actually removed.
 10. **Stream health = connected + server-confirmed synchronized**, not
     recently-delivered (`computeSubscriptionHealth`;
     `markSubscriptionSynchronized` only after the mux confirms the subscribe).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,7 +151,11 @@ machine-wide Playwright MCP server instead.
   longer exists.
 - Use the active Wails development-server URL supplied for the run. Confirm it
   responds before browser work because Wails may choose a different port on a
-  later run. If it is not reachable, ask for the current URL, not screenshots.
+  later run. If it is not reachable, check whether the development process is
+  running. Start it with `mage dev` when needed, wait for the command to report
+  the active URL, and use that URL. Ask the user for the current URL only when
+  an existing development process is running but its URL cannot be determined;
+  do not ask for screenshots.
 - Use browser snapshots/DOM inspection for structure and interaction, and take
   screenshots yourself for layout or visual checks. Exercise relevant clicks,
   filters, navigation, loading, empty, error, and populated states in proportion

--- a/backend/app.go
+++ b/backend/app.go
@@ -59,15 +59,20 @@ type App struct {
 	// governor holds the process-wide resource governor state: which open
 	// clusters run Foreground/Background/Cold so RAM stays bounded when many
 	// clusters are open. All fields are guarded by governorMu.
-	governorMu       sync.Mutex
-	governorPolicy   system.GovernorPolicy
-	governorMRU      []string                       // open cluster IDs, most-recently-visible first
-	governorVisible  string                         // the cluster the user is currently viewing
-	governorApplied  map[string]system.ResourceTier // last-applied tier per cluster
-	governorPressure bool                           // memory-pressure signal (HeapInuse over budget)
-	governorBudget   uint64                         // HeapInuse byte budget; 0 disables pressure demotion
-	spillRoot        string                         // override for the maintained-store spill root; empty = user cache dir (tests set a temp dir)
-	spillFormat      string                         // override for the spill format version; empty = app Version (tests set a fixed value)
+	// governorReconcileMu serializes slow tier applications without preventing
+	// callers from recording a newer visible cluster under governorMu. The next
+	// reconcile then observes that newer intent after the in-flight transition
+	// has reached a real, internally consistent subsystem state.
+	governorReconcileMu sync.Mutex
+	governorMu          sync.Mutex
+	governorPolicy      system.GovernorPolicy
+	governorMRU         []string                       // open cluster IDs, most-recently-visible first
+	governorVisible     string                         // the cluster the user is currently viewing
+	governorApplied     map[string]system.ResourceTier // last-applied tier per cluster
+	governorPressure    bool                           // memory-pressure signal (HeapInuse over budget)
+	governorBudget      uint64                         // HeapInuse byte budget; 0 disables pressure demotion
+	spillRoot           string                         // override for the maintained-store spill root; empty = user cache dir (tests set a temp dir)
+	spillFormat         string                         // override for the spill format version; empty = app Version (tests set a fixed value)
 
 	// cooledMmapClosers holds, per cooled cluster, the mmap closers returned by
 	// CoolMaintainedStoresToMmap. Each closer unmaps one domain's cooled column file and MUST

--- a/backend/app.go
+++ b/backend/app.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/luxury-yacht/app/backend/capabilities"
 	"github.com/luxury-yacht/app/backend/refresh"
@@ -68,9 +69,12 @@ type App struct {
 	governorPolicy      system.GovernorPolicy
 	governorMRU         []string                       // open cluster IDs, most-recently-visible first
 	governorVisible     string                         // the cluster the user is currently viewing
+	governorPlanned     map[string]system.ResourceTier // latest tier plan published before lifecycle work starts
 	governorApplied     map[string]system.ResourceTier // last-applied tier per cluster
 	governorPressure    bool                           // memory-pressure signal (HeapInuse over budget)
+	governorHeapInuse   uint64                         // latest sampled HeapInuse, for pressure diagnostics
 	governorBudget      uint64                         // HeapInuse byte budget; 0 disables pressure demotion
+	governorNow         func() time.Time               // clock for bounded pressure fallback; time.Now in production
 	spillRoot           string                         // override for the maintained-store spill root; empty = user cache dir (tests set a temp dir)
 	spillFormat         string                         // override for the spill format version; empty = app Version (tests set a fixed value)
 

--- a/backend/app_kubernetes_client.go
+++ b/backend/app_kubernetes_client.go
@@ -6,6 +6,38 @@ import (
 	"github.com/luxury-yacht/app/backend/internal/logsources"
 )
 
+func (a *App) initializeSelectedClustersAtStartup() (int, error) {
+	selectedCount := 0
+	err := a.runSelectionMutation("startup-initialize-selected-clusters", func(*selectionMutation) error {
+		a.settingsMu.Lock()
+		settingsErr := a.loadAppSettings()
+		if settingsErr != nil {
+			a.appSettings = getDefaultAppSettings()
+		}
+		a.settingsMu.Unlock()
+		if settingsErr != nil {
+			a.logger.Warn(fmt.Sprintf("Failed to load app settings: %v", settingsErr), logsources.App)
+			a.logger.Info("Initialized app settings with defaults", logsources.App)
+		} else {
+			a.logger.Debug("Application settings loaded successfully", logsources.App)
+		}
+
+		a.restoreKubeconfigSelection()
+		selectedCount = len(a.GetSelectedKubeconfigs())
+		if selectedCount == 0 {
+			return nil
+		}
+
+		a.logger.Info(fmt.Sprintf("Connecting to %d selected cluster(s)", selectedCount), logsources.App)
+		initializer := a.kubeClientInitializer
+		if initializer == nil {
+			initializer = a.initKubernetesClient
+		}
+		return initializer()
+	})
+	return selectedCount, err
+}
+
 func (a *App) initKubernetesClient() (err error) {
 	a.logger.Info("Initializing Kubernetes client", logsources.KubernetesClient)
 
@@ -40,11 +72,17 @@ func (a *App) initKubernetesClient() (err error) {
 }
 
 func (a *App) restoreKubeconfigSelection() {
-	a.selectedKubeconfigs = nil
+	a.settingsMu.Lock()
+	var savedSelections []string
+	if a.appSettings != nil {
+		savedSelections = append(savedSelections, a.appSettings.SelectedKubeconfigs...)
+	}
+	a.settingsMu.Unlock()
 
-	if a.appSettings != nil && len(a.appSettings.SelectedKubeconfigs) > 0 {
-		normalized := make([]string, 0, len(a.appSettings.SelectedKubeconfigs))
-		for _, selection := range a.appSettings.SelectedKubeconfigs {
+	var normalized []string
+	if len(savedSelections) > 0 {
+		normalized = make([]string, 0, len(savedSelections))
+		for _, selection := range savedSelections {
 			parsed, err := a.normalizeKubeconfigSelection(selection)
 			if err != nil {
 				continue
@@ -54,9 +92,17 @@ func (a *App) restoreKubeconfigSelection() {
 			}
 			normalized = append(normalized, parsed.String())
 		}
-		if len(normalized) > 0 {
-			a.selectedKubeconfigs = normalized
+	}
+
+	a.kubeconfigsMu.Lock()
+	a.selectedKubeconfigs = append([]string(nil), normalized...)
+	a.kubeconfigsMu.Unlock()
+
+	if len(normalized) > 0 {
+		a.settingsMu.Lock()
+		if a.appSettings != nil {
 			a.appSettings.SelectedKubeconfigs = normalized
 		}
+		a.settingsMu.Unlock()
 	}
 }

--- a/backend/app_kubernetes_client_test.go
+++ b/backend/app_kubernetes_client_test.go
@@ -3,9 +3,63 @@ package backend
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestInitializeSelectedClustersAtStartupUsesSelectionMutationCoordinator(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	app := NewApp()
+	app.logger = NewLogger(10)
+	selection := "/tmp/config:cluster-a"
+	app.availableKubeconfigs = []KubeconfigInfo{{
+		Name:    "config",
+		Path:    "/tmp/config",
+		Context: "cluster-a",
+	}}
+	settings := defaultSettingsFile()
+	settings.Kubeconfig.Selected = []string{selection}
+	require.NoError(t, app.saveSettingsFile(settings))
+
+	initializerCalled := make(chan struct{})
+	app.kubeClientInitializer = func() error {
+		close(initializerCalled)
+		return nil
+	}
+
+	app.selectionMutationMu.Lock()
+	type startupResult struct {
+		selectedCount int
+		err           error
+	}
+	result := make(chan startupResult, 1)
+	go func() {
+		selectedCount, err := app.initializeSelectedClustersAtStartup()
+		result <- startupResult{selectedCount: selectedCount, err: err}
+	}()
+
+	select {
+	case <-initializerCalled:
+		t.Fatal("startup initialization bypassed the selection mutation coordinator")
+	case <-time.After(50 * time.Millisecond):
+	}
+	require.Empty(t, app.GetSelectedKubeconfigs(), "startup restore must share the selection mutation coordinator")
+
+	app.selectionMutationMu.Unlock()
+	startup := <-result
+	require.NoError(t, startup.err)
+	require.Equal(t, 1, startup.selectedCount)
+	require.Equal(t, []string{selection}, app.GetSelectedKubeconfigs())
+	require.Eventually(t, func() bool {
+		select {
+		case <-initializerCalled:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+}
 
 // TestInitKubernetesClient_FailsWithNoSelections verifies that initKubernetesClient
 // returns an error when no kubeconfig selections are configured. This is the

--- a/backend/app_lifecycle.go
+++ b/backend/app_lifecycle.go
@@ -140,22 +140,11 @@ func (a *App) Startup(ctx context.Context) {
 		a.logger.Info(fmt.Sprintf("Found %d kubeconfig file(s)", len(a.availableKubeconfigs)), logsources.App)
 	}
 
-	// Startup is single-threaded here: the kubeconfig watcher has not started and
-	// Wails RPC handlers are not yet dispatching, so loadAppSettings is safe
-	// without settingsMu.
-	if err := a.loadAppSettings(); err != nil {
-		a.logger.Warn(fmt.Sprintf("Failed to load app settings: %v", err), logsources.App)
-		a.appSettings = getDefaultAppSettings()
-		a.logger.Info("Initialized app settings with defaults", logsources.App)
-	} else {
-		a.logger.Debug("Application settings loaded successfully", logsources.App)
-	}
-
-	a.restoreKubeconfigSelection()
-
-	if len(a.selectedKubeconfigs) > 0 {
-		a.logger.Info(fmt.Sprintf("Connecting to %d selected cluster(s)", len(a.selectedKubeconfigs)), logsources.App)
-		if err := a.initKubernetesClient(); err != nil {
+	// The window is already visible, so settings restore and client initialization
+	// share the runtime selection coordinator with any frontend mutation.
+	selectedCount, err := a.initializeSelectedClustersAtStartup()
+	if selectedCount > 0 {
+		if err != nil {
 			a.logger.Error(fmt.Sprintf("Failed to connect to cluster(s): %v", err), logsources.App)
 		} else {
 			a.logger.Info("Successfully connected to Kubernetes cluster(s)", logsources.App)

--- a/backend/app_object_catalog.go
+++ b/backend/app_object_catalog.go
@@ -152,6 +152,31 @@ func (a *App) startObjectCatalog() {
 	}
 }
 
+// ensureObjectCatalogForCluster makes the object catalog part of the live-tier
+// invariant. Rebuild normally starts it, but this also repairs a live subsystem
+// left catalog-less by an interrupted or previously mis-ordered transition.
+func (a *App) ensureObjectCatalogForCluster(clusterID string) error {
+	if a == nil || clusterID == "" {
+		return fmt.Errorf("cluster identifier missing")
+	}
+	if a.objectCatalogServiceForCluster(clusterID) != nil {
+		return nil
+	}
+	for _, target := range a.catalogTargets() {
+		if target.meta.ID != clusterID {
+			continue
+		}
+		if err := a.startObjectCatalogForTarget(target); err != nil {
+			return err
+		}
+		if a.objectCatalogServiceForCluster(clusterID) == nil {
+			return fmt.Errorf("object catalog did not start")
+		}
+		return nil
+	}
+	return fmt.Errorf("cluster selection unavailable")
+}
+
 func (a *App) startObjectCatalogForTarget(target catalogTarget) error {
 	if target.meta.ID == "" {
 		return fmt.Errorf("cluster identifier missing")

--- a/backend/app_object_catalog.go
+++ b/backend/app_object_catalog.go
@@ -156,6 +156,12 @@ func (a *App) startObjectCatalogForTarget(target catalogTarget) error {
 	if target.meta.ID == "" {
 		return fmt.Errorf("cluster identifier missing")
 	}
+	// Cold clusters deliberately have no live informer/ingest producers. Starting
+	// their catalogs would run discovery and capability checks, then repeatedly try
+	// to collect from stores whose feeds the governor intentionally stopped.
+	if a.governorKeepsClusterCold(target.meta.ID) {
+		return nil
+	}
 
 	clients := a.clusterClientsForID(target.meta.ID)
 	if clients == nil {

--- a/backend/app_object_catalog_test.go
+++ b/backend/app_object_catalog_test.go
@@ -38,6 +38,7 @@ func catalogLifecycleTestApp(t *testing.T, tier system.ResourceTier, cooled bool
 	const clusterID = "cluster-a:context-a"
 	app := newTestAppWithDefaults(t)
 	app.Ctx = context.Background()
+	app.governorPlanned = map[string]system.ResourceTier{clusterID: tier}
 	app.governorApplied = map[string]system.ResourceTier{clusterID: tier}
 
 	kubeClient := cgofake.NewClientset()
@@ -63,6 +64,12 @@ func catalogLifecycleTestApp(t *testing.T, tier system.ResourceTier, cooled bool
 			nil,
 		),
 	})
+	app.availableKubeconfigs = []KubeconfigInfo{{
+		Name:    "cluster-a",
+		Path:    "/p/a",
+		Context: "context-a",
+	}}
+	app.selectedKubeconfigs = []string{(kubeconfigSelection{Path: "/p/a", Context: "context-a"}).String()}
 	t.Cleanup(func() { app.stopObjectCatalogForCluster(clusterID) })
 	return app, catalogTarget{
 		selection: kubeconfigSelection{Path: "/p/a", Context: "context-a"},
@@ -86,6 +93,56 @@ func TestStartObjectCatalogForTargetStartsForForegroundSubsystem(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, app.objectCatalogServiceForCluster(target.meta.ID), "a live cluster must start its catalog")
+}
+
+type catalogStartingGovernorExecutor struct {
+	app    *App
+	target catalogTarget
+}
+
+func (e *catalogStartingGovernorExecutor) ensureRunning(string) bool {
+	return e.app.startObjectCatalogForTarget(e.target) == nil &&
+		e.app.objectCatalogServiceForCluster(e.target.meta.ID) != nil
+}
+
+func (e *catalogStartingGovernorExecutor) teardown(string) bool {
+	_ = e.app.startObjectCatalogForTarget(e.target)
+	return e.app.objectCatalogServiceForCluster(e.target.meta.ID) == nil
+}
+
+func TestReconcileGovernorPublishesForegroundPlanBeforeStartingCatalog(t *testing.T) {
+	app, target := catalogLifecycleTestApp(t, system.TierCold, false)
+	app.governorVisible = target.meta.ID
+	app.governorMRU = []string{target.meta.ID}
+
+	app.reconcileGovernorWith(&catalogStartingGovernorExecutor{app: app, target: target})
+
+	require.NotNil(t, app.objectCatalogServiceForCluster(target.meta.ID),
+		"the catalog start inside the re-warm executor must observe the planned live tier")
+	require.Equal(t, system.TierForeground, app.governorApplied[target.meta.ID])
+}
+
+func TestReconcileGovernorPublishesColdPlanBeforeTeardownStarts(t *testing.T) {
+	app, target := catalogLifecycleTestApp(t, system.TierBackground, false)
+	app.governorPolicy = system.GovernorPolicy{KeepWarm: 0}
+	app.governorMRU = []string{target.meta.ID}
+
+	app.reconcileGovernorWith(&catalogStartingGovernorExecutor{app: app, target: target})
+
+	require.Nil(t, app.objectCatalogServiceForCluster(target.meta.ID),
+		"catalog work started during teardown must observe the planned Cold tier")
+	require.Equal(t, system.TierCold, app.governorApplied[target.meta.ID])
+}
+
+func TestGovernorEnsureRunningStartsMissingCatalogForLiveCluster(t *testing.T) {
+	app, target := catalogLifecycleTestApp(t, system.TierForeground, false)
+	require.Nil(t, app.objectCatalogServiceForCluster(target.meta.ID))
+
+	reachedLiveTier := app.realGovernorExecutor().ensureRunning(target.meta.ID)
+
+	require.True(t, reachedLiveTier)
+	require.NotNil(t, app.objectCatalogServiceForCluster(target.meta.ID),
+		"a live tier is incomplete until the cluster object catalog is running")
 }
 
 func TestStopObjectCatalogCancelsAndResets(t *testing.T) {

--- a/backend/app_object_catalog_test.go
+++ b/backend/app_object_catalog_test.go
@@ -9,9 +9,14 @@ import (
 	"unsafe"
 
 	"github.com/luxury-yacht/app/backend/internal/config"
+	"github.com/luxury-yacht/app/backend/kind/streamrows"
 	"github.com/luxury-yacht/app/backend/objectcatalog"
+	refreshinformer "github.com/luxury-yacht/app/backend/refresh/informer"
+	"github.com/luxury-yacht/app/backend/refresh/ingest"
+	refreshpermissions "github.com/luxury-yacht/app/backend/refresh/permissions"
 	"github.com/luxury-yacht/app/backend/refresh/resourcestream"
 	"github.com/luxury-yacht/app/backend/refresh/snapshot"
+	"github.com/luxury-yacht/app/backend/refresh/system"
 	"github.com/luxury-yacht/app/backend/refresh/telemetry"
 	"github.com/stretchr/testify/require"
 	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
@@ -27,6 +32,61 @@ import (
 	cgofake "k8s.io/client-go/kubernetes/fake"
 	cgotesting "k8s.io/client-go/testing"
 )
+
+func catalogLifecycleTestApp(t *testing.T, tier system.ResourceTier, cooled bool) (*App, catalogTarget) {
+	t.Helper()
+	const clusterID = "cluster-a:context-a"
+	app := newTestAppWithDefaults(t)
+	app.Ctx = context.Background()
+	app.governorApplied = map[string]system.ResourceTier{clusterID: tier}
+
+	kubeClient := cgofake.NewClientset()
+	apiExtensionsClient := apiextensionsfake.NewSimpleClientset()
+	checker := refreshpermissions.NewCheckerWithReview(clusterID, time.Minute, func(context.Context, string, string, string, string) (bool, error) {
+		return true, nil
+	})
+	factory := refreshinformer.New(kubeClient, apiExtensionsClient, time.Minute, checker)
+	app.clusterClients = make(map[string]*clusterClients)
+	app.clusterClients[clusterID] = &clusterClients{
+		meta:                ClusterMeta{ID: clusterID, Name: "Cluster A"},
+		client:              kubeClient,
+		apiextensionsClient: apiExtensionsClient,
+		dynamicClient:       fake.NewSimpleDynamicClient(runtime.NewScheme()),
+	}
+	app.setRefreshSubsystem(clusterID, &system.Subsystem{
+		Cooled:          cooled,
+		InformerFactory: factory,
+		IngestManager: ingest.NewIngestManager(
+			streamrows.ClusterMeta{ClusterID: clusterID, ClusterName: "Cluster A"},
+			kubeClient,
+			apiExtensionsClient,
+			nil,
+		),
+	})
+	t.Cleanup(func() { app.stopObjectCatalogForCluster(clusterID) })
+	return app, catalogTarget{
+		selection: kubeconfigSelection{Path: "/p/a", Context: "context-a"},
+		meta:      ClusterMeta{ID: clusterID, Name: "Cluster A"},
+	}
+}
+
+func TestStartObjectCatalogForTargetSkipsCooledSubsystem(t *testing.T) {
+	app, target := catalogLifecycleTestApp(t, system.TierCold, true)
+
+	err := app.startObjectCatalogForTarget(target)
+
+	require.NoError(t, err)
+	require.Nil(t, app.objectCatalogServiceForCluster(target.meta.ID), "a Cold cluster must not start catalog API work against stopped feeds")
+}
+
+func TestStartObjectCatalogForTargetStartsForForegroundSubsystem(t *testing.T) {
+	app, target := catalogLifecycleTestApp(t, system.TierForeground, false)
+
+	err := app.startObjectCatalogForTarget(target)
+
+	require.NoError(t, err)
+	require.NotNil(t, app.objectCatalogServiceForCluster(target.meta.ID), "a live cluster must start its catalog")
+}
 
 func TestStopObjectCatalogCancelsAndResets(t *testing.T) {
 	app := NewApp()

--- a/backend/app_refresh_governor.go
+++ b/backend/app_refresh_governor.go
@@ -27,30 +27,52 @@ func (a *App) initGovernor() {
 	a.governorMu.Lock()
 	defer a.governorMu.Unlock()
 	a.governorPolicy = system.GovernorPolicy{KeepWarm: config.GovernorKeepWarm}
+	a.governorPlanned = make(map[string]system.ResourceTier)
 	a.governorApplied = make(map[string]system.ResourceTier)
 	a.governorBudget = config.GovernorHeapBudgetBytes
+	a.governorNow = time.Now
 }
 
 // ensureGovernorStateLocked lazily initializes governor state for App instances
 // built without NewApp (e.g. test fixtures), so the governor never assigns to a
 // nil map. Callers must hold governorMu.
 func (a *App) ensureGovernorStateLocked() {
+	if a.governorPlanned == nil {
+		a.governorPlanned = make(map[string]system.ResourceTier)
+	}
 	if a.governorApplied == nil {
 		a.governorApplied = make(map[string]system.ResourceTier)
 	}
+	if a.governorNow == nil {
+		a.governorNow = time.Now
+	}
 }
 
-// governorKeepsClusterCold reports whether the latest serialized governor
-// assignment intentionally keeps clusterID without live producers. It reads the
-// assignment rather than Subsystem.Cooled: during cooling the assignment changes
-// before feeds stop, and during re-warm it changes before the fresh catalog starts.
+func (a *App) governorTime() time.Time {
+	if a == nil {
+		return time.Now()
+	}
+	a.governorMu.Lock()
+	now := a.governorNow
+	a.governorMu.Unlock()
+	if now == nil {
+		return time.Now()
+	}
+	return now()
+}
+
+// governorKeepsClusterCold reports whether the latest serialized governor plan
+// intentionally keeps clusterID without live producers. The plan is published
+// before lifecycle work starts: cooling closes the catalog gate before feeds stop,
+// while re-warming opens it before the fresh catalog starts. governorApplied is
+// deliberately separate because it records only completed lifecycle work.
 func (a *App) governorKeepsClusterCold(clusterID string) bool {
 	if a == nil || clusterID == "" {
 		return false
 	}
 	a.governorMu.Lock()
 	defer a.governorMu.Unlock()
-	tier, tracked := a.governorApplied[clusterID]
+	tier, tracked := a.governorPlanned[clusterID]
 	return tracked && tier == system.TierCold
 }
 
@@ -148,6 +170,14 @@ func (a *App) reconcileGovernorWith(exec governorExecutor) {
 	}
 	desired := a.governorPolicy.Assign(mru, a.governorVisible, a.governorPressure)
 	transitions := system.PlanGovernorTransitions(a.governorApplied, desired)
+	// Catalog start/stop runs inside the lifecycle executor. Publish the plan
+	// first so those nested operations see where the serialized transition is
+	// going, while governorApplied continues to describe the state actually
+	// reached (including deferred Cold preparation).
+	a.governorPlanned = make(map[string]system.ResourceTier, len(desired))
+	for id, tier := range desired {
+		a.governorPlanned[id] = tier
+	}
 	a.governorMu.Unlock()
 
 	for _, t := range transitions {
@@ -238,7 +268,16 @@ func (e *appGovernorExecutor) ensureRunning(clusterID string) bool {
 		a.rewarmCooledClusterSubsystem(clusterID)
 	}
 	subsystem = a.getRefreshSubsystem(clusterID)
-	return subsystem != nil && !subsystem.Cooled
+	if subsystem == nil || subsystem.Cooled {
+		return false
+	}
+	if err := a.ensureObjectCatalogForCluster(clusterID); err != nil {
+		if a.logger != nil {
+			a.logger.Warn(fmt.Sprintf("Governor could not complete live tier for cluster %s: %v", clusterID, err), logsources.Refresh, clusterID, a.clusterNameForID(clusterID))
+		}
+		return false
+	}
+	return true
 }
 
 // rewarmCooledClusterSubsystem replaces a cooled (mmap-serving) subsystem with a fresh, live
@@ -285,6 +324,24 @@ func (e *appGovernorExecutor) teardown(clusterID string) bool {
 	}
 	if !subsystem.ColdServingReady() {
 		a.startColdPreparation(clusterID, subsystem)
+		if pendingFor, heapInuse, force := a.shouldForceColdTeardown(subsystem); force {
+			if a.logger != nil {
+				a.logger.Warn(fmt.Sprintf(
+					"Governor cold preparation for cluster %s remained unsettled for %s under sustained memory pressure; forcing full teardown (heap in use: %d bytes)",
+					clusterID,
+					pendingFor.Round(time.Second),
+					heapInuse,
+				), logsources.Refresh, clusterID, a.clusterNameForID(clusterID))
+			}
+			// Use the normal full-teardown path so feeds stop, the generation-owned
+			// preparation is canceled, and every available store is spilled before
+			// heap is reclaimed. The catalog must stop with the live producers.
+			a.teardownClusterSubsystem(clusterID)
+			a.stopObjectCatalogForCluster(clusterID)
+			runtime.GC()
+			debug.FreeOSMemory()
+			return true
+		}
 		return false
 	}
 	a.coolClusterToMmapServing(clusterID)
@@ -292,7 +349,28 @@ func (e *appGovernorExecutor) teardown(clusterID string) bool {
 	return subsystem == nil || subsystem.Cooled
 }
 
-const coldPreparationRetryInterval = 250 * time.Millisecond
+const (
+	coldPreparationRetryInterval = 250 * time.Millisecond
+	// One complete cache-bypass overview attempt gets the same bound used by
+	// buildColdPreparationSnapshot. Only sustained memory pressure may trade the
+	// settled retained baseline for a full teardown after this grace expires.
+	coldPreparationPressureGrace = config.RefreshInformerSyncTimeout + 5*time.Second
+)
+
+func (a *App) shouldForceColdTeardown(subsystem *system.Subsystem) (time.Duration, uint64, bool) {
+	if a == nil || subsystem == nil {
+		return 0, 0, false
+	}
+	pendingFor, pending := subsystem.ColdPreparationAge(a.governorTime())
+	if !pending || pendingFor < coldPreparationPressureGrace {
+		return pendingFor, 0, false
+	}
+	a.governorMu.Lock()
+	underPressure := a.governorPressure
+	heapInuse := a.governorHeapInuse
+	a.governorMu.Unlock()
+	return pendingFor, heapInuse, underPressure
+}
 
 // startColdPreparation waits for and builds the retained snapshots needed by
 // surfaces that remain visible while a cluster is Cold. The work is server-owned
@@ -301,7 +379,8 @@ func (a *App) startColdPreparation(clusterID string, subsystem *system.Subsystem
 	if a == nil || clusterID == "" || subsystem == nil || subsystem.SnapshotService == nil || a.refreshCtx == nil || a.clusterLifecycle == nil {
 		return
 	}
-	if !subsystem.BeginColdPreparation() {
+	preparationCtx, started := subsystem.BeginColdPreparation(a.refreshCtx, a.governorTime())
+	if !started {
 		return
 	}
 	go func() {
@@ -314,7 +393,8 @@ func (a *App) startColdPreparation(clusterID string, subsystem *system.Subsystem
 			// this generation's own workload tracker to have settled.
 			return subsystem.NamespaceNotifier == nil || subsystem.NamespaceNotifier.WorkloadsReady()
 		}
-		if !primeColdServingSnapshots(a.refreshCtx, subsystem.SnapshotService, clusterID, namespaceBaselineReady) {
+		stillCurrent := func() bool { return a.getRefreshSubsystem(clusterID) == subsystem }
+		if !primeColdServingSnapshots(preparationCtx, subsystem.SnapshotService, clusterID, namespaceBaselineReady, stillCurrent) {
 			return
 		}
 		// A rebuild may have replaced this subsystem while its sources settled.
@@ -338,12 +418,16 @@ func primeColdServingSnapshots(
 	service refresh.SnapshotService,
 	clusterID string,
 	namespaceBaselineReady func() bool,
+	stillCurrent func() bool,
 ) bool {
-	if ctx == nil || service == nil || clusterID == "" || namespaceBaselineReady == nil {
+	if ctx == nil || service == nil || clusterID == "" || namespaceBaselineReady == nil || stillCurrent == nil {
 		return false
 	}
 	scope := refresh.JoinClusterScope(clusterID, "")
 	for {
+		if !stillCurrent() {
+			return false
+		}
 		if namespaceBaselineReady() {
 			if _, err := buildColdPreparationSnapshot(ctx, service, "cluster-overview", scope); err == nil {
 				return true
@@ -459,10 +543,28 @@ func (a *App) seedGovernorFromOpenClusters() {
 	a.reconcileGovernor()
 }
 
-// startGovernorPressureLoop periodically samples heap usage and flips the
-// memory-pressure signal, reconciling when it changes so non-visible clusters are
-// shed under pressure and re-warmed when it clears. It stops when ctx is
-// cancelled (bound to the refresh context, so no goroutine leak on shutdown).
+// handleGovernorPressureSample records the latest heap sample. Every sample that
+// remains over budget re-drives reconciliation so a Cold transition deferred for
+// retained-baseline preparation can reach its bounded pressure fallback.
+func (a *App) handleGovernorPressureSample(heapInuse uint64) {
+	if a == nil {
+		return
+	}
+	a.governorMu.Lock()
+	budget := a.governorBudget
+	underPressure := budget > 0 && heapInuse > budget
+	changed := underPressure != a.governorPressure
+	a.governorPressure = underPressure
+	a.governorHeapInuse = heapInuse
+	a.governorMu.Unlock()
+
+	if changed || underPressure {
+		a.reconcileGovernor()
+	}
+}
+
+// startGovernorPressureLoop periodically samples heap usage. It stops when ctx
+// is cancelled (bound to the refresh context, so no goroutine leak on shutdown).
 func (a *App) startGovernorPressureLoop(ctx context.Context) {
 	if a == nil || ctx == nil {
 		return
@@ -485,16 +587,7 @@ func (a *App) startGovernorPressureLoop(ctx context.Context) {
 		case <-ticker.C:
 			var stats runtime.MemStats
 			runtime.ReadMemStats(&stats)
-			underPressure := stats.HeapInuse > budget
-
-			a.governorMu.Lock()
-			changed := underPressure != a.governorPressure
-			a.governorPressure = underPressure
-			a.governorMu.Unlock()
-
-			if changed {
-				a.reconcileGovernor()
-			}
+			a.handleGovernorPressureSample(stats.HeapInuse)
 		}
 	}
 }

--- a/backend/app_refresh_governor.go
+++ b/backend/app_refresh_governor.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/luxury-yacht/app/backend/internal/config"
 	"github.com/luxury-yacht/app/backend/internal/logsources"
+	"github.com/luxury-yacht/app/backend/refresh"
 	"github.com/luxury-yacht/app/backend/refresh/snapshot"
 	"github.com/luxury-yacht/app/backend/refresh/system"
 )
@@ -96,10 +97,11 @@ func moveToFront(mru []string, id string) []string {
 type governorExecutor interface {
 	// ensureRunning builds+starts the cluster's subsystem if it is not already
 	// running. Metrics activity is owned independently by cluster-scoped
-	// frontend leases.
-	ensureRunning(clusterID string)
-	// teardown stops the cluster's subsystem and reclaims its heap.
-	teardown(clusterID string)
+	// frontend leases. It reports whether the requested live tier was reached.
+	ensureRunning(clusterID string) bool
+	// teardown reaches Cold only after its retained serving baseline exists. It
+	// reports false while that server-owned preparation is still running.
+	teardown(clusterID string) bool
 }
 
 // reconcileGovernor computes the desired tier for every open cluster and applies
@@ -146,19 +148,23 @@ func (a *App) reconcileGovernorWith(exec governorExecutor) {
 	}
 	desired := a.governorPolicy.Assign(mru, a.governorVisible, a.governorPressure)
 	transitions := system.PlanGovernorTransitions(a.governorApplied, desired)
-	// Record the tiers being applied. A later serialized reconcile computes from
-	// this applied intent and any visibility or pressure changes recorded meanwhile.
-	for id, tier := range desired {
-		a.governorApplied[id] = tier
-	}
 	a.governorMu.Unlock()
 
 	for _, t := range transitions {
+		applied := false
 		switch {
 		case t.Teardown:
-			exec.teardown(t.ClusterID)
+			applied = exec.teardown(t.ClusterID)
 		case t.EnsureRunning:
-			exec.ensureRunning(t.ClusterID)
+			applied = exec.ensureRunning(t.ClusterID)
+		}
+		if applied {
+			// Record the tier only after the executor reaches it. A deferred Cold
+			// transition remains at its live tier, so the retained-baseline callback
+			// can reconcile it again instead of leaving it permanently misclassified.
+			a.governorMu.Lock()
+			a.governorApplied[t.ClusterID] = t.Tier
+			a.governorMu.Unlock()
 		}
 	}
 }
@@ -214,10 +220,10 @@ type appGovernorExecutor struct {
 
 // ensureRunning builds+starts the subsystem if absent, reusing the existing
 // per-cluster rebuild path. Metrics demand is routed separately by cluster ID.
-func (e *appGovernorExecutor) ensureRunning(clusterID string) {
+func (e *appGovernorExecutor) ensureRunning(clusterID string) bool {
 	a := e.app
 	if a == nil {
-		return
+		return false
 	}
 	subsystem := a.getRefreshSubsystem(clusterID)
 	switch {
@@ -231,6 +237,8 @@ func (e *appGovernorExecutor) ensureRunning(clusterID string) {
 		// mmap-backed stores. Re-warm it to a fresh, live, mutable subsystem.
 		a.rewarmCooledClusterSubsystem(clusterID)
 	}
+	subsystem = a.getRefreshSubsystem(clusterID)
+	return subsystem != nil && !subsystem.Cooled
 }
 
 // rewarmCooledClusterSubsystem replaces a cooled (mmap-serving) subsystem with a fresh, live
@@ -266,15 +274,100 @@ func (a *App) rewarmCooledClusterSubsystem(clusterID string) {
 // keeping the subsystem registered so it still serves Build queries — and only falls back to a
 // full teardown (heap fully reclaimed, blank until re-warm) if cooling fails at any step. Either
 // way the cluster's informer/metrics heap is reclaimed.
-func (e *appGovernorExecutor) teardown(clusterID string) {
+func (e *appGovernorExecutor) teardown(clusterID string) bool {
 	a := e.app
 	if a == nil {
-		return
+		return false
 	}
-	if a.getRefreshSubsystem(clusterID) == nil {
-		return
+	subsystem := a.getRefreshSubsystem(clusterID)
+	if subsystem == nil {
+		return true
+	}
+	if !subsystem.ColdServingReady() {
+		a.startColdPreparation(clusterID, subsystem)
+		return false
 	}
 	a.coolClusterToMmapServing(clusterID)
+	subsystem = a.getRefreshSubsystem(clusterID)
+	return subsystem == nil || subsystem.Cooled
+}
+
+const coldPreparationRetryInterval = 250 * time.Millisecond
+
+// startColdPreparation waits for and builds the retained snapshots needed by
+// surfaces that remain visible while a cluster is Cold. The work is server-owned
+// and independent of frontend leases: until it succeeds, the subsystem stays live.
+func (a *App) startColdPreparation(clusterID string, subsystem *system.Subsystem) {
+	if a == nil || clusterID == "" || subsystem == nil || subsystem.SnapshotService == nil || a.refreshCtx == nil || a.clusterLifecycle == nil {
+		return
+	}
+	if !subsystem.BeginColdPreparation() {
+		return
+	}
+	go func() {
+		namespaceBaselineReady := func() bool {
+			if a.clusterLifecycle.GetState(clusterID) != ClusterStateReady {
+				return false
+			}
+			// The aggregate lifecycle may still carry Ready from a subsystem this
+			// one replaced. When the namespace domain is registered, also require
+			// this generation's own workload tracker to have settled.
+			return subsystem.NamespaceNotifier == nil || subsystem.NamespaceNotifier.WorkloadsReady()
+		}
+		if !primeColdServingSnapshots(a.refreshCtx, subsystem.SnapshotService, clusterID, namespaceBaselineReady) {
+			return
+		}
+		// A rebuild may have replaced this subsystem while its sources settled.
+		// Never transfer readiness across subsystem generations.
+		if a.getRefreshSubsystem(clusterID) != subsystem {
+			a.reconcileGovernor()
+			return
+		}
+		subsystem.MarkColdServingReady()
+		a.reconcileGovernor()
+	}()
+}
+
+// primeColdServingSnapshots waits for the server-owned namespace lifecycle to
+// prove its retained baseline, then builds cluster-overview. Waiting on lifecycle
+// state performs no snapshot or Kubernetes API calls. Cache bypass forces the
+// overview through its current source gates; its cluster-prefixed empty scope
+// matches Global requests exactly.
+func primeColdServingSnapshots(
+	ctx context.Context,
+	service refresh.SnapshotService,
+	clusterID string,
+	namespaceBaselineReady func() bool,
+) bool {
+	if ctx == nil || service == nil || clusterID == "" || namespaceBaselineReady == nil {
+		return false
+	}
+	scope := refresh.JoinClusterScope(clusterID, "")
+	for {
+		if namespaceBaselineReady() {
+			if _, err := buildColdPreparationSnapshot(ctx, service, "cluster-overview", scope); err == nil {
+				return true
+			}
+		}
+		timer := time.NewTimer(coldPreparationRetryInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return false
+		case <-timer.C:
+		}
+	}
+}
+
+func buildColdPreparationSnapshot(
+	ctx context.Context,
+	service refresh.SnapshotService,
+	domainName string,
+	scope string,
+) (*refresh.Snapshot, error) {
+	attemptCtx, cancel := context.WithTimeout(ctx, config.RefreshInformerSyncTimeout+5*time.Second)
+	defer cancel()
+	return service.Build(refresh.WithCacheBypass(attemptCtx), domainName, scope)
 }
 
 // coolClusterToMmapServing transitions a cluster to the Cold-tier SERVING state: it stops the
@@ -340,8 +433,9 @@ func (a *App) coolClusterToMmapServing(clusterID string) {
 }
 
 // seedGovernorFromOpenClusters initializes the MRU/visible/applied state from the
-// currently open clusters and settles them to the policy's tiers. Called once the
-// initial subsystems have been built+started. The first open cluster is treated
+// currently open clusters and starts settling them to the policy's tiers. Called
+// once the initial subsystems have been built and their manager starts launched.
+// A Cold assignment remains live while its retained baseline settles. The first open cluster is treated
 // as visible if none has been set yet, so a fresh start lands one Foreground.
 func (a *App) seedGovernorFromOpenClusters() {
 	if a == nil {
@@ -360,8 +454,8 @@ func (a *App) seedGovernorFromOpenClusters() {
 	a.governorMu.Unlock()
 
 	// Leave last-applied tier updates to the serialized reconcile path. The initial
-	// build already started every subsystem, so its ensureRunning calls are idempotent;
-	// Cold assignments still perform the required cooling transition.
+	// build already launched every subsystem, so its ensureRunning calls are idempotent;
+	// Cold assignments prepare their retained baselines before cooling.
 	a.reconcileGovernor()
 }
 

--- a/backend/app_refresh_governor.go
+++ b/backend/app_refresh_governor.go
@@ -39,6 +39,20 @@ func (a *App) ensureGovernorStateLocked() {
 	}
 }
 
+// governorKeepsClusterCold reports whether the latest serialized governor
+// assignment intentionally keeps clusterID without live producers. It reads the
+// assignment rather than Subsystem.Cooled: during cooling the assignment changes
+// before feeds stop, and during re-warm it changes before the fresh catalog starts.
+func (a *App) governorKeepsClusterCold(clusterID string) bool {
+	if a == nil || clusterID == "" {
+		return false
+	}
+	a.governorMu.Lock()
+	defer a.governorMu.Unlock()
+	tier, tracked := a.governorApplied[clusterID]
+	return tracked && tier == system.TierCold
+}
+
 // SetVisibleCluster records the cluster the user is currently viewing and
 // re-tiers the open clusters accordingly. It is Wails-bound so the frontend
 // calls it whenever the active cluster tab changes.
@@ -57,6 +71,9 @@ func (a *App) SetVisibleCluster(clusterID string) {
 	a.governorMu.Unlock()
 
 	a.reconcileGovernor()
+	if a.clusterLifecycle != nil {
+		a.clusterLifecycle.Replay(clusterID)
+	}
 }
 
 // moveToFront returns mru with id at the front, preserving the relative order of
@@ -93,13 +110,19 @@ func (a *App) reconcileGovernor() {
 }
 
 // reconcileGovernorWith is the testable core: it reads the governor state under
-// the lock, computes transitions, then dispatches them through exec. exec calls
-// run OUTSIDE the lock because building/tearing down a subsystem is slow and must
-// not block SetVisibleCluster or the pressure loop.
+// governorMu, computes transitions, then dispatches them through exec. Slow executor
+// calls run outside governorMu so newer visibility and pressure intent can still be
+// recorded; governorReconcileMu orders their application so executor calls cannot
+// overlap on an intermediate subsystem state.
 func (a *App) reconcileGovernorWith(exec governorExecutor) {
 	if a == nil || exec == nil {
 		return
 	}
+	// Applying a tier is a multi-step lifecycle operation: cooling stops feeds
+	// before publishing the cooled subsystem, while warming replaces the entire
+	// subsystem. Never let another reconcile act on that intermediate state.
+	a.governorReconcileMu.Lock()
+	defer a.governorReconcileMu.Unlock()
 
 	open := a.openClusterIDs()
 
@@ -123,8 +146,8 @@ func (a *App) reconcileGovernorWith(exec governorExecutor) {
 	}
 	desired := a.governorPolicy.Assign(mru, a.governorVisible, a.governorPressure)
 	transitions := system.PlanGovernorTransitions(a.governorApplied, desired)
-	// Record the new tiers now; the executor calls below are idempotent, so a
-	// concurrent reconcile observing the updated map will simply find no work.
+	// Record the tiers being applied. A later serialized reconcile computes from
+	// this applied intent and any visibility or pressure changes recorded meanwhile.
 	for id, tier := range desired {
 		a.governorApplied[id] = tier
 	}
@@ -334,14 +357,11 @@ func (a *App) seedGovernorFromOpenClusters() {
 			a.governorVisible = a.governorMRU[0]
 		}
 	}
-	// Mark every open cluster as currently Foreground: the initial build path
-	// already started them all fully, so reconcile only needs to DEMOTE the ones
-	// the policy wants Background/Cold (idempotent for the visible one).
-	for id := range open {
-		a.governorApplied[id] = system.TierForeground
-	}
 	a.governorMu.Unlock()
 
+	// Leave last-applied tier updates to the serialized reconcile path. The initial
+	// build already started every subsystem, so its ensureRunning calls are idempotent;
+	// Cold assignments still perform the required cooling transition.
 	a.reconcileGovernor()
 }
 

--- a/backend/app_refresh_governor_test.go
+++ b/backend/app_refresh_governor_test.go
@@ -3,10 +3,37 @@ package backend
 import (
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/luxury-yacht/app/backend/refresh/system"
 	"github.com/stretchr/testify/require"
 )
+
+type blockingGovernorExecutor struct {
+	teardownStarted  chan struct{}
+	allowTeardown    chan struct{}
+	teardownFinished chan struct{}
+	ensureStarted    chan struct{}
+}
+
+func newBlockingGovernorExecutor() *blockingGovernorExecutor {
+	return &blockingGovernorExecutor{
+		teardownStarted:  make(chan struct{}),
+		allowTeardown:    make(chan struct{}),
+		teardownFinished: make(chan struct{}),
+		ensureStarted:    make(chan struct{}),
+	}
+}
+
+func (e *blockingGovernorExecutor) ensureRunning(string) {
+	close(e.ensureStarted)
+}
+
+func (e *blockingGovernorExecutor) teardown(string) {
+	close(e.teardownStarted)
+	<-e.allowTeardown
+	close(e.teardownFinished)
+}
 
 // recordingGovernorExecutor captures the transitions reconcile dispatches so the
 // pure decision-to-action wiring can be asserted without real subsystems.
@@ -107,6 +134,53 @@ func TestReconcileGovernorIdempotentNoOp(t *testing.T) {
 
 	require.Empty(t, exec.ensureSeq, "no rebuilds when already at desired tier")
 	require.Empty(t, exec.tornDown, "no teardowns when already at desired tier")
+}
+
+func TestReconcileGovernorDoesNotPromoteClusterUntilItsInFlightCoolingFinishes(t *testing.T) {
+	selections := []kubeconfigSelection{{Path: "/p/a", Context: "a"}}
+	app, ids := governorTestApp(t, selections, 0)
+	clusterID := ids[0]
+
+	// The cluster is open but not visible, so the first reconciliation cools it.
+	app.governorMRU = []string{clusterID}
+	app.governorApplied = map[string]system.ResourceTier{clusterID: system.TierBackground}
+
+	exec := newBlockingGovernorExecutor()
+	firstDone := make(chan struct{})
+	go func() {
+		app.reconcileGovernorWith(exec)
+		close(firstDone)
+	}()
+	<-exec.teardownStarted
+
+	// The user returns to the cluster while cooling is still between stopping the
+	// feeds and publishing the cooled state.
+	app.governorMu.Lock()
+	app.governorVisible = clusterID
+	app.governorMRU = moveToFront(app.governorMRU, clusterID)
+	app.governorMu.Unlock()
+
+	secondDone := make(chan struct{})
+	go func() {
+		app.reconcileGovernorWith(exec)
+		close(secondDone)
+	}()
+
+	select {
+	case <-exec.ensureStarted:
+		t.Fatal("foreground promotion ran before the in-flight cooling action finished")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(exec.allowTeardown)
+	<-firstDone
+	<-secondDone
+
+	select {
+	case <-exec.ensureStarted:
+	case <-time.After(time.Second):
+		t.Fatal("foreground promotion did not run after cooling finished")
+	}
 }
 
 func TestReconcileGovernorPromotionKeepsBothWarmClustersRunning(t *testing.T) {
@@ -226,4 +300,36 @@ func TestSetVisibleClusterMovesToFrontOfMRU(t *testing.T) {
 
 	require.Equal(t, y, app.governorVisible)
 	require.Equal(t, []string{y, x}, app.governorMRU)
+}
+
+func TestSetVisibleClusterReplaysCurrentLifecycleState(t *testing.T) {
+	selections := []kubeconfigSelection{{Path: "/p/x", Context: "x"}}
+	app, ids := governorTestApp(t, selections, 0)
+	clusterID := ids[0]
+
+	type lifecycleEvent struct {
+		clusterID string
+		state     ClusterLifecycleState
+		previous  ClusterLifecycleState
+	}
+	var events []lifecycleEvent
+	app.clusterLifecycle = newClusterLifecycle(func(clusterID string, state, previous ClusterLifecycleState) {
+		events = append(events, lifecycleEvent{clusterID: clusterID, state: state, previous: previous})
+	})
+	app.clusterLifecycle.SetState(clusterID, ClusterStateReady)
+	events = nil
+
+	// The backend may already be ready while the frontend still holds an older
+	// connected event. Activating the tab is the deterministic convergence point:
+	// it must replay the current state even though no lifecycle transition occurs.
+	app.governorVisible = clusterID
+	app.governorMRU = []string{clusterID}
+	app.governorApplied[clusterID] = system.TierForeground
+	app.SetVisibleCluster(clusterID)
+
+	require.Equal(t, []lifecycleEvent{{
+		clusterID: clusterID,
+		state:     ClusterStateReady,
+		previous:  ClusterStateReady,
+	}}, events)
 }

--- a/backend/app_refresh_governor_test.go
+++ b/backend/app_refresh_governor_test.go
@@ -1,13 +1,104 @@
 package backend
 
 import (
+	"context"
 	"sort"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/luxury-yacht/app/backend/refresh"
+	"github.com/luxury-yacht/app/backend/refresh/domain"
+	"github.com/luxury-yacht/app/backend/refresh/snapshot"
 	"github.com/luxury-yacht/app/backend/refresh/system"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+type coldPreparationSnapshotService struct {
+	mu             sync.Mutex
+	namespaceReady bool
+	calls          []string
+}
+
+// coldPreparationNamespaceSource models the current subsystem's namespace
+// workload stores independently from the aggregate cluster lifecycle. A rebuilt
+// subsystem starts unsynced even when the lifecycle still carries Ready from
+// the subsystem it replaced.
+type coldPreparationNamespaceSource struct {
+	mu     sync.Mutex
+	synced bool
+}
+
+func (s *coldPreparationNamespaceSource) Tracks(gvr schema.GroupVersionResource) bool {
+	return gvr == snapshot.PodGVR
+}
+
+func (s *coldPreparationNamespaceSource) HasSyncedFor(schema.GroupVersionResource) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.synced
+}
+
+func (s *coldPreparationNamespaceSource) CatalogRows(schema.GroupVersionResource) []interface{} {
+	return nil
+}
+
+func (s *coldPreparationNamespaceSource) AggregateRows(schema.GroupVersionResource) []interface{} {
+	return nil
+}
+
+func (s *coldPreparationNamespaceSource) ObjectMapRows(schema.GroupVersionResource) []interface{} {
+	return nil
+}
+
+func (s *coldPreparationNamespaceSource) setSynced(synced bool) {
+	s.mu.Lock()
+	s.synced = synced
+	s.mu.Unlock()
+}
+
+func (s *coldPreparationSnapshotService) Build(_ context.Context, domainName, scope string) (*refresh.Snapshot, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, domainName+"@"+scope)
+	switch domainName {
+	case "namespaces":
+		return &refresh.Snapshot{
+			Domain: domainName,
+			Scope:  scope,
+			Payload: snapshot.NamespaceSnapshot{
+				WorkloadsReady: s.namespaceReady,
+			},
+		}, nil
+	case "cluster-overview":
+		return &refresh.Snapshot{
+			Domain:  domainName,
+			Scope:   scope,
+			Payload: snapshot.ClusterOverviewSnapshot{},
+		}, nil
+	default:
+		return nil, nil
+	}
+}
+
+func (s *coldPreparationSnapshotService) callsSnapshot() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.calls...)
+}
+
+func keepGovernorForeground(app *App, clusterID string) {
+	app.governorVisible = clusterID
+	app.governorMRU = []string{clusterID}
+	app.governorApplied = map[string]system.ResourceTier{clusterID: system.TierForeground}
+}
+
+func governorAppliedTier(app *App, clusterID string) system.ResourceTier {
+	app.governorMu.Lock()
+	defer app.governorMu.Unlock()
+	return app.governorApplied[clusterID]
+}
 
 type blockingGovernorExecutor struct {
 	teardownStarted  chan struct{}
@@ -25,14 +116,16 @@ func newBlockingGovernorExecutor() *blockingGovernorExecutor {
 	}
 }
 
-func (e *blockingGovernorExecutor) ensureRunning(string) {
+func (e *blockingGovernorExecutor) ensureRunning(string) bool {
 	close(e.ensureStarted)
+	return true
 }
 
-func (e *blockingGovernorExecutor) teardown(string) {
+func (e *blockingGovernorExecutor) teardown(string) bool {
 	close(e.teardownStarted)
 	<-e.allowTeardown
 	close(e.teardownFinished)
+	return true
 }
 
 // recordingGovernorExecutor captures the transitions reconcile dispatches so the
@@ -47,13 +140,15 @@ func newRecordingGovernorExecutor() *recordingGovernorExecutor {
 	return &recordingGovernorExecutor{ensured: map[string]bool{}}
 }
 
-func (r *recordingGovernorExecutor) ensureRunning(clusterID string) {
+func (r *recordingGovernorExecutor) ensureRunning(clusterID string) bool {
 	r.ensured[clusterID] = true
 	r.ensureSeq = append(r.ensureSeq, clusterID)
+	return true
 }
 
-func (r *recordingGovernorExecutor) teardown(clusterID string) {
+func (r *recordingGovernorExecutor) teardown(clusterID string) bool {
 	r.tornDown = append(r.tornDown, clusterID)
+	return true
 }
 
 // governorTestApp returns an app whose open-cluster set is exactly the supplied
@@ -111,6 +206,236 @@ func TestReconcileGovernorColdStartTiers(t *testing.T) {
 	require.Equal(t, system.TierForeground, app.governorApplied[a])
 	require.Equal(t, system.TierBackground, app.governorApplied[b])
 	require.Equal(t, system.TierCold, app.governorApplied[c])
+}
+
+func TestGovernorDoesNotCoolBeforeColdServingSnapshotsAreReady(t *testing.T) {
+	app := newTestAppWithDefaults(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	app.refreshCtx = ctx
+	app.spillRoot = t.TempDir()
+	app.clusterLifecycle = newClusterLifecycle(nil)
+	app.clusterLifecycle.SetState("cluster-a", ClusterStateLoading)
+
+	service := &coldPreparationSnapshotService{namespaceReady: false}
+	subsystem := &system.Subsystem{
+		Registry:        domain.New(),
+		SnapshotService: service,
+	}
+	app.setRefreshSubsystem("cluster-a", subsystem)
+
+	app.realGovernorExecutor().teardown("cluster-a")
+
+	require.False(t, subsystem.Cooled,
+		"a cluster without a settled retained baseline must remain live")
+	require.Empty(t, service.callsSnapshot())
+}
+
+func TestColdPreparationDoesNotPollSnapshotsWhileNamespaceLifecycleIsLoading(t *testing.T) {
+	app := newTestAppWithDefaults(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	app.refreshCtx = ctx
+	app.spillRoot = t.TempDir()
+	keepGovernorForeground(app, "cluster-a")
+	app.clusterLifecycle = newClusterLifecycle(nil)
+	app.clusterLifecycle.SetState("cluster-a", ClusterStateLoading)
+
+	service := &coldPreparationSnapshotService{namespaceReady: false}
+	subsystem := &system.Subsystem{
+		Registry:        domain.New(),
+		SnapshotService: service,
+	}
+	app.setRefreshSubsystem("cluster-a", subsystem)
+
+	app.realGovernorExecutor().teardown("cluster-a")
+	time.Sleep(2 * coldPreparationRetryInterval)
+
+	require.Empty(t, service.callsSnapshot(),
+		"the existing server lifecycle owns namespace readiness; Cold preparation must not poll namespace snapshots")
+	require.False(t, subsystem.ColdServingReady())
+}
+
+func TestReconcileGovernorDoesNotRecordDeferredColdTransitionAsApplied(t *testing.T) {
+	selections := []kubeconfigSelection{{Path: "/p/a", Context: "a"}}
+	app, ids := governorTestApp(t, selections, 0)
+	clusterID := ids[0]
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	app.refreshCtx = ctx
+	app.spillRoot = t.TempDir()
+	app.governorMRU = []string{clusterID}
+	app.governorApplied[clusterID] = system.TierBackground
+	app.clusterLifecycle = newClusterLifecycle(nil)
+	app.clusterLifecycle.SetState(clusterID, ClusterStateLoading)
+
+	service := &coldPreparationSnapshotService{namespaceReady: false}
+	subsystem := &system.Subsystem{
+		Registry:        domain.New(),
+		SnapshotService: service,
+	}
+	app.setRefreshSubsystem(clusterID, subsystem)
+
+	app.reconcileGovernorWith(app.realGovernorExecutor())
+
+	require.Equal(t, system.TierBackground, app.governorApplied[clusterID],
+		"the applied tier must describe the still-live subsystem while cold preparation is pending")
+	require.False(t, subsystem.Cooled)
+}
+
+func TestColdPreparationUsesAggregateLifecycleBeforeCooling(t *testing.T) {
+	app := newTestAppWithDefaults(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	app.refreshCtx = ctx
+	app.spillRoot = t.TempDir()
+	keepGovernorForeground(app, "cluster-a")
+	app.clusterLifecycle = newClusterLifecycle(nil)
+	app.clusterLifecycle.SetState("cluster-a", ClusterStateLoading)
+
+	service := &coldPreparationSnapshotService{namespaceReady: true}
+	subsystem := &system.Subsystem{
+		Registry:        domain.New(),
+		SnapshotService: service,
+	}
+	app.setRefreshSubsystem("cluster-a", subsystem)
+	aggregate := newAggregateSnapshotService(
+		[]string{"cluster-a"},
+		map[string]*system.Subsystem{"cluster-a": subsystem},
+	)
+	aggregate.onNamespaceSnapshot = func(clusterID string) {
+		state := app.clusterLifecycle.GetState(clusterID)
+		if state == ClusterStateLoading || state == ClusterStateLoadingSlow {
+			app.clusterLifecycle.SetState(clusterID, ClusterStateReady)
+		}
+	}
+	app.refreshAggregates.Store(&refreshAggregateHandlers{snapshot: aggregate})
+
+	app.realGovernorExecutor().teardown("cluster-a")
+	runNamespacesReadinessSelfBuild(app.clusterLifecycle, aggregate, "cluster-a")
+
+	require.Eventually(t, func() bool {
+		return app.clusterLifecycle.GetState("cluster-a") == ClusterStateReady
+	}, time.Second, 10*time.Millisecond,
+		"cold preparation must cross the same server lifecycle gate as a normal namespace snapshot")
+	require.Eventually(t, subsystem.ColdServingReady, time.Second, 10*time.Millisecond)
+}
+
+func TestColdPreparationBuildsExactRetainedScopesBeforeCooling(t *testing.T) {
+	app := newTestAppWithDefaults(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	app.refreshCtx = ctx
+	app.spillRoot = t.TempDir()
+	keepGovernorForeground(app, "cluster-a")
+	app.clusterLifecycle = newClusterLifecycle(nil)
+	app.clusterLifecycle.SetState("cluster-a", ClusterStateReady)
+
+	service := &coldPreparationSnapshotService{namespaceReady: true}
+	subsystem := &system.Subsystem{
+		Registry:        domain.New(),
+		SnapshotService: service,
+	}
+	app.setRefreshSubsystem("cluster-a", subsystem)
+
+	require.False(t, app.realGovernorExecutor().teardown("cluster-a"),
+		"the first transition starts preparation instead of stopping producers")
+	require.Eventually(t, subsystem.ColdServingReady, time.Second, 10*time.Millisecond)
+	require.Equal(t, []string{
+		"cluster-overview@cluster-a|",
+	}, service.callsSnapshot())
+}
+
+func TestColdPreparationRequiresCurrentSubsystemWorkloadReadiness(t *testing.T) {
+	app := newTestAppWithDefaults(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	app.refreshCtx = ctx
+	app.spillRoot = t.TempDir()
+	keepGovernorForeground(app, "cluster-a")
+	app.clusterLifecycle = newClusterLifecycle(nil)
+	// Ready may have been set by the subsystem this one replaced.
+	app.clusterLifecycle.SetState("cluster-a", ClusterStateReady)
+
+	service := &coldPreparationSnapshotService{namespaceReady: true}
+	source := &coldPreparationNamespaceSource{}
+	subsystem := &system.Subsystem{
+		Registry:          domain.New(),
+		SnapshotService:   service,
+		NamespaceNotifier: snapshot.NewNamespaceChangeNotifier(source, snapshot.NewNamespaceWorkloadTracker(source)),
+	}
+	app.setRefreshSubsystem("cluster-a", subsystem)
+
+	app.realGovernorExecutor().teardown("cluster-a")
+	time.Sleep(2 * coldPreparationRetryInterval)
+
+	require.Empty(t, service.callsSnapshot(),
+		"an old aggregate Ready state must not authorize cooling the current unsynced subsystem")
+	require.False(t, subsystem.ColdServingReady())
+
+	source.setSynced(true)
+	require.Eventually(t, subsystem.ColdServingReady, time.Second, 10*time.Millisecond,
+		"preparation must continue after the current subsystem settles")
+	require.Equal(t, []string{"cluster-overview@cluster-a|"}, service.callsSnapshot())
+}
+
+func TestColdPreparationContinuesWhenNamespaceSourcesBecomeReady(t *testing.T) {
+	app := newTestAppWithDefaults(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	app.refreshCtx = ctx
+	app.spillRoot = t.TempDir()
+	keepGovernorForeground(app, "cluster-a")
+	app.clusterLifecycle = newClusterLifecycle(nil)
+	app.clusterLifecycle.SetState("cluster-a", ClusterStateLoading)
+
+	service := &coldPreparationSnapshotService{namespaceReady: false}
+	subsystem := &system.Subsystem{
+		Registry:        domain.New(),
+		SnapshotService: service,
+	}
+	app.setRefreshSubsystem("cluster-a", subsystem)
+
+	app.realGovernorExecutor().teardown("cluster-a")
+	time.Sleep(2 * coldPreparationRetryInterval)
+	require.NotContains(t, service.callsSnapshot(), "cluster-overview@cluster-a|",
+		"overview must not be retained while namespace workload sources are unsettled")
+	require.False(t, subsystem.ColdServingReady())
+
+	app.clusterLifecycle.SetState("cluster-a", ClusterStateReady)
+	require.Eventually(t, subsystem.ColdServingReady, time.Second, 10*time.Millisecond,
+		"the same server-owned preparation must continue once sources settle")
+	require.Contains(t, service.callsSnapshot(), "cluster-overview@cluster-a|")
+}
+
+func TestReconcileGovernorAppliesColdAfterRetainedBaselineIsReady(t *testing.T) {
+	selections := []kubeconfigSelection{{Path: "/p/a", Context: "a"}}
+	app, ids := governorTestApp(t, selections, 0)
+	clusterID := ids[0]
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	app.refreshCtx = ctx
+	app.spillRoot = t.TempDir()
+	app.governorMRU = []string{clusterID}
+	app.governorApplied[clusterID] = system.TierBackground
+	app.clusterLifecycle = newClusterLifecycle(nil)
+	app.clusterLifecycle.SetState(clusterID, ClusterStateReady)
+
+	service := &coldPreparationSnapshotService{namespaceReady: true}
+	subsystem := &system.Subsystem{
+		Registry:        domain.New(),
+		SnapshotService: service,
+	}
+	app.setRefreshSubsystem(clusterID, subsystem)
+
+	app.reconcileGovernorWith(app.realGovernorExecutor())
+	require.Equal(t, system.TierBackground, governorAppliedTier(app, clusterID))
+
+	require.Eventually(t, func() bool {
+		return governorAppliedTier(app, clusterID) == system.TierCold
+	}, time.Second, 10*time.Millisecond,
+		"the retained-baseline completion must retry and finish the deferred transition")
+	require.True(t, subsystem.Cooled)
 }
 
 func TestReconcileGovernorIdempotentNoOp(t *testing.T) {

--- a/backend/app_refresh_governor_test.go
+++ b/backend/app_refresh_governor_test.go
@@ -2,11 +2,16 @@ package backend
 
 import (
 	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/luxury-yacht/app/backend/objectcatalog"
 	"github.com/luxury-yacht/app/backend/refresh"
 	"github.com/luxury-yacht/app/backend/refresh/domain"
 	"github.com/luxury-yacht/app/backend/refresh/snapshot"
@@ -19,6 +24,28 @@ type coldPreparationSnapshotService struct {
 	mu             sync.Mutex
 	namespaceReady bool
 	calls          []string
+}
+
+type blockingColdPreparationSnapshotService struct {
+	started  chan struct{}
+	canceled chan struct{}
+	once     sync.Once
+}
+
+func (s *blockingColdPreparationSnapshotService) Build(ctx context.Context, _, _ string) (*refresh.Snapshot, error) {
+	s.once.Do(func() { close(s.started) })
+	<-ctx.Done()
+	close(s.canceled)
+	return nil, ctx.Err()
+}
+
+type failingColdPreparationSnapshotService struct {
+	calls chan struct{}
+}
+
+func (s *failingColdPreparationSnapshotService) Build(context.Context, string, string) (*refresh.Snapshot, error) {
+	s.calls <- struct{}{}
+	return nil, errors.New("sources have not settled")
 }
 
 // coldPreparationNamespaceSource models the current subsystem's namespace
@@ -408,6 +435,65 @@ func TestColdPreparationContinuesWhenNamespaceSourcesBecomeReady(t *testing.T) {
 	require.Contains(t, service.callsSnapshot(), "cluster-overview@cluster-a|")
 }
 
+func TestReplacingSubsystemCancelsInFlightColdPreparationBuild(t *testing.T) {
+	app := newTestAppWithDefaults(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	app.refreshCtx = ctx
+	app.clusterLifecycle = newClusterLifecycle(nil)
+	app.clusterLifecycle.SetState("cluster-a", ClusterStateReady)
+
+	service := &blockingColdPreparationSnapshotService{
+		started:  make(chan struct{}),
+		canceled: make(chan struct{}),
+	}
+	previous := &system.Subsystem{SnapshotService: service}
+	app.setRefreshSubsystem("cluster-a", previous)
+	app.realGovernorExecutor().teardown("cluster-a")
+
+	select {
+	case <-service.started:
+	case <-time.After(time.Second):
+		t.Fatal("cold preparation build did not start")
+	}
+	app.swapRefreshSubsystem("cluster-a", &system.Subsystem{})
+
+	select {
+	case <-service.canceled:
+	case <-time.After(time.Second):
+		t.Fatal("replacing the subsystem did not cancel its in-flight cold preparation build")
+	}
+}
+
+func TestColdPreparationRetryStopsWhenSubsystemIsNoLongerCurrent(t *testing.T) {
+	app := newTestAppWithDefaults(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	app.refreshCtx = ctx
+	app.clusterLifecycle = newClusterLifecycle(nil)
+	app.clusterLifecycle.SetState("cluster-a", ClusterStateReady)
+
+	service := &failingColdPreparationSnapshotService{calls: make(chan struct{}, 4)}
+	previous := &system.Subsystem{SnapshotService: service}
+	app.setRefreshSubsystem("cluster-a", previous)
+	app.realGovernorExecutor().teardown("cluster-a")
+
+	select {
+	case <-service.calls:
+	case <-time.After(time.Second):
+		t.Fatal("cold preparation build did not start")
+	}
+	// Direct replacement deliberately bypasses swap cancellation so this test
+	// independently pins the retry loop's current-generation check.
+	app.setRefreshSubsystem("cluster-a", &system.Subsystem{})
+
+	select {
+	case <-service.calls:
+		t.Fatal("obsolete subsystem issued another cold preparation build")
+	case <-time.After(2 * coldPreparationRetryInterval):
+	}
+}
+
 func TestReconcileGovernorAppliesColdAfterRetainedBaselineIsReady(t *testing.T) {
 	selections := []kubeconfigSelection{{Path: "/p/a", Context: "a"}}
 	app, ids := governorTestApp(t, selections, 0)
@@ -572,6 +658,101 @@ func TestReconcileGovernorMemoryPressureCoolsNonVisible(t *testing.T) {
 	require.Equal(t, want, tornDown, "under pressure every non-visible cluster is cooled")
 	require.NotContains(t, exec.ensureSeq, b)
 	require.NotContains(t, exec.ensureSeq, c)
+}
+
+func TestColdPreparationIsNotForcedWithoutMemoryPressure(t *testing.T) {
+	app := newTestAppWithDefaults(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	app.refreshCtx = ctx
+	app.clusterLifecycle = newClusterLifecycle(nil)
+	app.clusterLifecycle.SetState("cluster-a", ClusterStateLoading)
+	now := time.Now()
+	app.governorNow = func() time.Time { return now }
+
+	subsystem := &system.Subsystem{
+		Registry:        domain.New(),
+		SnapshotService: &coldPreparationSnapshotService{},
+	}
+	app.setRefreshSubsystem("cluster-a", subsystem)
+	require.False(t, app.realGovernorExecutor().teardown("cluster-a"))
+
+	now = now.Add(coldPreparationPressureGrace + time.Second)
+	require.False(t, app.realGovernorExecutor().teardown("cluster-a"))
+	require.Same(t, subsystem, app.getRefreshSubsystem("cluster-a"),
+		"elapsed preparation alone must not weaken the retained-baseline rule")
+}
+
+func TestSustainedMemoryPressureForcesFullTeardownAfterColdPreparationGrace(t *testing.T) {
+	selections := []kubeconfigSelection{{Path: "/p/a", Context: "a"}}
+	app, ids := governorTestApp(t, selections, 5)
+	clusterID := ids[0]
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	app.refreshCtx = ctx
+	app.spillRoot = t.TempDir()
+	app.governorBudget = 1
+	app.governorMRU = []string{clusterID}
+	app.governorApplied[clusterID] = system.TierBackground
+	app.clusterLifecycle = newClusterLifecycle(nil)
+	app.clusterLifecycle.SetState(clusterID, ClusterStateLoading)
+	now := time.Now()
+	app.governorNow = func() time.Time { return now }
+
+	reg := domain.New()
+	reg.RegisterMaintainedStore("cluster-overview", &spillFake{rows: []string{"retained"}})
+	subsystem := &system.Subsystem{
+		Registry:        reg,
+		SnapshotService: &coldPreparationSnapshotService{},
+	}
+	app.setRefreshSubsystem(clusterID, subsystem)
+	done := make(chan struct{}, 1)
+	done <- struct{}{}
+	app.storeObjectCatalogEntry(clusterID, &objectCatalogEntry{
+		service: &objectcatalog.Service{},
+		cancel:  func() {},
+		done:    done,
+	})
+
+	app.handleGovernorPressureSample(2)
+	require.Same(t, subsystem, app.getRefreshSubsystem(clusterID),
+		"the first pressure sample starts preparation without discarding live data")
+
+	now = now.Add(coldPreparationPressureGrace - time.Second)
+	app.handleGovernorPressureSample(2)
+	require.Same(t, subsystem, app.getRefreshSubsystem(clusterID),
+		"sustained pressure must respect the bounded preparation grace")
+
+	now = now.Add(2 * time.Second)
+	app.handleGovernorPressureSample(2)
+	require.Nil(t, app.getRefreshSubsystem(clusterID),
+		"an unchanged pressure signal must re-drive and eventually force full teardown")
+	require.Nil(t, app.objectCatalogServiceForCluster(clusterID))
+
+	spillDir, err := app.clusterSpillDir(clusterID)
+	require.NoError(t, err)
+	_, err = os.Stat(filepath.Join(spillDir, "cluster-overview.spill"))
+	require.NoError(t, err, "forced teardown must preserve the normal spill path")
+
+	entries := app.logger.GetEntries()
+	forcedLogs := 0
+	for _, entry := range entries {
+		if entry.ClusterID == clusterID &&
+			strings.Contains(entry.Message, "forcing full teardown") &&
+			strings.Contains(entry.Message, "heap in use: 2 bytes") {
+			forcedLogs++
+		}
+	}
+	require.Equal(t, 1, forcedLogs,
+		"forced teardown must emit exactly one cluster-scoped diagnostic with heap use")
+	require.Condition(t, func() bool {
+		for _, entry := range entries {
+			if entry.ClusterID == clusterID && strings.Contains(entry.Message, "Tearing down subsystem") {
+				return true
+			}
+		}
+		return false
+	}, "forced pressure fallback must route through the normal full-teardown lifecycle")
 }
 
 func TestReconcileGovernorDropsClosedClusterTier(t *testing.T) {

--- a/backend/app_refresh_setup.go
+++ b/backend/app_refresh_setup.go
@@ -70,10 +70,11 @@ func (a *App) setupRefreshSubsystem() error {
 		return err
 	}
 
-	// The subsystems above are all started Foreground. Settle them to the
-	// governor's tiers (visible Foreground, warm set Background with metrics
-	// paused, the rest Cold) and start the memory-pressure loop, which stops
-	// when the refresh context is cancelled.
+	// The subsystems above all have live manager starts in flight. Begin settling
+	// them to the governor's tiers (visible Foreground, warm set Background, the
+	// rest Cold). A Cold assignment keeps its producers live until the server has
+	// built the retained namespace/overview baseline. The memory-pressure loop
+	// stops when the refresh context is cancelled.
 	a.seedGovernorFromOpenClusters()
 	go a.startGovernorPressureLoop(ctx)
 

--- a/backend/app_refresh_subsystems.go
+++ b/backend/app_refresh_subsystems.go
@@ -51,6 +51,7 @@ func (a *App) swapRefreshSubsystem(clusterID string, next *system.Subsystem) {
 	if previous == nil || previous == next {
 		return
 	}
+	previous.CancelColdPreparation()
 	// stopRefreshSubsystem no-ops without a manager; silence the doorbell
 	// notifiers explicitly so a partially-built previous subsystem cannot keep
 	// them.

--- a/backend/app_refresh_update.go
+++ b/backend/app_refresh_update.go
@@ -130,7 +130,11 @@ func (a *App) stopRefreshSubsystems(subsystems map[string]*system.Subsystem) {
 }
 
 func (a *App) stopRefreshSubsystem(subsystem *system.Subsystem) {
-	if subsystem == nil || subsystem.Manager == nil {
+	if subsystem == nil {
+		return
+	}
+	subsystem.CancelColdPreparation()
+	if subsystem.Manager == nil {
 		return
 	}
 	subsystem.StopDoorbellNotifiers()

--- a/backend/cluster_auth.go
+++ b/backend/cluster_auth.go
@@ -112,6 +112,7 @@ func (a *App) stopClusterFeeds(clusterID string, subsystem *system.Subsystem) {
 	if a == nil || clusterID == "" || subsystem == nil {
 		return
 	}
+	subsystem.CancelColdPreparation()
 
 	// Stop permission revalidation for this cluster.
 	a.stopRefreshPermissionRevalidation(clusterID)

--- a/backend/cluster_clients.go
+++ b/backend/cluster_clients.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"runtime"
-	"sync"
 
 	appconfig "github.com/luxury-yacht/app/backend/internal/config"
 	"github.com/luxury-yacht/app/backend/internal/logsources"
@@ -54,6 +53,12 @@ type clusterClients struct {
 	fallbackResourceResolver common.ResourceResolver
 }
 
+type clusterClientBuilder func(
+	context.Context,
+	kubeconfigSelection,
+	ClusterMeta,
+) (*clusterClients, error)
+
 func (a *App) clusterClientsForID(clusterID string) *clusterClients {
 	if a == nil || clusterID == "" {
 		return nil
@@ -72,8 +77,12 @@ func (a *App) clusterClientsForSelection(selection kubeconfigSelection) *cluster
 	}
 	a.clusterClientsMu.Lock()
 	defer a.clusterClientsMu.Unlock()
+	return a.clusterClientsForSelectionLocked(selection)
+}
+
+func (a *App) clusterClientsForSelectionLocked(selection kubeconfigSelection) *clusterClients {
 	for _, c := range a.clusterClients {
-		if c.kubeconfigPath == selection.Path && c.kubeconfigContext == selection.Context {
+		if c != nil && c.kubeconfigPath == selection.Path && c.kubeconfigContext == selection.Context {
 			return c
 		}
 	}
@@ -87,8 +96,19 @@ func (a *App) syncClusterClientPool(selections []kubeconfigSelection) error {
 
 // syncClusterClientPoolWithContext builds missing clients for the provided selections and drops stale entries.
 func (a *App) syncClusterClientPoolWithContext(ctx context.Context, selections []kubeconfigSelection) error {
+	return a.syncClusterClientPoolWithBuilder(ctx, selections, a.buildClusterClientsWithContext)
+}
+
+func (a *App) syncClusterClientPoolWithBuilder(
+	ctx context.Context,
+	selections []kubeconfigSelection,
+	build clusterClientBuilder,
+) error {
 	if a == nil {
 		return fmt.Errorf("app is nil")
+	}
+	if build == nil {
+		return fmt.Errorf("cluster client builder is nil")
 	}
 	if ctx == nil {
 		ctx = context.Background()
@@ -125,11 +145,6 @@ func (a *App) syncClusterClientPoolWithContext(ctx context.Context, selections [
 	a.clusterClientsMu.Unlock()
 
 	if len(toCreate) > 0 {
-		type builtClient struct {
-			id      string
-			clients *clusterClients
-		}
-
 		// Pre-build metadata so worker goroutines do not repeatedly derive IDs.
 		type createTask struct {
 			selection kubeconfigSelection
@@ -150,50 +165,55 @@ func (a *App) syncClusterClientPoolWithContext(ctx context.Context, selections [
 			}
 		}
 
-		built := make([]builtClient, 0, len(tasks))
 		limit := clusterClientBuildConcurrencyLimit(len(tasks))
-		var builtMu sync.Mutex
 		err := parallel.ForEach(ctx, tasks, limit, func(taskCtx context.Context, task createTask) error {
 			return a.runClusterOperation(taskCtx, task.meta.ID, func(opCtx context.Context) error {
 				if err := opCtx.Err(); err != nil {
 					return err
 				}
-				clients, buildErr := a.buildClusterClientsWithContext(opCtx, task.selection, task.meta)
+
+				// Another selection sync may have installed this client while this task
+				// waited for its per-cluster operation slot.
+				if a.clusterClientsForID(task.meta.ID) != nil || a.clusterClientsForSelection(task.selection) != nil {
+					return nil
+				}
+
+				clients, buildErr := build(opCtx, task.selection, task.meta)
 				if buildErr != nil {
 					return buildErr
 				}
+				if clients == nil {
+					return fmt.Errorf("cluster client builder returned nil clients for %s", task.meta.ID)
+				}
 				if err := opCtx.Err(); err != nil {
-					if clients != nil && clients.authManager != nil {
+					if clients.authManager != nil {
 						clients.authManager.Shutdown()
 					}
 					return err
 				}
-				builtMu.Lock()
-				built = append(built, builtClient{id: task.meta.ID, clients: clients})
-				builtMu.Unlock()
+
+				installed := false
+				a.clusterClientsMu.Lock()
+				if a.clusterClients[task.meta.ID] == nil && a.clusterClientsForSelectionLocked(task.selection) == nil {
+					a.clusterClients[task.meta.ID] = clients
+					installed = true
+				}
+				a.clusterClientsMu.Unlock()
+
+				if !installed {
+					if clients.authManager != nil {
+						clients.authManager.Shutdown()
+					}
+					return nil
+				}
+				if a.clusterLifecycle != nil {
+					a.clusterLifecycle.SetState(task.meta.ID, ClusterStateConnected)
+				}
 				return nil
 			})
 		})
 		if err != nil {
-			// Cleanup any successfully created auth managers on partial failure.
-			for _, item := range built {
-				if item.clients != nil && item.clients.authManager != nil {
-					item.clients.authManager.Shutdown()
-				}
-			}
 			return err
-		}
-
-		a.clusterClientsMu.Lock()
-		for _, item := range built {
-			a.clusterClients[item.id] = item.clients
-		}
-		a.clusterClientsMu.Unlock()
-
-		for _, item := range built {
-			if a.clusterLifecycle != nil {
-				a.clusterLifecycle.SetState(item.id, ClusterStateConnected)
-			}
 		}
 	}
 

--- a/backend/cluster_clients_sync_test.go
+++ b/backend/cluster_clients_sync_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/luxury-yacht/app/backend/internal/authstate"
 	appconfig "github.com/luxury-yacht/app/backend/internal/config"
@@ -389,4 +390,62 @@ func TestSyncClusterClientPool_ConcurrentAccess(t *testing.T) {
 	defer app.clusterClientsMu.Unlock()
 	require.Len(t, app.clusterClients, 1)
 	require.NotNil(t, app.clusterClients[id])
+}
+
+func TestSyncClusterClientPoolPublishesEachBuiltClientWithoutWaitingForSiblingBuilds(t *testing.T) {
+	app := newTestAppWithDefaults(t)
+	app.Ctx = context.Background()
+	app.clusterClients = make(map[string]*clusterClients)
+	app.clusterOps = newClusterOperationCoordinator()
+
+	selA := kubeconfigSelection{Path: "/tmp/config-a", Context: "ctx-a"}
+	selB := kubeconfigSelection{Path: "/tmp/config-b", Context: "ctx-b"}
+	app.availableKubeconfigs = []KubeconfigInfo{
+		{Name: "config-a", Path: selA.Path, Context: selA.Context},
+		{Name: "config-b", Path: selB.Path, Context: selB.Context},
+	}
+	idA := app.clusterMetaForSelection(selA).ID
+
+	aBuilt := make(chan struct{})
+	releaseB := make(chan struct{})
+	var aBuiltOnce sync.Once
+	var releaseBOnce sync.Once
+	t.Cleanup(func() { releaseBOnce.Do(func() { close(releaseB) }) })
+
+	build := func(ctx context.Context, selection kubeconfigSelection, meta ClusterMeta) (*clusterClients, error) {
+		if selection == selB {
+			select {
+			case <-releaseB:
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+		clients := &clusterClients{
+			meta:              meta,
+			kubeconfigPath:    selection.Path,
+			kubeconfigContext: selection.Context,
+		}
+		if selection == selA {
+			aBuiltOnce.Do(func() { close(aBuilt) })
+		}
+		return clients, nil
+	}
+
+	result := make(chan error, 1)
+	go func() {
+		result <- app.syncClusterClientPoolWithBuilder(context.Background(), []kubeconfigSelection{selA, selB}, build)
+	}()
+
+	select {
+	case <-aBuilt:
+	case <-time.After(time.Second):
+		t.Fatal("cluster A client build did not finish")
+	}
+
+	require.Eventually(t, func() bool {
+		return app.clusterClientsForID(idA) != nil
+	}, 250*time.Millisecond, 10*time.Millisecond, "one slow cluster must not delay publishing another cluster's completed client")
+
+	releaseBOnce.Do(func() { close(releaseB) })
+	require.NoError(t, <-result)
 }

--- a/backend/cluster_lifecycle.go
+++ b/backend/cluster_lifecycle.go
@@ -71,6 +71,10 @@ func (cl *clusterLifecycle) SetState(clusterId string, state ClusterLifecycleSta
 	}
 
 	previousState := entry.state
+	if isRefreshServingState(previousState) && isClientInitializationState(state) {
+		cl.mu.Unlock()
+		return
+	}
 
 	// Cancel any pending slow-loading timer before changing state.
 	if entry.slowTimer != nil {
@@ -107,6 +111,14 @@ func (cl *clusterLifecycle) SetState(clusterId string, state ClusterLifecycleSta
 	}
 }
 
+func isClientInitializationState(state ClusterLifecycleState) bool {
+	return state == ClusterStateConnecting || state == ClusterStateConnected
+}
+
+func isRefreshServingState(state ClusterLifecycleState) bool {
+	return state == ClusterStateLoading || state == ClusterStateLoadingSlow || state == ClusterStateReady
+}
+
 // GetState returns the current lifecycle state for a cluster.
 // Returns an empty string if the cluster is not tracked.
 func (cl *clusterLifecycle) GetState(clusterId string) ClusterLifecycleState {
@@ -130,6 +142,26 @@ func (cl *clusterLifecycle) GetAllStates() map[string]ClusterLifecycleState {
 		result[id] = entry.state
 	}
 	return result
+}
+
+// Replay emits the cluster's current authoritative state without changing the
+// state machine or restarting its slow-loading timer. Foreground activation uses
+// this after governor reconciliation so a frontend that missed an earlier edge
+// converges even when the backend state itself did not change.
+func (cl *clusterLifecycle) Replay(clusterId string) {
+	cl.mu.Lock()
+	entry := cl.entries[clusterId]
+	if entry == nil {
+		cl.mu.Unlock()
+		return
+	}
+	state := entry.state
+	emitter := cl.emitter
+	cl.mu.Unlock()
+
+	if emitter != nil {
+		emitter(clusterId, state, state)
+	}
 }
 
 // Remove deletes a cluster's lifecycle entry and cancels any pending slow timer.

--- a/backend/cluster_lifecycle_test.go
+++ b/backend/cluster_lifecycle_test.go
@@ -58,6 +58,35 @@ func TestClusterLifecycleFullTransitionSequence(t *testing.T) {
 	require.Equal(t, emittedEvent{"cluster-a", "ready", "loading"}, events[3])
 }
 
+func TestClusterLifecycleRejectsLateClientPhaseAfterSubsystemStarted(t *testing.T) {
+	emitter, getEvents := collectingEmitter()
+	cl := newClusterLifecycleWithSlowThreshold(emitter, time.Minute)
+
+	cl.SetState("cluster-a", ClusterStateConnecting)
+	cl.SetState("cluster-a", ClusterStateConnected)
+	cl.SetState("cluster-a", ClusterStateLoading)
+
+	// A stale client initialization may complete after the refresh subsystem has
+	// already started. It must not move the lifecycle back behind the serving gate.
+	cl.SetState("cluster-a", ClusterStateConnecting)
+	require.Equal(t, ClusterStateLoading, cl.GetState("cluster-a"))
+	cl.SetState("cluster-a", ClusterStateConnected)
+	require.Equal(t, ClusterStateLoading, cl.GetState("cluster-a"))
+
+	cl.SetState("cluster-a", ClusterStateReady)
+	cl.SetState("cluster-a", ClusterStateConnecting)
+	require.Equal(t, ClusterStateReady, cl.GetState("cluster-a"))
+	cl.SetState("cluster-a", ClusterStateConnected)
+	require.Equal(t, ClusterStateReady, cl.GetState("cluster-a"))
+
+	require.Equal(t, []emittedEvent{
+		{"cluster-a", ClusterStateConnecting, ""},
+		{"cluster-a", ClusterStateConnected, ClusterStateConnecting},
+		{"cluster-a", ClusterStateLoading, ClusterStateConnected},
+		{"cluster-a", ClusterStateReady, ClusterStateLoading},
+	}, getEvents())
+}
+
 func TestClusterLifecycleSlowLoading(t *testing.T) {
 	emitter, getEvents := collectingEmitter()
 	threshold := 50 * time.Millisecond

--- a/backend/refresh/snapshot/namespace_notifier.go
+++ b/backend/refresh/snapshot/namespace_notifier.go
@@ -90,6 +90,13 @@ func NewNamespaceChangeNotifier(ingest namespacePodIngestSource, tracker *Namesp
 	}
 }
 
+// WorkloadsReady reports whether this notifier's workload tracker has settled.
+// The notifier and tracker belong to one refresh subsystem generation, so this
+// is the generation-local readiness check used before that subsystem may cool.
+func (n *NamespaceChangeNotifier) WorkloadsReady() bool {
+	return n != nil && n.tracker != nil && n.tracker.Synced()
+}
+
 // SetBroadcast wires the doorbell sink. Events recorded before wiring are
 // flushed on the next debounce tick. The reason describes what rang the
 // doorbell, for the debug log at the broadcast site.

--- a/backend/refresh/system/governor.go
+++ b/backend/refresh/system/governor.go
@@ -10,7 +10,8 @@ package system
 //
 // Metrics demand is independent of governor tier and follows active frontend
 // leases for each cluster.
-//   - Cold: torn down, heap reclaimed; re-warmed (re-synced) when the user revisits.
+//   - Cold: live producers stopped only after a retained serving baseline exists;
+//     re-warmed (re-synced) when the user revisits.
 type ResourceTier int
 
 const (

--- a/backend/refresh/system/manager.go
+++ b/backend/refresh/system/manager.go
@@ -116,6 +116,31 @@ type Subsystem struct {
 	// cooled, always-settled informer hub). A cooled subsystem is non-nil but NOT live:
 	// the governor re-warm path detects this and rebuilds a fresh, live subsystem.
 	Cooled bool
+
+	// coldPreparation is the server-owned gate in front of Cooled. A subsystem may
+	// stop its live producers only after the retained namespace and cluster-overview
+	// snapshots have been built from settled sources. State transitions are:
+	// 0 = not started, 1 = preparing, 2 = ready.
+	coldPreparation atomic.Uint32
+}
+
+// BeginColdPreparation elects one goroutine to prepare the retained snapshots
+// required before this subsystem may stop its live producers.
+func (s *Subsystem) BeginColdPreparation() bool {
+	return s != nil && s.coldPreparation.CompareAndSwap(0, 1)
+}
+
+// MarkColdServingReady records that the retained baseline has been built from
+// settled sources and this subsystem is eligible for the Cold serving tier.
+func (s *Subsystem) MarkColdServingReady() {
+	if s != nil {
+		s.coldPreparation.Store(2)
+	}
+}
+
+// ColdServingReady reports whether the server-owned retained baseline exists.
+func (s *Subsystem) ColdServingReady() bool {
+	return s != nil && s.coldPreparation.Load() == 2
 }
 
 // NewSubsystem prepares the refresh manager, HTTP handler, and supporting services.

--- a/backend/refresh/system/manager.go
+++ b/backend/refresh/system/manager.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -117,30 +118,102 @@ type Subsystem struct {
 	// the governor re-warm path detects this and rebuilds a fresh, live subsystem.
 	Cooled bool
 
-	// coldPreparation is the server-owned gate in front of Cooled. A subsystem may
-	// stop its live producers only after the retained namespace and cluster-overview
-	// snapshots have been built from settled sources. State transitions are:
-	// 0 = not started, 1 = preparing, 2 = ready.
-	coldPreparation atomic.Uint32
+	// coldPreparation is the server-owned gate in front of Cooled. Its context is
+	// owned by this subsystem generation so replacement/teardown can stop both an
+	// in-flight build and its retry loop.
+	coldPreparationMu      sync.Mutex
+	coldPreparationState   coldPreparationState
+	coldPreparationStarted time.Time
+	coldPreparationCancel  context.CancelFunc
 }
 
+type coldPreparationState uint8
+
+const (
+	coldPreparationNotStarted coldPreparationState = iota
+	coldPreparationRunning
+	coldPreparationReady
+)
+
 // BeginColdPreparation elects one goroutine to prepare the retained snapshots
-// required before this subsystem may stop its live producers.
-func (s *Subsystem) BeginColdPreparation() bool {
-	return s != nil && s.coldPreparation.CompareAndSwap(0, 1)
+// required before this subsystem may stop its live producers. The returned
+// context is canceled when this subsystem generation stops.
+func (s *Subsystem) BeginColdPreparation(parent context.Context, startedAt time.Time) (context.Context, bool) {
+	if s == nil || parent == nil {
+		return nil, false
+	}
+	s.coldPreparationMu.Lock()
+	defer s.coldPreparationMu.Unlock()
+	if s.coldPreparationState != coldPreparationNotStarted {
+		return nil, false
+	}
+	ctx, cancel := context.WithCancel(parent)
+	s.coldPreparationState = coldPreparationRunning
+	s.coldPreparationStarted = startedAt
+	s.coldPreparationCancel = cancel
+	return ctx, true
 }
 
 // MarkColdServingReady records that the retained baseline has been built from
 // settled sources and this subsystem is eligible for the Cold serving tier.
 func (s *Subsystem) MarkColdServingReady() {
-	if s != nil {
-		s.coldPreparation.Store(2)
+	if s == nil {
+		return
+	}
+	s.coldPreparationMu.Lock()
+	if s.coldPreparationState == coldPreparationRunning {
+		s.coldPreparationState = coldPreparationReady
+	}
+	cancel := s.coldPreparationCancel
+	s.coldPreparationCancel = nil
+	s.coldPreparationMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+// CancelColdPreparation stops work owned by this subsystem generation.
+func (s *Subsystem) CancelColdPreparation() {
+	if s == nil {
+		return
+	}
+	s.coldPreparationMu.Lock()
+	cancel := s.coldPreparationCancel
+	s.coldPreparationCancel = nil
+	s.coldPreparationState = coldPreparationNotStarted
+	s.coldPreparationStarted = time.Time{}
+	s.coldPreparationMu.Unlock()
+	if cancel != nil {
+		cancel()
 	}
 }
 
 // ColdServingReady reports whether the server-owned retained baseline exists.
 func (s *Subsystem) ColdServingReady() bool {
-	return s != nil && s.coldPreparation.Load() == 2
+	if s == nil {
+		return false
+	}
+	s.coldPreparationMu.Lock()
+	defer s.coldPreparationMu.Unlock()
+	return s.coldPreparationState == coldPreparationReady
+}
+
+// ColdPreparationAge reports how long this generation has been preparing its
+// retained baseline. Ready and not-started generations are not pending.
+func (s *Subsystem) ColdPreparationAge(now time.Time) (time.Duration, bool) {
+	if s == nil {
+		return 0, false
+	}
+	s.coldPreparationMu.Lock()
+	defer s.coldPreparationMu.Unlock()
+	if s.coldPreparationState != coldPreparationRunning || s.coldPreparationStarted.IsZero() {
+		return 0, false
+	}
+	age := now.Sub(s.coldPreparationStarted)
+	if age < 0 {
+		age = 0
+	}
+	return age, true
 }
 
 // NewSubsystem prepares the refresh manager, HTTP handler, and supporting services.

--- a/docs/architecture/data-freshness.md
+++ b/docs/architecture/data-freshness.md
@@ -17,7 +17,8 @@ payload shape; they link here instead of restating freshness behavior.
    service-unavailable errors. When reconciliation completes, its snapshot
    replaces the retained data. This activation boundary applies to every refresh
    domain and every dispatch path, including scheduled work, stream-triggered
-   snapshots, and stream-only domains.
+   snapshots, and stream-only domains. Backend cool/re-warm transitions are
+   serialized so this boundary cannot complete against a half-cooled subsystem.
 3. **Keep background work passive.** An open inactive cluster retains snapshots
    and object-change subscriptions. It does not continuously fetch snapshots,
    start metrics collection, or produce manual-refresh errors merely because
@@ -50,7 +51,12 @@ stream reconciliation path rather than creating a ManualQueue job.
 ## Retention and leases
 
 - Refresh state is keyed by one `clusterId` plus the domain-owned scope.
+- The selected cluster and domain scope determine the retained-data read key.
+  Lifecycle/readiness may gate leases and requests, but must not remove that read
+  key or hide a retained snapshot.
 - Disabling or switching a visible scope preserves its last successful data.
+- If an open cluster temporarily loses refresh eligibility, stop its active work
+  with state preservation. Only closing/removing the cluster clears that scope.
 - Re-enabling paints that data before the activation request settles.
 - Cross-cluster views acquire one lease per displayed cluster; membership
   changes acquire/release only the changed clusters.
@@ -124,6 +130,17 @@ The authored domain contract declares which clocks can change a payload:
   error state clears that scope's dedupe so a later failure can notify again.
 - Loading gates may block invalid early reads, but must still allow the request
   that advances the cluster to ready.
+- After foreground governor reconciliation, the backend replays that cluster's
+  current authoritative lifecycle state even when no transition occurred. The
+  frontend relay applies it to both React lifecycle consumers and refresh
+  readiness consumers so a missed earlier event cannot leave the tab behind the
+  serving gate.
+- Startup settings restore, saved-selection restore, and client initialization
+  use the same serialized selection-mutation boundary as runtime selection
+  changes. Each completed cluster client is published independently; one slow
+  sibling may not delay it. After a cluster enters `loading`, `loading_slow`, or
+  `ready`, a late `connecting`/`connected` result cannot move it back behind the
+  frontend serving gate.
 - When a cluster subsystem is replaced, queued or running manual work moves to
   its replacement queue. Succeeded, failed, and cancelled jobs remain terminal
   and are never re-enqueued.
@@ -163,5 +180,9 @@ For a freshness change, test the contract at the producer/consumer seam:
     domain, aborts in-flight work for only the activating cluster, preserves
     visible request intent, and never converts passive background work into
     queued demand.
+11. a temporarily unavailable open cluster stops refresh work without losing its
+    retained snapshot, including when every open cluster is unavailable;
+12. tab activation replays the backend's unchanged authoritative lifecycle state
+    to both frontend lifecycle consumer paths.
 
 Finish non-documentation changes with `mage qc:prerelease`.

--- a/docs/architecture/data-freshness.md
+++ b/docs/architecture/data-freshness.md
@@ -73,6 +73,14 @@ stream reconciliation path rather than creating a ManualQueue job.
   replacement subsystem. Preparation does not poll namespace snapshots, because
   scoped namespace builds can perform API probes. This is automatic preparation,
   never a manual refresh.
+- Sustained memory pressure is the only exception to that Cold-serving entry
+  rule. If preparation remains unsettled for one bounded snapshot-attempt grace
+  period, each still-over-budget pressure sample re-drives the transition and the
+  backend may force a full teardown of an inactive cluster. It first stops feeds
+  and spills every store currently available, while frontend leases keep their
+  last successful rows. The backend then serves no data for that cluster until a
+  foreground re-warm rebuilds its subsystem and catalog. It must not freeze or
+  present an unsettled store as settled Cold truth.
 
 ## Signals and source clocks
 
@@ -195,5 +203,8 @@ For a freshness change, test the contract at the producer/consumer seam:
     retained snapshot, including when every open cluster is unavailable;
 12. tab activation replays the backend's unchanged authoritative lifecycle state
     to both frontend lifecycle consumer paths.
+13. Cold preparation belongs to one subsystem generation, stops on replacement,
+    and under sustained memory pressure re-drives until either a settled mmap
+    transition or the bounded full-teardown fallback completes.
 
 Finish non-documentation changes with `mage qc:prerelease`.

--- a/docs/architecture/data-freshness.md
+++ b/docs/architecture/data-freshness.md
@@ -62,6 +62,17 @@ stream reconciliation path rather than creating a ManualQueue job.
   changes acquire/release only the changed clusters.
 - A lease expresses consumer demand. Do not use an open background workspace as
   demand for expensive producers that only feed visible data.
+- A governor Cold assignment is not applied until the backend has built a settled
+  `namespaces` snapshot and a `cluster-overview` snapshot for that exact cluster
+  scope. The namespace build runs through the aggregate lifecycle callback so
+  loading reaches Ready without a frontend request. Until both retained baselines
+  exist, the subsystem and its producers stay live; completion retries the tier
+  reconciliation. Cold preparation requires both that aggregate lifecycle state
+  and the current subsystem generation's namespace workload tracker to be ready;
+  this prevents a Ready state retained across re-warm from authorizing an unsynced
+  replacement subsystem. Preparation does not poll namespace snapshots, because
+  scoped namespace builds can perform API probes. This is automatic preparation,
+  never a manual refresh.
 
 ## Signals and source clocks
 

--- a/docs/architecture/data-layer.md
+++ b/docs/architecture/data-layer.md
@@ -117,7 +117,9 @@ the completed `v2` rewrite plan.
   columnar format, warm-paint on re-warm (cross-restart, format-version-guarded), and
   reconcile after sync. A Cold cluster can serve from read-only **mmap-aliased** stores
   (column data off-heap/OS-reclaimable, indexes resident) rather than full teardown;
-  re-warm unroutes then closes the mappings safely. Starting points:
+  re-warm unroutes then closes the mappings safely. Cold clusters do not run object-catalog
+  discovery, capability checks, or sync loops against their stopped feeds; the catalog
+  restarts as part of re-warm. Starting points:
   `domain/maintained_stores.go`, `querypage/columnstore_mmap.go`, `app_refresh_spill.go`.
 - **Re-warm keeps Ready.** Governor re-warms rebuild the subsystem through the same
   per-cluster chokepoint as first builds, but serving is continuous (cooled mmap stores
@@ -127,12 +129,25 @@ the completed `v2` rewrite plan.
   only that cluster's old-manager subscriptions so they re-establish against the
   replacement without reconnecting other clusters; continuity follows
   [the freshness contract](data-freshness.md#signals-and-source-clocks).
+- **Tier application is serialized.** Cooling and re-warming are multi-step subsystem
+  replacements. A newer visible-cluster intent may be recorded while one is running,
+  but its reconciliation waits until the in-flight transition has reached a consistent
+  Cold or live state. Foreground activation must never inspect or accept the interval
+  after feeds stop but before the subsystem is marked Cold. After reconciliation,
+  activation replays the cluster's current lifecycle state so a frontend that missed
+  an earlier transition converges even when the backend state did not change.
 - **Cluster-Ready is server-driven.** The loading→ready transition rides a namespaces
   snapshot build after the workload stores settle; the backend self-builds it on each
   pre-Ready namespaces doorbell (`runNamespacesReadinessSelfBuild` via the
   `Subsystem.NamespacesDoorbell` observer, wired per cluster in
   `buildRefreshSubsystemForSelection`). Readiness never depends on the frontend
   asking first.
+- **Client publication and lifecycle are ordered per cluster.** Startup settings and
+  saved-selection restore run through the runtime selection coordinator. A completed
+  client is installed inside its per-cluster operation before that operation publishes
+  `connected`, without waiting for sibling builds. Building the refresh subsystem then
+  advances the cluster to `loading`; stale client-build completions cannot demote
+  `loading`, `loading_slow`, or `ready` back to `connecting`/`connected`.
 
 ## Delivery — page + refetch-on-signal
 

--- a/docs/architecture/data-layer.md
+++ b/docs/architecture/data-layer.md
@@ -121,6 +121,16 @@ the completed `v2` rewrite plan.
   discovery, capability checks, or sync loops against their stopped feeds; the catalog
   restarts as part of re-warm. Starting points:
   `domain/maintained_stores.go`, `querypage/columnstore_mmap.go`, `app_refresh_spill.go`.
+- **Cold has a server-owned entry gate.** A desired Cold tier stays unapplied while
+  the live subsystem builds settled `namespaces` and `cluster-overview` snapshots
+  for its cluster scope. The namespace build uses the aggregate lifecycle callback,
+  so Ready and the retained sidebar/Global payloads exist before any producer stops.
+  Preparation waits on that lifecycle state and the current subsystem generation's
+  namespace workload tracker without polling namespace snapshots, retries the overview
+  from the backend, and does not wait for tab activation. This generation-local gate
+  prevents a retained Ready state from cooling a replacement subsystem before its own
+  stores settle. Only a successful preparation marks the subsystem eligible for
+  cooling; the governor records Cold after the executor reaches it.
 - **Re-warm keeps Ready.** Governor re-warms rebuild the subsystem through the same
   per-cluster chokepoint as first builds, but serving is continuous (cooled mmap stores
   serve until the aggregate re-routes; fresh stores warm-paint from spill) —

--- a/docs/architecture/data-layer.md
+++ b/docs/architecture/data-layer.md
@@ -130,10 +130,19 @@ the completed `v2` rewrite plan.
   from the backend, and does not wait for tab activation. This generation-local gate
   prevents a retained Ready state from cooling a replacement subsystem before its own
   stores settle. Only a successful preparation marks the subsystem eligible for
-  cooling; the governor records Cold after the executor reaches it.
+  cooling; the governor records Cold after the executor reaches it. Preparation is
+  owned by that subsystem generation: replacement or teardown cancels an in-flight
+  build, and the retry loop exits as soon as the generation is no longer current.
+  Under sustained HeapInuse pressure only, an unsettled preparation that exceeds one
+  bounded snapshot-attempt grace degrades to the normal full teardown path. Available
+  stores still spill, but the backend is unavailable for that cluster until re-warm;
+  it never serves an unsettled store as a Cold mmap baseline. Every over-budget sample
+  re-drives reconciliation so this fallback remains reachable after the pressure edge.
 - **Re-warm keeps Ready.** Governor re-warms rebuild the subsystem through the same
-  per-cluster chokepoint as first builds, but serving is continuous (cooled mmap stores
-  serve until the aggregate re-routes; fresh stores warm-paint from spill) —
+  per-cluster chokepoint as first builds. Normal mmap-cooled serving is continuous
+  (cooled stores serve until the aggregate re-routes; fresh stores warm-paint from spill);
+  after a pressure-forced full teardown, frontend-retained rows remain visible while the
+  backend rebuilds from spill —
   `transitionClusterToLoading` guards the chokepoint so an already-READY cluster is
   never demoted to loading on a tab switch. Aggregate stream routing then ends
   only that cluster's old-manager subscriptions so they re-establish against the
@@ -145,7 +154,11 @@ the completed `v2` rewrite plan.
   Cold or live state. Foreground activation must never inspect or accept the interval
   after feeds stop but before the subsystem is marked Cold. After reconciliation,
   activation replays the cluster's current lifecycle state so a frontend that missed
-  an earlier transition converges even when the backend state did not change.
+  an earlier transition converges even when the backend state did not change. The
+  governor publishes a separate planned tier before executor work begins, then records
+  the applied tier only after that work completes. Catalog gating reads the plan: it
+  closes before cooling stops feeds and opens before re-warm starts the catalog. A live
+  tier is reached only when both the subsystem and its cluster object catalog exist.
 - **Cluster-Ready is server-driven.** The loading→ready transition rides a namespaces
   snapshot build after the workload stores settle; the backend self-builds it on each
   pre-Ready namespaces doorbell (`runNamespacesReadinessSelfBuild` via the

--- a/docs/release/pending.md
+++ b/docs/release/pending.md
@@ -57,6 +57,9 @@
   retained snapshot when fresh backend data arrives.
 - Preserved namespace change subscriptions when a cooled cluster re-warms, so
   namespace creation and deletion continue appearing without fallback polling.
+- Restored Browse and discovery data when a cooled cluster re-warms, and kept
+  inactive clusters recoverable when sustained memory pressure forces a full
+  teardown before their retained backend snapshot can settle.
 - Stopped automatic navigation from creating manual-refresh jobs and prevented
   retained namespace timeout errors from reappearing on every tab switch.
 - Updated namespace utilization immediately when metrics collection fails,

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,1 +1,5 @@
-- Intermittent "awaiting metrics data", check the thresholds for that
+Feature ideas
+
+- Allow user to add a Label or Annotation as a custom column
+  - For example, add `topology.kubernetes.io/zone` to see which zones the nodes are in
+  - User can add label and optionally customize the column header

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,5 +1,6 @@
 Feature ideas
 
+- Import/export configs, favorites
 - Allow user to add a Label or Annotation as a custom column
   - For example, add `topology.kubernetes.io/zone` to see which zones the nodes are in
   - User can add label and optionally customize the column header

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,8 +27,8 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.5.4",
-        "@storybook/react": "^10.5.2",
-        "@storybook/react-vite": "^10.5.2",
+        "@storybook/react": "^10.5.3",
+        "@storybook/react-vite": "^10.5.3",
         "@types/node": "^26.1.1",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
@@ -36,7 +36,7 @@
         "@vitest/coverage-v8": "^4.1.10",
         "jsdom": "^29.1.1",
         "knip": "^6.27.0",
-        "storybook": "^10.5.2",
+        "storybook": "^10.5.3",
         "typescript": "^7.0.2",
         "vite": "^8.1.5",
         "vitest": "^4.1.10"
@@ -2670,13 +2670,13 @@
       "license": "MIT"
     },
     "node_modules/@storybook/builder-vite": {
-      "version": "10.5.2",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.5.2.tgz",
-      "integrity": "sha512-XxY/zpMrEOXqdJaEw8s7fJefDCjO1eRkjvZvb50ojiqDJpTdfguhBrwqlHilpWWt5a12VjbbMrUHza4YPs/bBg==",
+      "version": "10.5.3",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.5.3.tgz",
+      "integrity": "sha512-qX1jb1nbG1mWJrCn3YrDkpbii+KA1uxdVgENeNusD80RrWCwVG8ce+awjZxKuT8qjYyALSAPBvTHUqZ4C1b7Pg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/csf-plugin": "10.5.2",
+        "@storybook/csf-plugin": "10.5.3",
         "ts-dedent": "^2.0.0"
       },
       "funding": {
@@ -2684,14 +2684,14 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.5.2",
+        "storybook": "^10.5.3",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@storybook/csf-plugin": {
-      "version": "10.5.2",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.5.2.tgz",
-      "integrity": "sha512-PK/wXiALFf88mt4HmDtiZJ6NRvhExSXEM9uFIN+OIHxGqg7Xbp6MB0SPdhsTbMY9720ahiu/DJx5iIzkidcA3w==",
+      "version": "10.5.3",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.5.3.tgz",
+      "integrity": "sha512-mkPq6zru8fN5+46uC1cZEbKW2ws1hh9KvF4g4/Gu8pNbKnvqULPhk0/Bf0ZCtlr7zI7DvcFhyCy3dbvN+2n4Gw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2704,7 +2704,7 @@
       "peerDependencies": {
         "esbuild": "*",
         "rollup": "*",
-        "storybook": "^10.5.2",
+        "storybook": "^10.5.3",
         "vite": "*",
         "webpack": "*"
       },
@@ -2742,14 +2742,14 @@
       }
     },
     "node_modules/@storybook/react": {
-      "version": "10.5.2",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-10.5.2.tgz",
-      "integrity": "sha512-DQkTEvQ3Tn5ndyZnOyNTnYuJWBZdnUsVFuvImtt1H6QyHsZGhl35/3CqRwERa/P10Sw/6vLP5DS+KhDCz1hWbg==",
+      "version": "10.5.3",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-10.5.3.tgz",
+      "integrity": "sha512-d/CK78xgA7DDvqnxkqcYmiTjomE4ch2TWvk0O8/xHQWW6y0nMjKtsZbmUBfZ0QcdYdWq7dErzfbG7YAzxDi7Ig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
-        "@storybook/react-dom-shim": "10.5.2",
+        "@storybook/react-dom-shim": "10.5.3",
         "react-docgen": "^8.0.2",
         "react-docgen-typescript": "^2.2.2"
       },
@@ -2762,7 +2762,7 @@
         "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.5.2",
+        "storybook": "^10.5.3",
         "typescript": ">= 4.9.x"
       },
       "peerDependenciesMeta": {
@@ -2778,9 +2778,9 @@
       }
     },
     "node_modules/@storybook/react-dom-shim": {
-      "version": "10.5.2",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.5.2.tgz",
-      "integrity": "sha512-TbdYVLuD7gwj1CFsDJhCHUiwfVmzFWzalKEUGy9XgXyNpyOV1CYRsdmRdhaOHgmn2ljQZuTAxSnG7NlElghVaw==",
+      "version": "10.5.3",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.5.3.tgz",
+      "integrity": "sha512-eUWBsRRax5R3MDJVFs/CrFDF1bYS58AMB9tX02lLRuiZe6xy1cKh3CRFS+2xH571l0fNaXQ+7j69TOJ0fk2tmA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2792,7 +2792,7 @@
         "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.5.2"
+        "storybook": "^10.5.3"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -2804,16 +2804,16 @@
       }
     },
     "node_modules/@storybook/react-vite": {
-      "version": "10.5.2",
-      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-10.5.2.tgz",
-      "integrity": "sha512-YZoSLSMwU1dmxW8VkfJy6KzJELkbM2cHpa0mj7dih+p0JyWkWDEjLStrMB+sy9W7jF/fbojyzf0/oHlvVRUc3w==",
+      "version": "10.5.3",
+      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-10.5.3.tgz",
+      "integrity": "sha512-9cXaeU3+Kos4M3+Ezur2u/eBn3JIkED6ckxi7lhVQ6r2lK9NAGh5tfHSTQ/206KNSjvaHxZMAhPpxJP3/e2vfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@joshwooding/vite-plugin-react-docgen-typescript": "^0.7.0",
         "@rollup/pluginutils": "^5.0.2",
-        "@storybook/builder-vite": "10.5.2",
-        "@storybook/react": "10.5.2",
+        "@storybook/builder-vite": "10.5.3",
+        "@storybook/react": "10.5.3",
         "empathic": "^2.0.0",
         "magic-string": "^0.30.0",
         "react-docgen": "^8.0.2",
@@ -2827,7 +2827,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.5.2",
+        "storybook": "^10.5.3",
         "typescript": ">= 4.9.x",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       },
@@ -6262,9 +6262,9 @@
       "license": "MIT"
     },
     "node_modules/storybook": {
-      "version": "10.5.2",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.5.2.tgz",
-      "integrity": "sha512-zkYxVZoDMj8njzZc3EH5UyY7885wpi9a1mmWVwFiNHSo+i5r2Go84E2OI1cdOctRymLkNvgs1j5jqAKA0ftBqg==",
+      "version": "10.5.3",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.5.3.tgz",
+      "integrity": "sha512-c8Wumu5qz0N2fnzWBxcPzUsY+8BpKBKChNyl4BEh9qhMV6KW587gL8il8emRB+4Hay+zMjDHA7cIeTkl4FKYuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,8 +44,8 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.4",
-    "@storybook/react": "^10.5.2",
-    "@storybook/react-vite": "^10.5.2",
+    "@storybook/react": "^10.5.3",
+    "@storybook/react-vite": "^10.5.3",
     "@types/node": "^26.1.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
@@ -53,7 +53,7 @@
     "@vitest/coverage-v8": "^4.1.10",
     "jsdom": "^29.1.1",
     "knip": "^6.27.0",
-    "storybook": "^10.5.2",
+    "storybook": "^10.5.3",
     "typescript": "^7.0.2",
     "vite": "^8.1.5",
     "vitest": "^4.1.10"

--- a/frontend/src/modules/namespace/contexts/NamespaceContext.test.tsx
+++ b/frontend/src/modules/namespace/contexts/NamespaceContext.test.tsx
@@ -584,6 +584,45 @@ describe('NamespaceProvider selection behaviour', () => {
     cleanup();
   });
 
+  it('stops every temporarily unavailable open scope without clearing retained snapshots', () => {
+    const { rerender, cleanup } = renderWithProvider();
+    act(() => {
+      vi.runAllTimers();
+    });
+    mockRefreshOrchestrator.setScopedDomainEnabled.mockClear();
+    mockRefreshOrchestrator.fetchScopedDomain.mockClear();
+
+    mockClusterLifecycleStates = new Map([
+      ['cluster-a', 'connected'],
+      ['cluster-b', 'connected'],
+    ]);
+    rerender();
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(mockRefreshOrchestrator.setScopedDomainEnabled).toHaveBeenCalledWith(
+      'namespaces',
+      'cluster-a|',
+      false,
+      { preserveState: true }
+    );
+    expect(mockRefreshOrchestrator.setScopedDomainEnabled).toHaveBeenCalledWith(
+      'namespaces',
+      'cluster-b|',
+      false,
+      { preserveState: true }
+    );
+    expect(mockRefreshOrchestrator.fetchScopedDomain).not.toHaveBeenCalled();
+    expect(namespaceRef.current?.namespaces.map((item) => item.name)).toEqual([
+      ALL_NAMESPACES_DISPLAY_NAME,
+      'alpha',
+      'beta',
+    ]);
+
+    cleanup();
+  });
+
   it('keeps namespace selection scoped to the active cluster tab', () => {
     namespaceDomainRef.current = createNamespaceDomainMulti('ready', [
       {
@@ -700,6 +739,93 @@ describe('NamespaceProvider selection behaviour', () => {
       (call) => call[0] === 'namespaces' && call[2] === false
     );
     expect(disables).toEqual([]);
+
+    cleanup();
+  });
+
+  it('paints retained namespaces before a stale lifecycle gate allows refresh', () => {
+    namespaceDomainsByScopeRef.current = {
+      'cluster-a|': createNamespaceDomainWithCluster('ready', ['alpha'], 'cluster-a', 'alpha'),
+      'cluster-b|': createNamespaceDomainWithCluster('ready', ['gamma'], 'cluster-b', 'beta'),
+    };
+    mockClusterLifecycleStates = new Map([
+      ['cluster-a', 'loading'],
+      ['cluster-b', 'loading'],
+    ]);
+
+    const { rerender, cleanup } = renderWithProvider();
+    act(() => {
+      vi.runAllTimers();
+    });
+    mockRefreshOrchestrator.setScopedDomainEnabled.mockClear();
+    mockRefreshOrchestrator.fetchScopedDomain.mockClear();
+
+    // A late/stale lifecycle edge makes an open cluster temporarily ineligible
+    // for refresh. Its lease must stop without erasing its retained snapshot.
+    mockClusterLifecycleStates = new Map([
+      ['cluster-a', 'loading'],
+      ['cluster-b', 'connected'],
+    ]);
+    rerender();
+    act(() => {
+      vi.runAllTimers();
+    });
+    expect(mockRefreshOrchestrator.setScopedDomainEnabled).toHaveBeenCalledWith(
+      'namespaces',
+      'cluster-b|',
+      false,
+      { preserveState: true }
+    );
+    mockRefreshOrchestrator.setScopedDomainEnabled.mockClear();
+    mockRefreshOrchestrator.fetchScopedDomain.mockClear();
+
+    // The backend activation boundary has not converged yet, but retained data
+    // belongs to the selected cluster and must paint during this render.
+    mockClusterId = 'cluster-b';
+    rerender();
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(namespaceRef.current?.namespaces.map((item) => item.name)).toEqual([
+      ALL_NAMESPACES_DISPLAY_NAME,
+      'gamma',
+    ]);
+    expect(namespaceRef.current?.namespaceLoading).toBe(false);
+    expect(mockRefreshOrchestrator.setScopedDomainEnabled).not.toHaveBeenCalledWith(
+      'namespaces',
+      'cluster-b|',
+      true,
+      expect.anything()
+    );
+    expect(mockRefreshOrchestrator.fetchScopedDomain).not.toHaveBeenCalledWith(
+      'namespaces',
+      'cluster-b|',
+      expect.anything()
+    );
+
+    // Once lifecycle catches up, the same retained scope becomes eligible for
+    // its ordinary non-manual reconciliation.
+    mockClusterLifecycleStates = new Map([
+      ['cluster-a', 'loading'],
+      ['cluster-b', 'loading'],
+    ]);
+    rerender();
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(mockRefreshOrchestrator.setScopedDomainEnabled).toHaveBeenCalledWith(
+      'namespaces',
+      'cluster-b|',
+      true,
+      { preserveState: true }
+    );
+    expect(mockRefreshOrchestrator.fetchScopedDomain).toHaveBeenCalledWith(
+      'namespaces',
+      'cluster-b|',
+      { isManual: false, streamSignal: false }
+    );
 
     cleanup();
   });
@@ -934,6 +1060,11 @@ describe('NamespaceProvider selection behaviour', () => {
         (call) => call[1] === 'cluster-a|' && call[2] === false
       );
     expect(clusterADisablesAfterClose).toEqual([]);
+    expect(mockRefreshOrchestrator.setScopedDomainEnabled).toHaveBeenCalledWith(
+      'namespaces',
+      'cluster-b|',
+      false
+    );
     cleanup();
   });
 

--- a/frontend/src/modules/namespace/contexts/NamespaceContext.tsx
+++ b/frontend/src/modules/namespace/contexts/NamespaceContext.tsx
@@ -120,6 +120,21 @@ interface NamespaceProviderProps {
 export const isNamespaceRefreshAvailable = (state: ClusterLifecycleState | undefined): boolean =>
   state === 'loading' || state === 'loading_slow' || state === 'ready';
 
+const buildNamespaceScopes = (clusterIds: string[]): string[] => {
+  const seen = new Set<string>();
+  const scopes: string[] = [];
+  clusterIds.forEach((rawClusterId) => {
+    const clusterId = rawClusterId.trim();
+    const scope = clusterId ? buildClusterScope(clusterId, '') : '';
+    if (!scope || seen.has(scope)) {
+      return;
+    }
+    seen.add(scope);
+    scopes.push(scope);
+  });
+  return scopes;
+};
+
 export const NamespaceProvider: React.FC<NamespaceProviderProps> = ({ children }) => {
   const { selectedKubeconfig, selectedClusterId, selectedClusterIds } = useKubeconfig();
   const { getClusterState } = useClusterLifecycle();
@@ -141,22 +156,18 @@ export const NamespaceProvider: React.FC<NamespaceProviderProps> = ({ children }
   // Namespace refresh state is per cluster. Cross-cluster namespace views should
   // derive from per-cluster scoped entries rather than one aggregate domain.
   const namespacesScope = useMemo(
-    () => (activeClusterRefreshAvailable ? buildClusterScope(activeClusterId, '') : ''),
-    [activeClusterId, activeClusterRefreshAvailable]
+    () => (activeClusterId ? buildClusterScope(activeClusterId, '') : ''),
+    [activeClusterId]
   );
-  const namespaceScopes = useMemo(() => {
-    const seen = new Set<string>();
-    const scopes: string[] = [];
-    refreshAvailableClusterIds.forEach((clusterId) => {
-      const scope = buildClusterScope(clusterId, '');
-      if (!scope || seen.has(scope)) {
-        return;
-      }
-      seen.add(scope);
-      scopes.push(scope);
-    });
-    return scopes;
-  }, [refreshAvailableClusterIds]);
+  const namespacesRefreshScope = activeClusterRefreshAvailable ? namespacesScope : '';
+  const retainedNamespaceScopes = useMemo(
+    () => buildNamespaceScopes(selectedClusterIds),
+    [selectedClusterIds]
+  );
+  const namespaceScopes = useMemo(
+    () => buildNamespaceScopes(refreshAvailableClusterIds),
+    [refreshAvailableClusterIds]
+  );
 
   const namespaceDomain = useRefreshScopedDomain('namespaces', namespacesScope);
   const namespaceMetricsDomain = useRefreshScopedDomain('namespace-metrics', namespacesScope);
@@ -164,12 +175,12 @@ export const NamespaceProvider: React.FC<NamespaceProviderProps> = ({ children }
   // Doorbell refetch: the namespaces stream signal only bumps the scoped
   // sourceVersion — the snapshot itself must be refetched. The shared hook
   // covers every leased cluster scope so background cluster tabs stay fresh.
-  const namespaceSignalScopes = useMemo(
-    () => (namespaceScopes.length > 0 ? namespaceScopes : namespacesScope ? [namespacesScope] : []),
-    [namespaceScopes, namespacesScope]
-  );
+  const namespaceSignalScopes = namespaceScopes;
   useStreamSignalRefetch('namespaces', namespaceSignalScopes);
-  useStreamSignalRefetch('namespace-metrics', namespacesScope ? [namespacesScope] : []);
+  useStreamSignalRefetch(
+    'namespace-metrics',
+    namespacesRefreshScope ? [namespacesRefreshScope] : []
+  );
   const { suppressPassiveLoading } = useAutoRefreshLoadingState();
   // Track namespace selection per cluster tab to avoid cross-tab selection bleed.
   const [namespaceSelections, setNamespaceSelections] = useState<
@@ -183,7 +194,7 @@ export const NamespaceProvider: React.FC<NamespaceProviderProps> = ({ children }
   const namespaceScopesRef = useRef<string[]>([]);
   const lastEvaluatedNamespaceRef = useRef<string | null>(null);
   const requestedNamespaceScopesRef = useRef<Set<string>>(new Set());
-  const previousForegroundNamespacesScopeRef = useRef(namespacesScope);
+  const previousForegroundNamespacesScopeRef = useRef(namespacesRefreshScope);
   const namespaceMetricsScopeRef = useRef('');
 
   // Keep a ref to the latest namespace selections map for stable callback access.
@@ -228,19 +239,14 @@ export const NamespaceProvider: React.FC<NamespaceProviderProps> = ({ children }
   }, []);
 
   const scopedNamespaces = useMemo(() => {
-    if (!namespaceDomain.data || !activeClusterId || !activeClusterRefreshAvailable) {
+    if (!namespaceDomain.data || !activeClusterId) {
       return [];
     }
     const objectRows = (namespaceDomain.data.namespaces ?? []).filter(
       (ns) => ns.clusterId === activeClusterId
     );
     return joinNamespaceMetrics(objectRows, namespaceMetricsDomain.data?.namespaces);
-  }, [
-    activeClusterId,
-    activeClusterRefreshAvailable,
-    namespaceDomain.data,
-    namespaceMetricsDomain.data?.namespaces,
-  ]);
+  }, [activeClusterId, namespaceDomain.data, namespaceMetricsDomain.data?.namespaces]);
 
   useEffect(() => {
     if (!namespaceDomain.data) {
@@ -250,7 +256,7 @@ export const NamespaceProvider: React.FC<NamespaceProviderProps> = ({ children }
       return;
     }
 
-    if (!activeClusterId || !activeClusterRefreshAvailable) {
+    if (!activeClusterId) {
       updateNamespaces([]);
       return;
     }
@@ -327,7 +333,6 @@ export const NamespaceProvider: React.FC<NamespaceProviderProps> = ({ children }
     updateNamespaces([allNamespaceItem, ...mappedNamespaces]);
   }, [
     activeClusterId,
-    activeClusterRefreshAvailable,
     allNamespaceItem,
     namespaceDomain.status,
     namespaceDomain.data,
@@ -351,8 +356,7 @@ export const NamespaceProvider: React.FC<NamespaceProviderProps> = ({ children }
 
   const loadNamespaces = useCallback(
     async (_showSpinner: boolean = true) => {
-      const scopes =
-        namespaceScopes.length > 0 ? namespaceScopes : namespacesScope ? [namespacesScope] : [];
+      const scopes = namespaceScopes;
       if (scopes.length === 0) {
         return;
       }
@@ -366,7 +370,7 @@ export const NamespaceProvider: React.FC<NamespaceProviderProps> = ({ children }
         )
       );
     },
-    [namespaceScopes, namespacesScope]
+    [namespaceScopes]
   );
 
   const refreshNamespaces = useCallback(async () => {
@@ -409,19 +413,6 @@ export const NamespaceProvider: React.FC<NamespaceProviderProps> = ({ children }
   useEffect(() => {
     const enabled = Boolean(selectedKubeconfig);
 
-    // Skip scoped calls when no clusters are connected (scope is empty).
-    if (namespaceScopes.length === 0) {
-      if (!enabled) {
-        clearSelection();
-        refreshOrchestrator.resetDomain('namespaces');
-        updateNamespaces([]);
-        lastEvaluatedNamespaceRef.current = null;
-        lastErrorByScopeRef.current.clear();
-        requestedNamespaceScopesRef.current.clear();
-      }
-      return;
-    }
-
     // Diff-based reconciliation — NEVER a blanket disable/re-enable. This
     // effect re-runs whenever the scope-set identity changes (any tab
     // open/close, any cluster lifecycle event), and a disable->enable cycle on
@@ -429,9 +420,15 @@ export const NamespaceProvider: React.FC<NamespaceProviderProps> = ({ children }
     // (spinner) and its Diagnostics row churned whenever ANY OTHER cluster's
     // tab or lifecycle moved. One cluster's state must never disturb another's.
     const activeScopeSet = new Set(namespaceScopes);
+    const retainedScopeSet = new Set(retainedNamespaceScopes);
     requestedNamespaceScopesRef.current.forEach((scope) => {
       if (!activeScopeSet.has(scope)) {
-        setRefreshDomainEnabled({ domain: 'namespaces', scope, enabled: false });
+        setRefreshDomainEnabled({
+          domain: 'namespaces',
+          scope,
+          enabled: false,
+          preserveState: retainedScopeSet.has(scope),
+        });
         lastErrorByScopeRef.current.delete(scope);
         requestedNamespaceScopesRef.current.delete(scope);
       }
@@ -466,12 +463,18 @@ export const NamespaceProvider: React.FC<NamespaceProviderProps> = ({ children }
         reason: 'startup',
       });
     });
-  }, [clearSelection, namespaceScopes, selectedKubeconfig, updateNamespaces]);
+  }, [
+    clearSelection,
+    namespaceScopes,
+    retainedNamespaceScopes,
+    selectedKubeconfig,
+    updateNamespaces,
+  ]);
 
   useEffect(() => {
     const previousScope = previousForegroundNamespacesScopeRef.current;
-    previousForegroundNamespacesScopeRef.current = namespacesScope;
-    if (!previousScope || !namespacesScope || previousScope === namespacesScope) {
+    previousForegroundNamespacesScopeRef.current = namespacesRefreshScope;
+    if (!previousScope || !namespacesRefreshScope || previousScope === namespacesRefreshScope) {
       return;
     }
 
@@ -480,14 +483,14 @@ export const NamespaceProvider: React.FC<NamespaceProviderProps> = ({ children }
     // newly visible cluster instead of fanning out across every open tab.
     void requestRefreshDomain({
       domain: 'namespaces',
-      scope: namespacesScope,
+      scope: namespacesRefreshScope,
       reason: 'foreground',
     });
-  }, [namespacesScope]);
+  }, [namespacesRefreshScope]);
 
   useEffect(() => {
     const previousScope = namespaceMetricsScopeRef.current;
-    if (previousScope && previousScope !== namespacesScope) {
+    if (previousScope && previousScope !== namespacesRefreshScope) {
       setRefreshDomainEnabled({
         domain: 'namespace-metrics',
         scope: previousScope,
@@ -496,23 +499,23 @@ export const NamespaceProvider: React.FC<NamespaceProviderProps> = ({ children }
       });
     }
 
-    namespaceMetricsScopeRef.current = namespacesScope;
-    if (!namespacesScope) {
+    namespaceMetricsScopeRef.current = namespacesRefreshScope;
+    if (!namespacesRefreshScope) {
       return;
     }
 
     setRefreshDomainEnabled({
       domain: 'namespace-metrics',
-      scope: namespacesScope,
+      scope: namespacesRefreshScope,
       enabled: true,
       preserveState: true,
     });
     void requestRefreshDomain({
       domain: 'namespace-metrics',
-      scope: namespacesScope,
+      scope: namespacesRefreshScope,
       reason: previousScope ? 'foreground' : 'startup',
     });
-  }, [namespacesScope]);
+  }, [namespacesRefreshScope]);
 
   // Unmount-only teardown: release whatever scopes are currently held. Kept
   // separate from the reconciliation effect above so re-runs never release


### PR DESCRIPTION
### Summary

- Publish each cluster client as soon as it connects and prevent late client lifecycle events from moving an already-loading or ready cluster backward.
- Restore retained-first namespace rendering: switching tabs immediately displays that cluster’s cached namespaces, then requests an ordinary foreground refresh when the backend is ready.
- Keep namespace object subscriptions active for eligible background clusters without activating background metrics collection, and preserve retained state when a cluster temporarily becomes unavailable.
- Serialize governor cooling and re-warming so tab activation cannot encounter a half-transitioned refresh subsystem.
- Keep background producers running while namespace and overview data settle, bind Cold preparation to the current subsystem generation, and cancel obsolete preparation work when that subsystem is replaced.
- Under sustained memory pressure, fall back after a bounded grace to spilling available data and fully tearing down an inactive cluster that cannot settle, rather than keeping its producers alive indefinitely.
- Avoid polling namespace snapshots during Cold preparation, preventing repeated scoped namespace API probes; preparation builds only the cluster overview after namespace readiness is established.
- Gate object-catalog work on the governor’s planned tier: prevent Cold clusters from starting discovery and capability work against stopped informer feeds, open the gate before re-warm, and require the catalog to exist before a cluster is considered live.
- Replay the backend’s authoritative lifecycle state when a cluster becomes active so missed events cannot leave the frontend stuck behind a stale loading gate.

### User impact

Cluster data can finish loading in the background, switching tabs immediately shows retained data, namespace changes remain live across open clusters, and foreground activation refreshes the displayed data without manual-refresh jobs or avoidable Kubernetes API traffic. Under normal conditions, the governor keeps a cluster live until the data needed by Global and sidebar surfaces has settled. Under sustained memory pressure, it can reclaim a stuck inactive cluster after a bounded grace while preserving retained frontend data and spilling available backend data for re-warm.