### PR TITLE
Browse column sort

### DIFF
--- a/backend/objectcatalog/query.go
+++ b/backend/objectcatalog/query.go
@@ -65,7 +65,7 @@ func normalizeCatalogQuerySortField(field string) string {
 	switch strings.ToLower(strings.TrimSpace(field)) {
 	case "", catalogQueryDefaultSort:
 		return catalogQueryDefaultSort
-	case "kind", "namespace", "name", "age", "creationtimestamp", "creation-timestamp":
+	case "kind", "namespace", "name", "api", "age", "creationtimestamp", "creation-timestamp":
 		return strings.ToLower(strings.TrimSpace(field))
 	default:
 		return catalogQueryDefaultSort

--- a/backend/objectcatalog/query_engine.go
+++ b/backend/objectcatalog/query_engine.go
@@ -27,6 +27,7 @@ const (
 	catalogEngineSortKind              = "kind"
 	catalogEngineSortNamespace         = "namespace"
 	catalogEngineSortName              = "name"
+	catalogEngineSortAPI               = "api"
 	catalogEngineSortAge               = "age"
 	catalogEngineSortCreationTimestamp = "creationtimestamp"
 )
@@ -79,6 +80,7 @@ func newCatalogQueryStoreSchema() querypage.Schema[Summary] {
 			catalogEngineSortKind:      func(s Summary) string { return s.Ref.Kind },
 			catalogEngineSortNamespace: func(s Summary) string { return s.Ref.Namespace },
 			catalogEngineSortName:      func(s Summary) string { return s.Ref.Name },
+			catalogEngineSortAPI:       catalogEngineAPIDisplay,
 			// Both "age" and "creationtimestamp" sort newest-first when ascending: the
 			// catalog flips BOTH age AND creationtimestamp, so "asc" means newest first.
 			// Encoding the creation
@@ -138,6 +140,14 @@ func catalogEngineKindIdentity(s Summary) string {
 	return key.group + catalogEngineFieldSep + key.version + catalogEngineFieldSep + key.kind
 }
 
+func catalogEngineAPIDisplay(s Summary) string {
+	group := s.Ref.Group
+	if group == "" {
+		group = "core"
+	}
+	return group + "/" + s.Ref.Version
+}
+
 // catalogSummaryIsCustom reports whether a summary is a non-built-in (discovered/CRD)
 // kind, reusing the catalog's builtin identity set.
 func catalogSummaryIsCustom(s Summary) bool {
@@ -185,7 +195,7 @@ func catalogEngineInvertTimestamp(ts string) string {
 // the default and unknown fields fall back to the identity composite.
 func catalogEngineSortKey(field string) string {
 	switch field {
-	case catalogEngineSortKind, catalogEngineSortNamespace, catalogEngineSortName, catalogEngineSortAge:
+	case catalogEngineSortKind, catalogEngineSortNamespace, catalogEngineSortName, catalogEngineSortAPI, catalogEngineSortAge:
 		return field
 	case "creationtimestamp", "creation-timestamp":
 		return catalogEngineSortCreationTimestamp

--- a/backend/objectcatalog/query_engine_pagination_test.go
+++ b/backend/objectcatalog/query_engine_pagination_test.go
@@ -122,6 +122,7 @@ func TestCatalogQueryPaginationComplete(t *testing.T) {
 		{"kind", "asc"}, {"kind", "desc"},
 		{"namespace", "asc"}, {"namespace", "desc"},
 		{"name", "asc"}, {"name", "desc"},
+		{"api", "asc"}, {"api", "desc"},
 		{"age", "asc"}, {"age", "desc"},
 		{"creationtimestamp", "asc"}, {"creationtimestamp", "desc"},
 	}

--- a/backend/objectcatalog/query_oracle_test.go
+++ b/backend/objectcatalog/query_oracle_test.go
@@ -105,7 +105,6 @@ func generateOracleObjects(rng *rand.Rand, n int) []Summary {
 		name := fmt.Sprintf("%s-%s-%d", oracleNameStems[rng.Intn(len(oracleNameStems))], oracleNameStems[rng.Intn(len(oracleNameStems))], i)
 
 		created := oracleTimestamps[rng.Intn(len(oracleTimestamps))]
-
 		items = append(items, Summary{Ref: resourcemodel.ResourceRef{ClusterID: "cluster-a", Group: gvk.group, Version: gvk.version, Kind: gvk.kind, Resource: gvk.resource, Namespace: namespace, Name: name, UID: fmt.Sprintf("obj-%d", i)}, CreationTimestamp: created,
 			Scope: gvk.scope,
 		})
@@ -123,6 +122,8 @@ func oracleEncodedSortValue(s Summary, sortKey string) string {
 		return s.Ref.Namespace
 	case catalogEngineSortName:
 		return s.Ref.Name
+	case catalogEngineSortAPI:
+		return catalogEngineAPIDisplay(s)
 	case catalogEngineSortAge, catalogEngineSortCreationTimestamp:
 		return catalogEngineInvertTimestamp(s.CreationTimestamp)
 	default:
@@ -260,6 +261,7 @@ func TestCatalogQueryMatchesBruteForceOracle(t *testing.T) {
 		{"kind", "asc"}, {"kind", "desc"},
 		{"namespace", "asc"}, {"namespace", "desc"},
 		{"name", "asc"}, {"name", "desc"},
+		{"api", "asc"}, {"api", "desc"},
 		{"age", "asc"}, {"age", "desc"},
 		{"creationtimestamp", "asc"}, {"creationtimestamp", "desc"},
 	}

--- a/backend/objectcatalog/query_test.go
+++ b/backend/objectcatalog/query_test.go
@@ -637,6 +637,27 @@ func TestQueryBackendSortsByRequestedFieldAndDirection(t *testing.T) {
 	}
 }
 
+func TestQueryBackendSortsByBrowseAPIColumn(t *testing.T) {
+	svc := newEquivalenceService(t, []Summary{
+		{Ref: resourcemodel.ResourceRef{Group: "", Version: "v1", Kind: "ConfigMap", Resource: "configmaps", Namespace: "default", Name: "core", UID: "uid-core"}, Scope: ScopeNamespace},
+		{Ref: resourcemodel.ResourceRef{Group: "apps", Version: "v1", Kind: "StatefulSet", Resource: "statefulsets", Namespace: "default", Name: "apps", UID: "uid-apps"}, Scope: ScopeNamespace},
+		{Ref: resourcemodel.ResourceRef{Group: "example.com", Version: "v1beta1", Kind: "Gadget", Resource: "gadgets", Namespace: "default", Name: "custom", UID: "uid-custom"}, Scope: ScopeNamespace},
+	})
+
+	result := svc.Query(QueryOptions{Limit: 3, SortField: "api", SortDirection: "asc"})
+	got := []string{result.Items[0].Ref.Name, result.Items[1].Ref.Name, result.Items[2].Ref.Name}
+	want := []string{"apps", "core", "custom"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("API sort order = %v, want %v", got, want)
+	}
+}
+
+func TestCatalogQueryRejectsRemovedBrowseStatusSort(t *testing.T) {
+	if got := normalizeCatalogQuerySortField("status"); got != catalogQueryDefaultSort {
+		t.Fatalf("normalized Status sort field = %q, want default %q", got, catalogQueryDefaultSort)
+	}
+}
+
 func TestQueryCachedAndUncachedPathsUseSameOrdering(t *testing.T) {
 	svc := NewService(Dependencies{Common: common.Dependencies{}, ClusterID: "cluster-a"}, nil)
 	podDesc := resourceDescriptor{

--- a/backend/refresh/snapshot/catalog.go
+++ b/backend/refresh/snapshot/catalog.go
@@ -168,7 +168,7 @@ func (b *catalogBuilder) Build(ctx context.Context, scope string) (*refresh.Snap
 // describe only the query surface: sort/filter/search fields.
 func newCatalogCapabilities() ResourceQueryCapabilities {
 	return ResourceQueryCapabilities{
-		SortableFields:   []string{"name", "kind", "namespace", "age", "creationTimestamp"},
+		SortableFields:   []string{"name", "kind", "api", "namespace", "age", "creationTimestamp"},
 		FilterableFields: []string{"kinds", "namespaces", "apiGroups", "resourceScopes"},
 		SearchableFields: []string{"name", "kind", "namespace"},
 	}

--- a/backend/refresh/snapshot/resource_query_contract_test.go
+++ b/backend/refresh/snapshot/resource_query_contract_test.go
@@ -3,6 +3,7 @@ package snapshot
 import (
 	"encoding/json"
 	"net/url"
+	"slices"
 	"testing"
 )
 
@@ -198,6 +199,12 @@ func TestCatalogProviderPublishesQueryCapabilities(t *testing.T) {
 	caps := newCatalogCapabilities()
 	if len(caps.SortableFields) == 0 {
 		t.Error("catalog provider must publish sortable fields")
+	}
+	if !slices.Contains(caps.SortableFields, "api") {
+		t.Errorf("catalog provider sortable fields = %v, want API column", caps.SortableFields)
+	}
+	if slices.Contains(caps.SortableFields, "status") {
+		t.Errorf("catalog provider sortable fields = %v, do not want removed Status column", caps.SortableFields)
 	}
 	if len(caps.SearchableFields) == 0 {
 		t.Error("catalog provider must publish searchable fields")

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.7/schema.json",
   "formatter": {
     "enabled": true,
     "includes": [

--- a/docs/release/pending.md
+++ b/docs/release/pending.md
@@ -6,3 +6,4 @@
 ### Fixed
 
 - `API` column is now sortable in Browse views.
+- Favorites was not restoring filter text data in some cases.

--- a/docs/release/pending.md
+++ b/docs/release/pending.md
@@ -1,4 +1,8 @@
-### Added
+### Changed
 
-- Settings and favorites export/import controls under Settings -> Data Management.
-- Default-on Sentry error reporting for packaged builds, with privacy-filtered errors, useful stack traces, app-owned correlated breadcrumbs, aliased infrastructure context, pseudonymous installation/session counting, and frontend release health. You can turn it off under Settings -> Data Management -> Telemetry.
+- Removed unused `Status` column from Browse views.
+- Updated error reporting to be more actionable while maintaining privacy guarantees.
+
+### Fixed
+
+- `API` column is now sortable in Browse views.

--- a/frontend/biome.jsonc
+++ b/frontend/biome.jsonc
@@ -3,7 +3,7 @@
   // project stricter where additional rules describe this React application.
   // Keep the schema version aligned with the installed @biomejs/biome version so editors validate
   // exactly the options accepted by CI.
-  "$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.7/schema.json",
   // Resolve ignore rules from the repository-level Git configuration, not only the frontend folder.
   "vcs": {
     "enabled": true,

--- a/frontend/src/modules/browse/components/BrowseView.test.tsx
+++ b/frontend/src/modules/browse/components/BrowseView.test.tsx
@@ -436,10 +436,10 @@ describe('BrowseView', () => {
         await Promise.resolve();
       });
 
-      expect(sortableKeys()).toEqual(['age', 'kind', 'name']);
+      expect(sortableKeys()).toEqual(['age', 'api', 'kind', 'name']);
     });
 
-    it('shows API identity and available status alongside object identity', async () => {
+    it('shows API identity without presenting action state as a Status column', async () => {
       const deployment = catalogItem({
         ref: {
           kind: 'Deployment',
@@ -464,16 +464,21 @@ describe('BrowseView', () => {
       });
 
       expect(gridTablePropsRef.current.data[0]).toEqual(
-        expect.objectContaining({ apiDisplay: 'apps/v1', statusDisplay: 'Available' })
+        expect.objectContaining({ apiDisplay: 'apps/v1', actionFacts: { status: 'Available' } })
       );
       expect(gridTablePropsRef.current.columns.map((column) => column.key)).toEqual([
         'kind',
         'name',
         'api',
-        'status',
         'age',
       ]);
-      expect(sortableKeys()).toEqual(['age', 'kind', 'name']);
+      expect(gridTablePropsRef.current.columns.find((column) => column.key === 'api')).toEqual(
+        expect.objectContaining({ sortable: true })
+      );
+      expect(
+        gridTablePropsRef.current.columns.find((column) => column.key === 'status')
+      ).toBeUndefined();
+      expect(sortableKeys()).toEqual(['age', 'api', 'kind', 'name']);
     });
 
     it('renders Age from creationTimestamp and updates without catalog row replacement', async () => {
@@ -619,6 +624,17 @@ describe('BrowseView', () => {
       expect(hasNamespaceColumn).toBe(false);
     });
 
+    it('omits the Status column for namespace scope', async () => {
+      await act(async () => {
+        root.render(<BrowseView namespace="default" />);
+        await Promise.resolve();
+      });
+
+      expect(gridTablePropsRef.current.columns.some((column) => column.key === 'status')).toBe(
+        false
+      );
+    });
+
     it('disables namespace filtering for namespace scope', async () => {
       await act(async () => {
         root.render(<BrowseView namespace="default" />);
@@ -710,6 +726,7 @@ describe('BrowseView', () => {
       const columns = gridTablePropsRef.current?.columns ?? [];
       const hasNamespaceColumn = columns.some((column) => column.key === 'namespace');
       expect(hasNamespaceColumn).toBe(true);
+      expect(columns.some((column) => column.key === 'status')).toBe(false);
     });
 
     it('publishes only catalog-backed sortable keys for all-namespaces scope', async () => {
@@ -718,7 +735,7 @@ describe('BrowseView', () => {
         await Promise.resolve();
       });
 
-      expect(sortableKeys()).toEqual(['age', 'kind', 'name', 'namespace']);
+      expect(sortableKeys()).toEqual(['age', 'api', 'kind', 'name', 'namespace']);
     });
 
     it('enables namespace filtering for all-namespaces scope', async () => {

--- a/frontend/src/modules/browse/hooks/useBrowseColumns.test.tsx
+++ b/frontend/src/modules/browse/hooks/useBrowseColumns.test.tsx
@@ -1,0 +1,127 @@
+import type React from 'react';
+import { act } from 'react';
+import * as ReactDOM from 'react-dom/client';
+import { describe, expect, it, vi } from 'vitest';
+import type { CatalogItem } from '@/core/refresh/types';
+import { makeResourceRef } from '@/test-utils/makeResourceRef';
+import { requireReactElement } from '@/test-utils/requireReactElement';
+import { toTableRows, useBrowseColumns } from './useBrowseColumns';
+
+const navigateToView = vi.hoisted(() => vi.fn());
+
+vi.mock('@shared/hooks/useNavigateToView', () => ({
+  useNavigateToView: () => ({ navigateToView }),
+}));
+
+const renderHook = <T,>(hook: () => T) => {
+  const result: { current: T | undefined } = { current: undefined };
+
+  const TestComponent: React.FC = () => {
+    result.current = hook();
+    return null;
+  };
+
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = ReactDOM.createRoot(container);
+
+  act(() => {
+    root.render(<TestComponent />);
+  });
+
+  return {
+    get() {
+      if (result.current === undefined) {
+        throw new Error('Hook result not set');
+      }
+      return result.current;
+    },
+    cleanup() {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+};
+
+const catalogItem = (namespace: string): CatalogItem => ({
+  ref: makeResourceRef({
+    clusterId: 'cluster-a',
+    group: 'batch',
+    version: 'v1',
+    kind: 'CronJob',
+    resource: 'cronjobs',
+    namespace,
+    name: 'nightly',
+  }),
+  resourceVersion: '7',
+  creationTimestamp: '2026-08-04T12:00:00Z',
+  scope: 'Namespace',
+  actionFacts: { status: 'Suspended' },
+});
+
+describe('useBrowseColumns', () => {
+  it('preserves action facts without projecting a display-only Status field', () => {
+    const [row] = toTableRows([catalogItem('team-a')], false);
+
+    expect(row).toEqual(
+      expect.objectContaining({
+        apiDisplay: 'batch/v1',
+        namespaceDisplay: 'team-a',
+        ageTimestamp: Date.parse('2026-08-04T12:00:00Z'),
+        actionFacts: { status: 'Suspended' },
+      })
+    );
+    expect(row).not.toHaveProperty('statusDisplay');
+  });
+
+  it('omits Status from namespace and cross-namespace column sets', () => {
+    const onRowClick = vi.fn();
+    const onNamespaceClick = vi.fn();
+    const namespaceHook = renderHook(() =>
+      useBrowseColumns({ showNamespaceColumn: false, onRowClick, onNamespaceClick })
+    );
+    const namespaceColumns = namespaceHook.get();
+    expect(namespaceColumns.map((column) => column.key)).toEqual(['kind', 'name', 'api', 'age']);
+
+    const crossNamespaceHook = renderHook(() =>
+      useBrowseColumns({ showNamespaceColumn: true, onRowClick, onNamespaceClick })
+    );
+    const crossNamespaceColumns = crossNamespaceHook.get();
+    expect(crossNamespaceColumns.map((column) => column.key)).toEqual([
+      'kind',
+      'name',
+      'api',
+      'namespace',
+      'age',
+    ]);
+
+    const [row] = toTableRows([catalogItem('team-a')], false);
+    for (const column of crossNamespaceColumns) {
+      column.render(row);
+      column.sortValue?.(row);
+    }
+
+    const namespaceColumn = crossNamespaceColumns.find((column) => column.key === 'namespace');
+    const namespaceCell = requireReactElement<{
+      onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+    }>(namespaceColumn?.render(row), 'expected interactive namespace cell');
+    namespaceCell.props.onClick?.({ altKey: false } as React.MouseEvent<HTMLButtonElement>);
+    expect(onNamespaceClick).toHaveBeenCalledWith('team-a', 'cluster-a');
+
+    const nameColumn = crossNamespaceColumns.find((column) => column.key === 'name');
+    const nameCell = requireReactElement<{
+      onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+    }>(nameColumn?.render(row), 'expected interactive name cell');
+    nameCell.props.onClick?.({
+      altKey: true,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    } as unknown as React.MouseEvent<HTMLButtonElement>);
+    expect(navigateToView).toHaveBeenCalledWith(expect.objectContaining({ name: 'nightly' }));
+
+    namespaceHook.cleanup();
+    crossNamespaceHook.cleanup();
+  });
+});

--- a/frontend/src/modules/browse/hooks/useBrowseColumns.tsx
+++ b/frontend/src/modules/browse/hooks/useBrowseColumns.tsx
@@ -27,7 +27,6 @@ export type BrowseTableRow = {
   kindDisplay: string;
   namespaceDisplay: string;
   apiDisplay: string;
-  statusDisplay: string;
   age: string;
   ageTimestamp: number;
 };
@@ -51,7 +50,6 @@ export const toTableRows = (
       kindDisplay: kindLabel,
       namespaceDisplay,
       apiDisplay: `${item.ref.group || 'core'}/${item.ref.version}`,
-      statusDisplay: item.actionFacts?.status?.trim() || '—',
       age: '—',
       ageTimestamp: created ? created.getTime() : 0,
     };
@@ -100,10 +98,7 @@ export function useBrowseColumns({
         getClassName: () => 'object-panel-link',
       }),
       cf.createTextColumn<BrowseTableRow>('api', 'API', (row) => row.apiDisplay, {
-        sortable: false,
-      }),
-      cf.createTextColumn<BrowseTableRow>('status', 'Status', (row) => row.statusDisplay, {
-        sortable: false,
+        sortable: true,
       }),
     ];
 
@@ -134,7 +129,6 @@ export function useBrowseColumns({
       kind: { width: 160, autoWidth: false },
       name: { width: 320, autoWidth: false },
       api: { width: 180, autoWidth: false },
-      status: { width: 140, autoWidth: false },
       ...(showNamespaceColumn ? { namespace: { width: 220, autoWidth: false } } : {}),
       age: { width: 120, autoWidth: false },
     };

--- a/frontend/src/modules/resource-grid/useResourceGridTable.tsx
+++ b/frontend/src/modules/resource-grid/useResourceGridTable.tsx
@@ -423,14 +423,12 @@ function useResourceGridTableCommon<T extends ResourceGridTableRow>({
   );
   const { item: favToggle, modal: favModal } = useFavToggle({
     filters: persistence.filters,
-    includeMetadata: useMetadata ? metadata.includeMetadata : undefined,
     sortColumn: sortConfig?.key ?? null,
     sortDirection: sortConfig?.direction ?? 'asc',
     columnVisibility: persistence.columnVisibility ?? {},
     setFilters: persistence.setFilters,
     setSortConfig: persistence.setSortConfig,
     setColumnVisibility: persistence.setColumnVisibility,
-    setIncludeMetadata: useMetadata ? metadata.setIncludeMetadata : undefined,
     hydrated: persistence.hydrated,
     availableKinds,
     availableFilterNamespaces: showNamespaceFilters ? availableFilterNamespaces : undefined,

--- a/frontend/src/ui/favorites/FavToggle.test.tsx
+++ b/frontend/src/ui/favorites/FavToggle.test.tsx
@@ -6,10 +6,11 @@
  */
 
 import type React from 'react';
-import { act } from 'react';
+import { act, useState } from 'react';
 import * as ReactDOM from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Favorite } from '@/core/persistence/favorites';
+import type { GridTableFilterState } from '@/shared/components/tables/GridTable.types';
 import { requireValue } from '@/test-utils/requireValue';
 import type { FavSaveModalProps } from './FavSaveModal';
 
@@ -271,6 +272,27 @@ const GroupedWrapper: React.FC = () => (
   </FavoritePaneGroup>
 );
 
+const MetadataFavoriteRestoreWrapper: React.FC = () => {
+  const [filters, setFilters] = useState<GridTableFilterState>({
+    search: 'current filter',
+    kinds: { mode: 'all' as const },
+    namespaces: { mode: 'all' as const },
+    clusters: { mode: 'all' as const },
+    caseSensitive: false,
+    includeMetadata: false,
+  });
+  useFavToggle({
+    filters,
+    sortColumn: null,
+    sortDirection: 'asc',
+    columnVisibility: {},
+    hydrated: true,
+    setFilters,
+  });
+
+  return <input aria-label="Rendered filter text" readOnly value={filters.search} />;
+};
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -297,7 +319,7 @@ describe('useFavToggle', () => {
   beforeEach(() => {
     mockFavorites = [];
     mockPendingFavorite = null;
-    mockSetPendingFavorite.mockClear();
+    mockSetPendingFavorite.mockReset();
     mockAddFavorite.mockClear();
     mockUpdateFavorite.mockClear();
     mockDeleteFavorite.mockClear();
@@ -506,6 +528,36 @@ describe('useFavToggle', () => {
 
     expect(container.querySelector('[data-testid="group-toggle-workloads"]')).toBeTruthy();
     expect(container.querySelector('[data-testid="group-toggle-pods"]')).toBeNull();
+  });
+
+  it('applies saved filter text atomically when metadata search is available', async () => {
+    mockPendingFavorite = makeFavorite({
+      panes: {
+        main: {
+          filters: {
+            search: 'saved filter',
+            kinds: { mode: 'all' },
+            namespaces: { mode: 'all' },
+            clusters: { mode: 'all' },
+            caseSensitive: false,
+            includeMetadata: true,
+          },
+          tableState: { sortColumn: '', sortDirection: 'asc', columnVisibility: {} },
+        },
+      },
+    });
+    mockSetPendingFavorite.mockImplementationOnce((favorite) => {
+      mockPendingFavorite = favorite;
+    });
+
+    await act(async () => {
+      root.render(<MetadataFavoriteRestoreWrapper />);
+      await Promise.resolve();
+    });
+
+    expect(
+      container.querySelector<HTMLInputElement>('[aria-label="Rendered filter text"]')?.value
+    ).toBe('saved filter');
   });
 
   it('restores both hydrated panes before consuming a grouped favorite', async () => {

--- a/frontend/src/ui/favorites/FavToggle.tsx
+++ b/frontend/src/ui/favorites/FavToggle.tsx
@@ -47,8 +47,6 @@ import FavSaveModal from './FavSaveModal';
 export interface FavToggleState {
   /** Current grid table filter state (search, kinds, namespaces, caseSensitive). */
   filters: GridTableFilterState;
-  /** Whether the include-metadata search toggle is active. */
-  includeMetadata?: boolean;
   /** Current sort column key, or null if unsorted. */
   sortColumn: string | null;
   /** Current sort direction. */
@@ -71,7 +69,6 @@ export interface FavToggleState {
   setFilters?: (filters: GridTableFilterState) => void;
   setSortConfig?: (config: { key: string; direction: 'asc' | 'desc' } | null) => void;
   setColumnVisibility?: (visibility: Record<string, boolean>) => void;
-  setIncludeMetadata?: (value: boolean) => void;
 }
 
 interface RegisteredFavoritePane {
@@ -144,7 +141,7 @@ const snapshotFavoritePane = (state: FavToggleState): FavoritePaneState => {
       clusters: normalizeExactMultiSelectFilterSelection(state.filters.clusters),
       queryFacets: Object.keys(queryFacets).length > 0 ? queryFacets : undefined,
       caseSensitive: state.filters.caseSensitive ?? false,
-      includeMetadata: state.includeMetadata ?? state.filters.includeMetadata ?? false,
+      includeMetadata: state.filters.includeMetadata ?? false,
     },
     tableState: {
       sortColumn: state.sortColumn ?? '',
@@ -386,7 +383,6 @@ export function useFavToggle(state: FavToggleState): {
           : null
       );
       pane.state.setColumnVisibility?.(savedPane.tableState.columnVisibility);
-      pane.state.setIncludeMetadata?.(savedPane.filters.includeMetadata);
     }
     setPendingFavorite(null);
   }, [
@@ -527,7 +523,7 @@ export function useFavToggle(state: FavToggleState): {
         namespace={viewType === 'namespace' ? (selectedNamespace ?? '') : ''}
         filters={currentPane.filters}
         tableState={currentPane.tableState}
-        includeMetadata={state.includeMetadata ?? false}
+        includeMetadata={state.filters.includeMetadata ?? false}
         availableKinds={state.availableKinds}
         availableFilterNamespaces={state.availableFilterNamespaces}
         panes={modalPanes}


### PR DESCRIPTION
- Removed unused `Status` column from Browse views.
- `API` column is now sortable in Browse views.
- Favorites was not restoring filter text data in some cases.
