### PR TITLE
Handle forbidden permissions

### DIFF
--- a/backend/app_lifecycle.go
+++ b/backend/app_lifecycle.go
@@ -290,9 +290,6 @@ func containsAuthPattern(lower string) bool {
 		"expired",
 		"authentication",
 		"unauthorized",
-		"forbidden",
-		"permission denied",
-		"access denied",
 	}
 	for _, pattern := range authPatterns {
 		if strings.Contains(lower, pattern) {

--- a/backend/app_lifecycle_test.go
+++ b/backend/app_lifecycle_test.go
@@ -41,6 +41,13 @@ func TestSetupEnvironmentAddsHomeLocalBin(t *testing.T) {
 	require.Contains(t, pathVar, target)
 }
 
+func TestContainsAuthPatternDoesNotTreatPermissionDenialAsAuthentication(t *testing.T) {
+	require.True(t, containsAuthPattern("request unauthorized"))
+	require.False(t, containsAuthPattern("watch is forbidden"))
+	require.False(t, containsAuthPattern("permission denied"))
+	require.False(t, containsAuthPattern("access denied"))
+}
+
 func TestSetupRefreshSubsystemRequiresSelections(t *testing.T) {
 	app := newTestAppWithDefaults(t)
 	app.Ctx = context.Background()

--- a/backend/internal/errorcapture/error_capture.go
+++ b/backend/internal/errorcapture/error_capture.go
@@ -52,6 +52,12 @@ var (
 		regexp.MustCompile(`\bpermission\s+denied\b`),
 		regexp.MustCompile(`\baccess\s+denied\b`),
 	}
+	expectedConditionPatterns = []*regexp.Regexp{
+		regexp.MustCompile(`\bforbidden\b`),
+		regexp.MustCompile(`\bpermission\s+denied\b`),
+		regexp.MustCompile(`\baccess\s+denied\b`),
+		regexp.MustCompile(`\b403\b`),
+	}
 	fallbackErrorPatterns = []*regexp.Regexp{
 		regexp.MustCompile(`\berrors?\b`),
 		regexp.MustCompile(`\bfailed\b`),
@@ -242,6 +248,9 @@ func (c *Capture) captureIfInteresting(output string) {
 			return
 		}
 		lower := strings.ToLower(msg)
+		if isExpectedCondition(lower) {
+			return
+		}
 		if !isAuthRelated(lower) {
 			return
 		}
@@ -304,12 +313,19 @@ func scanRecentError(recent string) string {
 		if line == "" {
 			continue
 		}
+		if isExpectedCondition(strings.ToLower(line)) {
+			continue
+		}
 
 		if isFallbackErrorLine(line) {
 			return line
 		}
 	}
 	return ""
+}
+
+func isExpectedCondition(lower string) bool {
+	return matchAnyPattern(lower, expectedConditionPatterns)
 }
 
 // Enhance augments an error with recent stderr output when helpful.
@@ -379,7 +395,11 @@ func getLogSink() func(level string, message string) {
 func (c *Capture) emitToLogSink(chunk []byte) {
 	forEachTrimmedLine(string(chunk), func(msg string) {
 		if sink := getLogSink(); sink != nil {
-			sink(logclassify.Classify(msg), msg)
+			level := logclassify.Classify(msg)
+			if isExpectedCondition(strings.ToLower(msg)) {
+				level = "info"
+			}
+			sink(level, msg)
 		}
 	})
 }

--- a/backend/internal/errorcapture/error_capture.go
+++ b/backend/internal/errorcapture/error_capture.go
@@ -39,10 +39,11 @@ var (
 	eventEmitter func(string)                       // function to emit events
 	logSink      func(level string, message string) // function to handle log messages
 	// Word-boundary matching avoids false positives from resource names like "podidentityassociations".
-	tokenPattern   = regexp.MustCompile(`\btokens?\b`)
-	ssoPattern     = regexp.MustCompile(`\bsso\b`)
-	expiredPattern = regexp.MustCompile(`\bexpired\b`)
-	authPatterns   = []*regexp.Regexp{
+	tokenPattern           = regexp.MustCompile(`\btokens?\b`)
+	ssoPattern             = regexp.MustCompile(`\bsso\b`)
+	expiredPattern         = regexp.MustCompile(`\bexpired\b`)
+	forbiddenStatusPattern = regexp.MustCompile(`\b(?:http(?:/\d(?:\.\d)?)?\s+403|status(?:\s+(?:code|of))?(?:\s*[:=]\s*|\s+)403)\b`)
+	authPatterns           = []*regexp.Regexp{
 		tokenPattern,
 		ssoPattern,
 		expiredPattern,
@@ -56,7 +57,7 @@ var (
 		regexp.MustCompile(`\bforbidden\b`),
 		regexp.MustCompile(`\bpermission\s+denied\b`),
 		regexp.MustCompile(`\baccess\s+denied\b`),
-		regexp.MustCompile(`\b403\b`),
+		forbiddenStatusPattern,
 	}
 	fallbackErrorPatterns = []*regexp.Regexp{
 		regexp.MustCompile(`\berrors?\b`),

--- a/backend/internal/errorcapture/error_capture_test.go
+++ b/backend/internal/errorcapture/error_capture_test.go
@@ -57,6 +57,33 @@ func TestCaptureIfInterestingStoresLastAndEmits(t *testing.T) {
 	}
 }
 
+func TestPermissionDeniedStderrStaysLocal(t *testing.T) {
+	const line = `E0805 reflector.go:200] "Failed to watch" err="applicationnetworkpolicies.networking.k8s.aws is forbidden: User cannot watch resource"`
+	c := &Capture{buffer: bytes.NewBufferString(line + "\n")}
+	global = c
+	defer func() {
+		global = nil
+		eventEmitter = nil
+		logSink = nil
+	}()
+
+	var emitted []string
+	var logs []string
+	SetEventEmitter(func(msg string) {
+		emitted = append(emitted, msg)
+	})
+	SetLogSink(func(level, message string) {
+		logs = append(logs, level+":"+message)
+	})
+	c.flushCapturedLines([]byte(line + "\n"))
+
+	require.Empty(t, emitted, "expected RBAC denial to remain a local log")
+	require.Equal(t, []string{"info:" + line}, logs, "expected RBAC denial to be informational")
+	require.Empty(t, c.last(), "expected RBAC denial not to become captured application context")
+	original := errors.New("refresh failed")
+	require.Same(t, original, Enhance(original), "expected RBAC denial not to enhance an application error")
+}
+
 func TestCaptureIfInterestingIgnoresTokenSubstrings(t *testing.T) {
 	c := &Capture{buffer: &bytes.Buffer{}}
 	global = c

--- a/backend/internal/errorcapture/error_capture_test.go
+++ b/backend/internal/errorcapture/error_capture_test.go
@@ -84,6 +84,35 @@ func TestPermissionDeniedStderrStaysLocal(t *testing.T) {
 	require.Same(t, original, Enhance(original), "expected RBAC denial not to enhance an application error")
 }
 
+func TestExpectedConditionDoesNotMatchIncidental403Numbers(t *testing.T) {
+	lines := []string{
+		`E0805 10:15:30.123456 17 reflector.go:403] "Failed to watch" err="connection refused"`,
+		`E0805 10:15:30.123456 403 shared_informer.go:314] unable to sync caches`,
+		`E0805 10:15:30.123456 17 round_trippers.go:63] dial tcp 10.0.0.1:403: i/o timeout`,
+		`E0805 10:15:30.123456 17 transport.go:301] request took 403 ms`,
+	}
+
+	for _, line := range lines {
+		t.Run(line, func(t *testing.T) {
+			require.False(t, isExpectedCondition(strings.ToLower(line)))
+		})
+	}
+}
+
+func TestExpectedConditionMatchesStructured403Status(t *testing.T) {
+	lines := []string{
+		`request failed with HTTP 403`,
+		`request failed with status code 403`,
+		`server responded with a status of 403`,
+	}
+
+	for _, line := range lines {
+		t.Run(line, func(t *testing.T) {
+			require.True(t, isExpectedCondition(strings.ToLower(line)))
+		})
+	}
+}
+
 func TestCaptureIfInterestingIgnoresTokenSubstrings(t *testing.T) {
 	c := &Capture{buffer: &bytes.Buffer{}}
 	global = c

--- a/backend/refresh/informer/factory.go
+++ b/backend/refresh/informer/factory.go
@@ -122,6 +122,20 @@ func (f *Factory) CanListWatch(group, resource string) bool {
 	return true
 }
 
+// CanListWatchInNamespace reports whether the current identity can both list
+// and watch the resource in the exact namespace used by an informer.
+func (f *Factory) CanListWatchInNamespace(group, resource, namespace string) bool {
+	if f == nil {
+		return false
+	}
+	listAllowed, listErr := f.checkResourceVerbInNamespace(group, resource, "list", namespace)
+	if listErr != nil || !listAllowed {
+		return false
+	}
+	watchAllowed, watchErr := f.checkResourceVerbInNamespace(group, resource, "watch", namespace)
+	return watchErr == nil && watchAllowed
+}
+
 // New returns a new informer Factory with the provided resync period.
 // The checker is used for all permission (SSAR) checks; it must not be nil.
 func New(client kubernetes.Interface, apiextClient apiextensionsclientset.Interface, resync time.Duration, checker *permissions.Checker) *Factory {
@@ -618,6 +632,20 @@ func (f *Factory) checkResourceVerb(group, resource, verb string) (bool, error) 
 
 	key := fmt.Sprintf("%s/%s/%s", group, resource, verb)
 	decision, err := f.runtimePermissions.Can(context.Background(), group, resource, verb)
+	return f.recordPermissionDecision(key, decision, err)
+}
+
+func (f *Factory) checkResourceVerbInNamespace(group, resource, verb, namespace string) (bool, error) {
+	if f.runtimePermissions == nil {
+		return false, fmt.Errorf("permission checker not configured")
+	}
+
+	key := fmt.Sprintf("%s/%s/%s", group, resource, verb)
+	decision, err := f.runtimePermissions.CanInNamespace(context.Background(), group, resource, verb, namespace)
+	return f.recordPermissionDecision(key, decision, err)
+}
+
+func (f *Factory) recordPermissionDecision(key string, decision permissions.Decision, err error) (bool, error) {
 	if err != nil {
 		return false, err
 	}

--- a/backend/refresh/informer/factory.go
+++ b/backend/refresh/informer/factory.go
@@ -53,8 +53,8 @@ type Factory struct {
 
 	pendingClusterInformers []clusterInformerRegistration
 
-	// permissionAllowed tracks permission keys that have been allowed at least once.
-	permissionAllowed map[string]struct{}
+	// permissionAllowed tracks exact permission scopes that have been allowed at least once.
+	permissionAllowed map[PermissionGrant]struct{}
 	permissionMu      sync.RWMutex
 
 	runtimePermissions *permissions.Checker
@@ -65,6 +65,36 @@ type Factory struct {
 	// objects; this dedicated source serves the three helm consumers that still need
 	// the typed object. nil before New finishes wiring it.
 	helmStorage *HelmStorageSource
+}
+
+type permissionGrantScope uint8
+
+const (
+	permissionGrantDefaultScope permissionGrantScope = iota
+	permissionGrantExactNamespace
+)
+
+// PermissionGrant preserves the permission evaluator and scope that originally
+// produced an allowed decision so revalidation can repeat the same check.
+type PermissionGrant struct {
+	group     string
+	resource  string
+	verb      string
+	namespace string
+	scope     permissionGrantScope
+}
+
+// Revalidate repeats the same permission evaluation that produced the grant.
+func (g PermissionGrant) Revalidate(ctx context.Context, checker *permissions.Checker) (permissions.Decision, error) {
+	if g.scope == permissionGrantExactNamespace {
+		return checker.CanInNamespace(ctx, g.group, g.resource, g.verb, g.namespace)
+	}
+	return checker.Can(ctx, g.group, g.resource, g.verb)
+}
+
+// Identity returns the resource and verb used by the grant for diagnostics.
+func (g PermissionGrant) Identity() (group, resource, verb string) {
+	return g.group, g.resource, g.verb
 }
 
 // informerSyncState tracks one informer's progress toward its initial sync.
@@ -152,7 +182,7 @@ func New(client kubernetes.Interface, apiextClient apiextensionsclientset.Interf
 		resync:             resync,
 		factory:            kubeFactory,
 		syncDeadline:       config.RefreshInformerSyncDeadline,
-		permissionAllowed:  make(map[string]struct{}),
+		permissionAllowed:  make(map[PermissionGrant]struct{}),
 		runtimePermissions: checker,
 	}
 	// nodes is an owned-reflector ingest kind (IngestOwned): the typed node informer is never
@@ -630,9 +660,9 @@ func (f *Factory) checkResourceVerb(group, resource, verb string) (bool, error) 
 		return false, fmt.Errorf("permission checker not configured")
 	}
 
-	key := fmt.Sprintf("%s/%s/%s", group, resource, verb)
+	grant := PermissionGrant{group: group, resource: resource, verb: verb, scope: permissionGrantDefaultScope}
 	decision, err := f.runtimePermissions.Can(context.Background(), group, resource, verb)
-	return f.recordPermissionDecision(key, decision, err)
+	return f.recordPermissionDecision(grant, decision, err)
 }
 
 func (f *Factory) checkResourceVerbInNamespace(group, resource, verb, namespace string) (bool, error) {
@@ -640,29 +670,35 @@ func (f *Factory) checkResourceVerbInNamespace(group, resource, verb, namespace 
 		return false, fmt.Errorf("permission checker not configured")
 	}
 
-	key := fmt.Sprintf("%s/%s/%s", group, resource, verb)
+	grant := PermissionGrant{
+		group:     group,
+		resource:  resource,
+		verb:      verb,
+		namespace: namespace,
+		scope:     permissionGrantExactNamespace,
+	}
 	decision, err := f.runtimePermissions.CanInNamespace(context.Background(), group, resource, verb, namespace)
-	return f.recordPermissionDecision(key, decision, err)
+	return f.recordPermissionDecision(grant, decision, err)
 }
 
-func (f *Factory) recordPermissionDecision(key string, decision permissions.Decision, err error) (bool, error) {
+func (f *Factory) recordPermissionDecision(grant PermissionGrant, decision permissions.Decision, err error) (bool, error) {
 	if err != nil {
 		return false, err
 	}
 	if decision.Allowed {
-		f.trackAllowedPermission(key)
+		f.trackAllowedPermission(grant)
 	}
 	return decision.Allowed, nil
 }
 
-// trackAllowedPermission records that a permission key has been granted at least once.
-func (f *Factory) trackAllowedPermission(key string) {
+// trackAllowedPermission records that an exact permission scope has been granted at least once.
+func (f *Factory) trackAllowedPermission(grant PermissionGrant) {
 	if f == nil {
 		return
 	}
 	f.permissionMu.Lock()
 	if f.permissionAllowed != nil {
-		f.permissionAllowed[key] = struct{}{}
+		f.permissionAllowed[grant] = struct{}{}
 	}
 	f.permissionMu.Unlock()
 }
@@ -689,8 +725,8 @@ func (f *Factory) PrimePermissions(ctx context.Context, requests []PermissionReq
 	return g.Wait()
 }
 
-// PermissionAllowedSnapshot returns keys that have been allowed at least once.
-func (f *Factory) PermissionAllowedSnapshot() []string {
+// PermissionAllowedSnapshot returns exact permission scopes that have been allowed at least once.
+func (f *Factory) PermissionAllowedSnapshot() []PermissionGrant {
 	if f == nil {
 		return nil
 	}
@@ -699,9 +735,9 @@ func (f *Factory) PermissionAllowedSnapshot() []string {
 	if len(f.permissionAllowed) == 0 {
 		return nil
 	}
-	keys := make([]string, 0, len(f.permissionAllowed))
-	for key := range f.permissionAllowed {
-		keys = append(keys, key)
+	grants := make([]PermissionGrant, 0, len(f.permissionAllowed))
+	for grant := range f.permissionAllowed {
+		grants = append(grants, grant)
 	}
-	return keys
+	return grants
 }

--- a/backend/refresh/informer/factory_test.go
+++ b/backend/refresh/informer/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -536,7 +537,7 @@ func TestHelmStorageSourceSkipsDeniedKinds(t *testing.T) {
 func newMinimalFactory(checker *permissions.Checker) *Factory {
 	return &Factory{
 		kubeClient:         fake.NewClientset(),
-		permissionAllowed:  make(map[string]struct{}),
+		permissionAllowed:  make(map[PermissionGrant]struct{}),
 		runtimePermissions: checker,
 	}
 }
@@ -563,6 +564,65 @@ func TestCanListWatchInNamespaceChecksTheExactInformerScope(t *testing.T) {
 	if fmt.Sprint(checked) != fmt.Sprint(expected) {
 		t.Fatalf("unexpected permission checks: got %v want %v", checked, expected)
 	}
+}
+
+func TestPermissionAllowedSnapshotPreservesEvaluationScope(t *testing.T) {
+	allows := func(group, resource, namespace string) bool {
+		return (group == "apps" && resource == "deployments" && namespace == "team-b") ||
+			(group == "example.com" && resource == "widgets" && namespace == "team-a")
+	}
+	checker := permissions.NewCheckerWithReview("test", time.Minute, func(_ context.Context, group, resource, _, namespace string) (bool, error) {
+		return allows(group, resource, namespace), nil
+	})
+	checker.SetScope([]string{"team-b"}, func(group, resource string) bool {
+		return group == "apps" && resource == "deployments"
+	})
+	factory := newMinimalFactory(checker)
+	require.True(t, factory.CanListWatch("apps", "deployments"))
+	require.True(t, factory.CanListWatchInNamespace("example.com", "widgets", "team-a"))
+
+	var checked []string
+	revalidationChecker := permissions.NewCheckerWithReview("test", time.Minute, func(_ context.Context, group, resource, verb, namespace string) (bool, error) {
+		checked = append(checked, fmt.Sprintf("%s/%s/%s|%s", group, resource, verb, namespace))
+		return allows(group, resource, namespace), nil
+	})
+	revalidationChecker.SetScope([]string{"team-b"}, func(group, resource string) bool {
+		return group == "apps" && resource == "deployments"
+	})
+
+	grants := factory.PermissionAllowedSnapshot()
+	require.Len(t, grants, 4)
+	identities := make([]string, 0, len(grants))
+	for _, grant := range grants {
+		decision, err := grant.Revalidate(context.Background(), revalidationChecker)
+		require.NoError(t, err)
+		require.True(t, decision.Allowed)
+		group, resource, verb := grant.Identity()
+		identities = append(identities, fmt.Sprintf("%s/%s/%s", group, resource, verb))
+	}
+
+	require.ElementsMatch(t, []string{
+		"apps/deployments/list|team-b",
+		"apps/deployments/watch|team-b",
+		"example.com/widgets/list|team-a",
+		"example.com/widgets/watch|team-a",
+	}, checked)
+	require.ElementsMatch(t, []string{
+		"apps/deployments/list",
+		"apps/deployments/watch",
+		"example.com/widgets/list",
+		"example.com/widgets/watch",
+	}, identities)
+}
+
+func TestPermissionAllowedSnapshotIsEmptyBeforeAnyGrant(t *testing.T) {
+	var nilFactory *Factory
+	require.Nil(t, nilFactory.PermissionAllowedSnapshot())
+
+	checker := permissions.NewCheckerWithReview("test", time.Minute, func(context.Context, string, string, string, string) (bool, error) {
+		return true, nil
+	})
+	require.Nil(t, newMinimalFactory(checker).PermissionAllowedSnapshot())
 }
 
 // TestFactoryGateExemptInformerDoesNotBlockFactorySync pins the events exclusion: an

--- a/backend/refresh/informer/factory_test.go
+++ b/backend/refresh/informer/factory_test.go
@@ -541,6 +541,30 @@ func newMinimalFactory(checker *permissions.Checker) *Factory {
 	}
 }
 
+func TestCanListWatchInNamespaceChecksTheExactInformerScope(t *testing.T) {
+	var checked []string
+	checker := permissions.NewCheckerWithReview("test", time.Minute, func(_ context.Context, group, resource, verb, namespace string) (bool, error) {
+		checked = append(checked, fmt.Sprintf("%s/%s/%s|%s", group, resource, verb, namespace))
+		return namespace == "allowed", nil
+	})
+	factory := newMinimalFactory(checker)
+
+	if !factory.CanListWatchInNamespace("example.com", "widgets", "allowed") {
+		t.Fatal("expected the allowed namespace to pass list/watch checks")
+	}
+	if factory.CanListWatchInNamespace("example.com", "widgets", "denied") {
+		t.Fatal("expected the denied namespace to fail list/watch checks")
+	}
+	expected := []string{
+		"example.com/widgets/list|allowed",
+		"example.com/widgets/watch|allowed",
+		"example.com/widgets/list|denied",
+	}
+	if fmt.Sprint(checked) != fmt.Sprint(expected) {
+		t.Fatalf("unexpected permission checks: got %v want %v", checked, expected)
+	}
+}
+
 // TestFactoryGateExemptInformerDoesNotBlockFactorySync pins the events exclusion: an
 // informer registered as factory-gate-exempt must not hold the FACTORY-WIDE sync gate
 // (HasSynced / Start) even while it has neither synced nor degraded — only

--- a/backend/refresh/resourcestream/manager.go
+++ b/backend/refresh/resourcestream/manager.go
@@ -11,6 +11,7 @@ package resourcestream
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -158,6 +159,8 @@ type customResourceInformer struct {
 	gvr    schema.GroupVersionResource
 	kind   string
 	domain string
+	// namespaces records the exact scopes whose list/watch checks passed.
+	namespaces []string
 	// informers are the CRD's dynamic informers: one cluster-wide (or one
 	// per configured scope namespace for a namespaced CRD under a namespace
 	// scope, docs/plans/namespace-scope.md). All share stopCh.
@@ -515,23 +518,6 @@ func (m *Manager) ensureCustomInformer(crd *apiextensionsv1.CustomResourceDefini
 	}
 	kind := crd.Spec.Names.Kind
 
-	m.customInformerMu.Lock()
-	// Once stopped, never resurrect an informer; the check-and-insert below must
-	// stay atomic with Stop()'s drain, so both gate on stopped under this lock.
-	if m.stopped {
-		m.customInformerMu.Unlock()
-		return
-	}
-	existing := m.customInformers[crd.Name]
-	if existing != nil && existing.gvr == gvr && existing.kind == kind && existing.domain == customDomain {
-		m.customInformerMu.Unlock()
-		return
-	}
-	if existing != nil {
-		existing.stop()
-		delete(m.customInformers, crd.Name)
-	}
-
 	// One dynamic informer per CRD streams custom resource updates. Under a
 	// namespace scope a namespaced CRD fans out one informer per configured
 	// namespace (the scoped identity typically cannot watch cluster-wide);
@@ -540,12 +526,43 @@ func (m *Manager) ensureCustomInformer(crd *apiextensionsv1.CustomResourceDefini
 	if customDomain == domainNamespaceCustom && len(m.allowedNamespaces) > 0 {
 		namespaces = append([]string(nil), m.allowedNamespaces...)
 	}
-	info := &customResourceInformer{
-		gvr:    gvr,
-		kind:   kind,
-		domain: customDomain,
-		stopCh: make(chan struct{}),
+	permittedNamespaces := make([]string, 0, len(namespaces))
+	for _, ns := range namespaces {
+		if m.canListWatchInNamespace(gvr.Group, gvr.Resource, ns) {
+			permittedNamespaces = append(permittedNamespaces, ns)
+		}
 	}
+	if len(permittedNamespaces) == 0 {
+		m.removeCustomInformer(crd.Name)
+		return
+	}
+	namespaces = permittedNamespaces
+
+	info := &customResourceInformer{
+		gvr:        gvr,
+		kind:       kind,
+		domain:     customDomain,
+		namespaces: append([]string(nil), namespaces...),
+		stopCh:     make(chan struct{}),
+	}
+
+	m.customInformerMu.Lock()
+	// Once stopped, never resurrect an informer; the check-and-insert below must
+	// stay atomic with Stop()'s drain, so both gate on stopped under this lock.
+	if m.stopped {
+		m.customInformerMu.Unlock()
+		return
+	}
+	existing := m.customInformers[crd.Name]
+	if existing != nil && existing.gvr == gvr && existing.kind == kind && existing.domain == customDomain && slices.Equal(existing.namespaces, namespaces) {
+		m.customInformerMu.Unlock()
+		return
+	}
+	if existing != nil {
+		existing.stop()
+		delete(m.customInformers, crd.Name)
+	}
+
 	for _, ns := range namespaces {
 		dynamicInformer := dynamicinformer.NewFilteredDynamicInformer(
 			m.dynamicClient,

--- a/backend/refresh/resourcestream/manager_test.go
+++ b/backend/refresh/resourcestream/manager_test.go
@@ -82,6 +82,18 @@ func resumeForTest(t *testing.T, manager *Manager, domain, scope string, since u
 	return manager.ResumeSelector(selector, since)
 }
 
+type scopedListWatchStub struct {
+	allowed map[string]bool
+}
+
+func (s *scopedListWatchStub) CanListWatch(group, resource string) bool {
+	return s.CanListWatchInNamespace(group, resource, "")
+}
+
+func (s *scopedListWatchStub) CanListWatchInNamespace(group, resource, namespace string) bool {
+	return s.allowed[group+"/"+resource+"|"+namespace]
+}
+
 func TestManagerBroadcastsEventAndCatalogDoorbellSources(t *testing.T) {
 	manager := &Manager{
 		clusterMeta: snapshot.ClusterMeta{ClusterID: "c1", ClusterName: "cluster"},
@@ -738,6 +750,67 @@ func TestManagerSkipsCustomInformerForFirstClassGatewayCRD(t *testing.T) {
 	default:
 		t.Fatal("expected stale custom informer to be stopped")
 	}
+}
+
+func TestManagerStartsCustomInformersOnlyInPermittedNamespaces(t *testing.T) {
+	manager := &Manager{
+		clusterMeta: snapshot.ClusterMeta{ClusterID: "c1", ClusterName: "cluster"},
+		logger:      applog.Noop,
+		permissions: &scopedListWatchStub{allowed: map[string]bool{
+			"example.com/widgets|allowed": true,
+		}},
+		dynamicClient:     dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()),
+		allowedNamespaces: []string{"allowed", "denied"},
+		customInformers:   make(map[string]*customResourceInformer),
+		subscribers:       make(map[string]map[string]map[uint64]*subscription),
+	}
+	t.Cleanup(manager.Stop)
+	crd := customResourceDefinition("widgets.example.com", "example.com", "widgets", "Widget", apiextensionsv1.NamespaceScoped, "1")
+
+	manager.ensureCustomInformer(crd)
+
+	info := manager.customInformers[crd.Name]
+	require.NotNil(t, info)
+	require.Len(t, info.informers, 1, "denied namespaces must not get dynamic informers")
+}
+
+func TestManagerDoesNotStartCustomInformerWhenListWatchIsDenied(t *testing.T) {
+	manager := &Manager{
+		clusterMeta:       snapshot.ClusterMeta{ClusterID: "c1", ClusterName: "cluster"},
+		logger:            applog.Noop,
+		permissions:       &scopedListWatchStub{allowed: map[string]bool{}},
+		dynamicClient:     dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()),
+		allowedNamespaces: []string{"denied"},
+		customInformers:   make(map[string]*customResourceInformer),
+		subscribers:       make(map[string]map[string]map[uint64]*subscription),
+	}
+	crd := customResourceDefinition("widgets.example.com", "example.com", "widgets", "Widget", apiextensionsv1.NamespaceScoped, "1")
+
+	manager.ensureCustomInformer(crd)
+
+	require.NotContains(t, manager.customInformers, crd.Name)
+}
+
+func TestManagerChecksClusterScopedCustomInformerAtClusterScope(t *testing.T) {
+	manager := &Manager{
+		clusterMeta: snapshot.ClusterMeta{ClusterID: "c1", ClusterName: "cluster"},
+		logger:      applog.Noop,
+		permissions: &scopedListWatchStub{allowed: map[string]bool{
+			"example.com/widgets|": true,
+		}},
+		dynamicClient:   dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()),
+		customInformers: make(map[string]*customResourceInformer),
+		subscribers:     make(map[string]map[string]map[uint64]*subscription),
+	}
+	t.Cleanup(manager.Stop)
+	crd := customResourceDefinition("widgets.example.com", "example.com", "widgets", "Widget", apiextensionsv1.ClusterScoped, "1")
+
+	manager.ensureCustomInformer(crd)
+
+	info := manager.customInformers[crd.Name]
+	require.NotNil(t, info)
+	require.Equal(t, []string{""}, info.namespaces)
+	require.Len(t, info.informers, 1)
 }
 
 func TestManagerDoesNotRecreateCustomInformerAfterStop(t *testing.T) {

--- a/backend/refresh/resourcestream/stream_registration_helpers.go
+++ b/backend/refresh/resourcestream/stream_registration_helpers.go
@@ -13,6 +13,18 @@ func (m *Manager) canListWatch(group, resource string) bool {
 	return m.permissions == nil || m.permissions.CanListWatch(group, resource)
 }
 
+func (m *Manager) canListWatchInNamespace(group, resource, namespace string) bool {
+	if m.permissions == nil {
+		return true
+	}
+	if scoped, ok := m.permissions.(interface {
+		CanListWatchInNamespace(group, resource, namespace string) bool
+	}); ok {
+		return scoped.CanListWatchInNamespace(group, resource, namespace)
+	}
+	return m.permissions.CanListWatch(group, resource)
+}
+
 func (m *Manager) addResourceEventHandler(informer cache.SharedIndexInformer, handler streamResourceHandler) {
 	if m == nil || informer == nil || handler == nil {
 		return

--- a/backend/refresh/system/permission_revalidator.go
+++ b/backend/refresh/system/permission_revalidator.go
@@ -2,7 +2,6 @@ package system
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -43,21 +42,18 @@ func (s *Subsystem) runPermissionRevalidation(ctx context.Context, interval time
 
 // permissionRevoked returns true when a previously allowed permission is now denied.
 func (s *Subsystem) permissionRevoked(ctx context.Context) bool {
-	keys := s.InformerFactory.PermissionAllowedSnapshot()
-	if len(keys) == 0 {
+	grants := s.InformerFactory.PermissionAllowedSnapshot()
+	if len(grants) == 0 {
 		return false
 	}
 
-	for _, key := range keys {
-		group, resource, verb, ok := parsePermissionKey(key)
-		if !ok {
-			continue
-		}
-		decision, err := s.RuntimePerms.Can(ctx, group, resource, verb)
+	for _, grant := range grants {
+		decision, err := grant.Revalidate(ctx, s.RuntimePerms)
 		if err != nil {
 			continue
 		}
 		if !decision.Allowed {
+			group, resource, verb := grant.Identity()
 			klog.V(1).Infof("Permission revoked for %s/%s verb %s; stopping refresh subsystem", group, resource, verb)
 			return true
 		}
@@ -75,13 +71,4 @@ func (s *Subsystem) stopForPermissionRevocation() {
 	if err := s.Manager.Shutdown(ctx); err != nil {
 		klog.V(1).Infof("Permission revocation shutdown failed: %v", err)
 	}
-}
-
-// parsePermissionKey splits informer permission cache keys (group/resource/verb).
-func parsePermissionKey(key string) (string, string, string, bool) {
-	parts := strings.Split(key, "/")
-	if len(parts) != 3 {
-		return "", "", "", false
-	}
-	return parts[0], parts[1], parts[2], true
 }

--- a/backend/refresh/system/permission_revalidator_test.go
+++ b/backend/refresh/system/permission_revalidator_test.go
@@ -1,0 +1,75 @@
+package system
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/luxury-yacht/app/backend/refresh/informer"
+	"github.com/luxury-yacht/app/backend/refresh/permissions"
+)
+
+func TestPermissionRevalidationUsesRecordedNamespace(t *testing.T) {
+	checker := permissions.NewCheckerWithReview("cluster-a", time.Minute, func(_ context.Context, _, _, _, namespace string) (bool, error) {
+		return namespace == "team-a", nil
+	})
+	// Discovery-backed CRDs are intentionally absent from the static scope
+	// predicate, so a generic Can call would check them cluster-wide.
+	checker.SetScope([]string{"team-a"}, func(_, _ string) bool { return false })
+	factory := informer.New(fake.NewClientset(), nil, 0, checker)
+
+	require.True(t, factory.CanListWatchInNamespace("example.com", "widgets", "team-a"))
+
+	subsystem := &Subsystem{
+		RuntimePerms:    checker,
+		InformerFactory: factory,
+	}
+	require.False(t, subsystem.permissionRevoked(context.Background()),
+		"a namespace-scoped grant must not be rechecked cluster-wide")
+}
+
+func TestPermissionRevalidationPreservesDefaultScopeEvaluation(t *testing.T) {
+	checker := permissions.NewCheckerWithReview("cluster-a", time.Minute, func(_ context.Context, _, _, _, namespace string) (bool, error) {
+		return namespace == "team-a", nil
+	})
+	checker.SetScope([]string{"team-a"}, func(group, resource string) bool {
+		return group == "apps" && resource == "deployments"
+	})
+	factory := informer.New(fake.NewClientset(), nil, 0, checker)
+
+	require.True(t, factory.CanListWatch("apps", "deployments"))
+
+	subsystem := &Subsystem{
+		RuntimePerms:    checker,
+		InformerFactory: factory,
+	}
+	require.False(t, subsystem.permissionRevoked(context.Background()),
+		"a default permission grant must retain the checker's configured scope fan-out")
+}
+
+func TestPermissionRevalidationDetectsRevocationAtRecordedNamespace(t *testing.T) {
+	initialChecker := permissions.NewCheckerWithReview("cluster-a", time.Minute, func(_ context.Context, _, _, _, namespace string) (bool, error) {
+		return namespace == "team-a", nil
+	})
+	factory := informer.New(fake.NewClientset(), nil, 0, initialChecker)
+	require.True(t, factory.CanListWatchInNamespace("example.com", "widgets", "team-a"))
+
+	var checkedNamespaces []string
+	revalidationChecker := permissions.NewCheckerWithReview("cluster-a", time.Minute, func(_ context.Context, _, _, _, namespace string) (bool, error) {
+		checkedNamespaces = append(checkedNamespaces, namespace)
+		return false, nil
+	})
+	subsystem := &Subsystem{
+		RuntimePerms:    revalidationChecker,
+		InformerFactory: factory,
+	}
+
+	require.True(t, subsystem.permissionRevoked(context.Background()))
+	require.NotEmpty(t, checkedNamespaces)
+	for _, namespace := range checkedNamespaces {
+		require.Equal(t, "team-a", namespace, "revocation must be checked at the recorded informer namespace")
+	}
+}

--- a/docs/architecture/error-reporting.md
+++ b/docs/architecture/error-reporting.md
@@ -20,8 +20,8 @@ data-collection defaults with an application-owned privacy boundary:
   operational failures. `handle` reports before publishing a global error
   notification except when it classifies authentication or permission failure
   as an expected UI condition already owned by the auth overlay or permission
-  state. Those conditions add an allowlisted `ui.error.expected` warning
-  breadcrumb instead of creating an issue. `handleInline` and
+  state. Those conditions stay as local informational diagnostics: they do not
+  create Sentry exceptions or breadcrumbs. `handleInline` and
   `handleOperational` remain exception boundaries even for permission-shaped
   text, so an unexpected internal failure does not disappear merely because
   its message contains `permission` or `403`. Both preserve the original
@@ -68,7 +68,7 @@ data-collection defaults with an application-owned privacy boundary:
   read runs through `runUserAction`; the wrapper gives each invocation a
   `user-action-N` id and binds a rejected `Error` to that exact invocation.
 - Breadcrumbs are emitted by the navigation, broker-request, `runUserAction`,
-  error-presentation, expected-condition, and error-handler boundaries. Feature components do not
+  error-presentation, and error-handler boundaries. Feature components do not
   call Sentry directly. While exactly one broker request is active, those
   app-owned breadcrumbs receive its request id. Before a frontend event is
   sent, breadcrumbs from other request ids and breadcrumbs labeled with a
@@ -325,9 +325,12 @@ out of time is a real problem, unlike one the app itself cancelled.
 
 Entries from `logsources.ErrorCapture` never reach the reporter at all.
 `backend/internal/errorcapture` scrapes third-party stderr — klog lines from
-client-go and friends — and republishes them at whatever severity they claim.
-Those are not this application failing, and their stack is the scraper rather
-than any failing code, so they stay in the local application log and stop there.
+client-go and friends — and normally republishes their claimed severity. Those
+are not this application failing, and their stack is the scraper rather than
+any failing code, so they stay in the local application log and stop there.
+Permission-denied lines are additionally downgraded to informational entries;
+they do not emit `backend-error` events or become context attached to a later
+application failure.
 
 ## Build Configuration
 

--- a/docs/architecture/permissions.md
+++ b/docs/architecture/permissions.md
@@ -49,6 +49,9 @@ shape, failure behavior, and diagnostics differ.
 - Partial-data builders must guard nil or missing listers before use.
 - Resource-stream permissions must join with the corresponding snapshot runtime
   permission contract.
+- Discovery-backed custom-resource streams check list and watch at each exact
+  informer namespace. Denied namespaces start no informer while permitted
+  namespaces continue to provide partial change signals.
 
 ## UI Permission Rules
 

--- a/docs/release/pending.md
+++ b/docs/release/pending.md
@@ -7,3 +7,4 @@
 
 - `API` column is now sortable in Browse views.
 - Favorites was not restoring filter text data in some cases.
+- Permission-denied Kubernetes watches no longer appear as application errors or Sentry telemetry.

--- a/docs/release/pending.md
+++ b/docs/release/pending.md
@@ -4,4 +4,4 @@
 
 ### Fixed
 
-- Permission-denied Kubernetes watches no longer appear as application errors and are not reported.
+- When a Kubernetes watch is denied due to the user's permissions, this is the app behaving as designed and is no longer reported as an application error.

--- a/docs/release/pending.md
+++ b/docs/release/pending.md
@@ -1,10 +1,7 @@
-### Changed
+### Added
 
-- Removed unused `Status` column from Browse views.
-- Updated error reporting to be more actionable while maintaining privacy guarantees.
+### Changed
 
 ### Fixed
 
-- `API` column is now sortable in Browse views.
-- Favorites was not restoring filter text data in some cases.
-- Permission-denied Kubernetes watches no longer appear as application errors or Sentry telemetry.
+- Permission-denied Kubernetes watches no longer appear as application errors and are not reported.

--- a/frontend/src/core/telemetry/sentry.test.ts
+++ b/frontend/src/core/telemetry/sentry.test.ts
@@ -30,7 +30,6 @@ import {
   initializeErrorReporting,
   recordBrokerRequestCompleted,
   recordBrokerRequestStarted,
-  recordExpectedCondition,
   resetErrorReportingForTesting,
   runUserAction,
   setActiveNamespaceContext,
@@ -546,33 +545,6 @@ describe('Sentry error reporting', () => {
       expect.objectContaining({ secretValue: expect.anything() })
     );
     expect(sentryMocks.captureException).toHaveBeenCalledWith(error);
-  });
-
-  it('records an expected UI condition as a correlated breadcrumb without an exception', () => {
-    initializeErrorReporting({
-      enabled: true,
-      dsn: 'https://public@example.com/1',
-      environment: 'production',
-    });
-
-    recordExpectedCondition(new Error('403 forbidden'), {
-      category: 'PERMISSION',
-      severity: 'error',
-      context: { action: 'loadPods', clusterId: 'cluster-a' },
-    });
-
-    expect(sentryMocks.addBreadcrumb).toHaveBeenCalledWith({
-      type: 'default',
-      category: 'ui.error.expected',
-      level: 'warning',
-      message: 'Expected PERMISSION condition',
-      data: {
-        operationId: 'ui-expected-1',
-        action: 'loadPods',
-        'cluster.alias': 'cluster-1',
-      },
-    });
-    expect(sentryMocks.captureException).not.toHaveBeenCalled();
   });
 
   it('captures event-handler exceptions through the centralized operational boundary', () => {

--- a/frontend/src/core/telemetry/sentry.ts
+++ b/frontend/src/core/telemetry/sentry.ts
@@ -163,16 +163,6 @@ const allowedBreadcrumbFields: Record<string, ReadonlySet<string>> = {
     'cluster.alias',
     'namespace.alias',
   ]),
-  'ui.error.expected': new Set([
-    'operationId',
-    'action',
-    'requestId',
-    'request.ids',
-    'ui.view',
-    'ui.tab',
-    'cluster.alias',
-    'namespace.alias',
-  ]),
 };
 
 const privateTelemetryKeys = new Set([
@@ -921,52 +911,6 @@ export async function runUserAction<T>(action: string, work: () => T | Promise<T
     recordUserActionBreadcrumb(userAction, 'failed');
     throw error;
   }
-}
-
-export function recordExpectedCondition(error: unknown, details: UserVisibleErrorCapture): void {
-  if (!reportingInitialized) {
-    return;
-  }
-
-  const completedRequest =
-    error !== null &&
-    error !== undefined &&
-    (typeof error === 'object' || typeof error === 'function')
-      ? requestByError.get(error)
-      : undefined;
-  const explicitOperationId = contextString(details.context, 'operationId');
-  const request =
-    completedRequest ??
-    (explicitOperationId ? activeBrokerRequests.get(explicitOperationId) : undefined);
-  const userAction =
-    error !== null &&
-    error !== undefined &&
-    (typeof error === 'object' || typeof error === 'function')
-      ? userActionByError.get(error)
-      : undefined;
-  operationSequence += 1;
-  const operationId = request?.id ?? userAction?.id ?? `ui-expected-${operationSequence}`;
-  const action = contextString(details.context, 'action') ?? userAction?.action;
-  const operationClusterId = contextString(details.context, 'clusterId');
-  const operationNamespace = contextString(details.context, 'namespace');
-
-  Sentry.addBreadcrumb({
-    type: 'default',
-    category: 'ui.error.expected',
-    level: 'warning',
-    message: `Expected ${details.category} condition`,
-    data: {
-      operationId,
-      ...(action ? { action } : {}),
-      ...(request ? { requestId: request.id } : {}),
-      ...(operationClusterId
-        ? { 'cluster.alias': aliasForCluster(operationClusterId) ?? 'cluster-unknown' }
-        : {}),
-      ...(operationNamespace
-        ? { 'namespace.alias': aliasForNamespace(operationNamespace) ?? 'namespace-unknown' }
-        : {}),
-    },
-  });
 }
 
 export function captureUserVisibleError(error: unknown, details: UserVisibleErrorCapture): void {

--- a/frontend/src/utils/errorHandler.test.ts
+++ b/frontend/src/utils/errorHandler.test.ts
@@ -153,6 +153,27 @@ describe('ErrorHandler', () => {
     expect(telemetryMocks.captureUserVisibleError).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ['Failed to fetch: dial tcp 10.0.0.1:8403: connection refused', ErrorCategory.NETWORK],
+    ['dial tcp 10.0.0.1:403: i/o timeout', ErrorCategory.TIMEOUT],
+    ['request took 403 ms: internal server error', ErrorCategory.SERVER_ERROR],
+    ['processed 403 records before too many requests', ErrorCategory.RATE_LIMIT],
+  ])('does not treat incidental 403 digits in %s as permission denial', (message, category) => {
+    const details = handler.handle(message);
+
+    expect(details.category).toBe(category);
+  });
+
+  it.each([
+    'request failed with HTTP 403',
+    'request failed with status code 403',
+    'server responded with a status of 403',
+  ])('treats structured 403 status in %s as permission denial', (message) => {
+    const details = handler.handle(message);
+
+    expect(details.category).toBe(ErrorCategory.PERMISSION);
+  });
+
   it('treats forbidden Kubernetes resources with network in their API group as permission conditions', () => {
     const listener = vi.fn();
     handler.subscribe(listener);

--- a/frontend/src/utils/errorHandler.test.ts
+++ b/frontend/src/utils/errorHandler.test.ts
@@ -11,7 +11,6 @@ import { ErrorCategory, ErrorSeverity, errorHandler } from './errorHandler';
 
 const telemetryMocks = vi.hoisted(() => ({
   captureUserVisibleError: vi.fn(),
-  recordExpectedCondition: vi.fn(),
 }));
 
 vi.mock('@/core/telemetry/sentry', () => telemetryMocks);
@@ -24,12 +23,12 @@ describe('ErrorHandler', () => {
   const originalConsole = {
     groupCollapsed: console.groupCollapsed,
     error: console.error,
+    info: console.info,
     groupEnd: console.groupEnd,
   };
 
   beforeEach(() => {
     telemetryMocks.captureUserVisibleError.mockReset();
-    telemetryMocks.recordExpectedCondition.mockReset();
     handler = new ErrorHandlerClass({
       enableLogging: true,
       logToConsole: true,
@@ -37,12 +36,14 @@ describe('ErrorHandler', () => {
     });
     console.groupCollapsed = vi.fn();
     console.error = vi.fn();
+    console.info = vi.fn();
     console.groupEnd = vi.fn();
   });
 
   afterEach(() => {
     console.groupCollapsed = originalConsole.groupCollapsed;
     console.error = originalConsole.error;
+    console.info = originalConsole.info;
     console.groupEnd = originalConsole.groupEnd;
   });
 
@@ -148,12 +149,23 @@ describe('ErrorHandler', () => {
     expect(details.category).toBe(ErrorCategory.PERMISSION);
     expect(handler.getHistory()).toHaveLength(0);
     expect(listener).not.toHaveBeenCalled();
-    expect(console.groupCollapsed).toHaveBeenCalled();
+    expect(console.info).toHaveBeenCalled();
     expect(telemetryMocks.captureUserVisibleError).not.toHaveBeenCalled();
-    expect(telemetryMocks.recordExpectedCondition).toHaveBeenCalledWith(
-      '403 forbidden access',
-      expect.objectContaining({ category: ErrorCategory.PERMISSION })
+  });
+
+  it('treats forbidden Kubernetes resources with network in their API group as permission conditions', () => {
+    const listener = vi.fn();
+    handler.subscribe(listener);
+    const error = new Error(
+      'failed to list networking.k8s.aws/v1alpha1, Resource=applicationnetworkpolicies: forbidden'
     );
+
+    const details = handler.handle(error, { source: 'backend-fetch' });
+
+    expect(details.category).toBe(ErrorCategory.PERMISSION);
+    expect(handler.getHistory()).toHaveLength(0);
+    expect(listener).not.toHaveBeenCalled();
+    expect(telemetryMocks.captureUserVisibleError).not.toHaveBeenCalled();
   });
 
   it('still captures permission-shaped failures at an operational boundary', () => {
@@ -168,7 +180,6 @@ describe('ErrorHandler', () => {
         surface: 'operational',
       })
     );
-    expect(telemetryMocks.recordExpectedCondition).not.toHaveBeenCalled();
   });
 
   it('supports scoped handlers that merge context and custom message', () => {
@@ -209,7 +220,6 @@ describe('ErrorHandler', () => {
     expect(handler.getHistory()).toHaveLength(0);
     expect(listener).not.toHaveBeenCalled();
     expect(telemetryMocks.captureUserVisibleError).not.toHaveBeenCalled();
-    expect(telemetryMocks.recordExpectedCondition).toHaveBeenCalledTimes(3);
   });
 
   it('updates options and disables console logging when requested', () => {

--- a/frontend/src/utils/errorHandler.ts
+++ b/frontend/src/utils/errorHandler.ts
@@ -34,6 +34,8 @@ export type ErrorSeverity = (typeof ErrorSeverity)[keyof typeof ErrorSeverity];
 // (e.g. "authorization" in "rbac.authorization.k8s.io" is not an auth error).
 const authWordPattern = /\bauth\b/;
 const authTokenPattern = /\btokens?\b/;
+const forbiddenStatusPattern =
+  /\b(?:http(?:\/\d(?:\.\d)?)?\s+403|status(?:\s+(?:code|of))?(?:\s*[:=]\s*|\s+)403)\b/;
 
 export interface ErrorDetails {
   message: string;
@@ -94,7 +96,7 @@ class ErrorHandler {
       lowerError.includes('forbidden') ||
       lowerError.includes('permission') ||
       lowerError.includes('access denied') ||
-      lowerError.includes('403')
+      forbiddenStatusPattern.test(lowerError)
     ) {
       return ErrorCategory.PERMISSION;
     }

--- a/frontend/src/utils/errorHandler.ts
+++ b/frontend/src/utils/errorHandler.ts
@@ -5,10 +5,7 @@
  * Provides shared helper functions for the frontend.
  */
 
-import {
-  captureUserVisibleError,
-  recordExpectedCondition as recordExpectedTelemetryCondition,
-} from '@/core/telemetry/sentry';
+import { captureUserVisibleError } from '@/core/telemetry/sentry';
 
 export const ErrorCategory = {
   NETWORK: 'NETWORK',
@@ -91,6 +88,17 @@ class ErrorHandler {
     const errorString = this.getErrorString(error);
     const lowerError = errorString.toLowerCase();
 
+    // Permission markers are more specific than API group or resource names
+    // containing broad words such as "network".
+    if (
+      lowerError.includes('forbidden') ||
+      lowerError.includes('permission') ||
+      lowerError.includes('access denied') ||
+      lowerError.includes('403')
+    ) {
+      return ErrorCategory.PERMISSION;
+    }
+
     // Network errors
     if (
       lowerError.includes('network') ||
@@ -113,16 +121,6 @@ class ErrorHandler {
       lowerError.includes('401')
     ) {
       return ErrorCategory.AUTHENTICATION;
-    }
-
-    // Permission errors
-    if (
-      lowerError.includes('forbidden') ||
-      lowerError.includes('permission') ||
-      lowerError.includes('access denied') ||
-      lowerError.includes('403')
-    ) {
-      return ErrorCategory.PERMISSION;
     }
 
     // Not found errors
@@ -337,13 +335,11 @@ class ErrorHandler {
     this.logError(details);
   }
 
-  private recordExpectedCondition(error: unknown, details: ErrorDetails): void {
-    recordExpectedTelemetryCondition(error, {
-      category: details.category,
-      severity: details.severity,
-      context: details.context,
-    });
-    this.logError(details);
+  private logExpectedCondition(details: ErrorDetails): void {
+    if (!this.options.enableLogging || !this.options.logToConsole) {
+      return;
+    }
+    console.info(`[EXPECTED] ${details.category}:`, details.technicalMessage, details.context);
   }
 
   /**
@@ -374,7 +370,7 @@ class ErrorHandler {
       isAuthOverlayError;
 
     if (suppressNotification) {
-      this.recordExpectedCondition(error, errorDetails);
+      this.logExpectedCondition(errorDetails);
     } else {
       this.reportError(error, errorDetails);
       // Store in history


### PR DESCRIPTION
- Stop treating auth and permission denials as errors. Keep local info/diagnostics while excluding them from reported issues.
- Check custom-resource list/watch permissions at each exact namespace, allowing permitted namespaces to continue streaming while denied namespaces are skipped.
- Preserve permission scope during revalidation so namespace grants are never rechecked cluster-wide.
- Tighten `403` detection to actual HTTP/status-code shapes, avoiding false matches from ports, durations, thread IDs, and klog line numbers.
- Preserve reporting for genuine operational failures, including permission-shaped internal errors.
