### PR TITLE
Beta release prep

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,7 +174,6 @@ jobs:
       contents: write
     env:
       GH_TOKEN: ${{ secrets.RELEASES_REPO_TOKEN }}
-      RELEASE_PRERELEASE: ${{ contains(github.ref_name, 'beta') }}
       RELEASE_TAG: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,12 @@ jobs:
         with:
           install-linux-deps: "true"
 
+      - name: Validate release tag
+        if: ${{ github.event_name == 'push' || github.event.inputs.release == 'true' }}
+        env:
+          RELEASE_TAG: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
+        run: go run ./cmd/project validate-release-tag
+
       - name: Run tests
         run: |
           echo "Run a build to ensure frontend/dist is generated"
@@ -168,6 +174,8 @@ jobs:
       contents: write
     env:
       GH_TOKEN: ${{ secrets.RELEASES_REPO_TOKEN }}
+      RELEASE_PRERELEASE: ${{ contains(github.ref_name, 'beta') }}
+      RELEASE_TAG: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
     steps:
       - uses: actions/checkout@v7
 

--- a/cmd/project/main.go
+++ b/cmd/project/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 )
 
-const projectUsage = "usage: project <backend-coverage|binary-name|bindings|build-manifests|build-metadata|clean-all|clean-build|clean-frontend|config|fmt|go-mod-update|go-mod-update-check|install-unsigned|release-app|release-artifact-name|release-site|reset>"
+const projectUsage = "usage: project <backend-coverage|binary-name|bindings|build-manifests|build-metadata|clean-all|clean-build|clean-frontend|config|fmt|go-mod-update|go-mod-update-check|install-unsigned|release-app|release-artifact-name|release-site|reset|validate-release-tag>"
 
 var projectCommands = map[string]func() error{
 	"backend-coverage":      runBackendCoverage,
@@ -25,6 +25,7 @@ var projectCommands = map[string]func() error{
 	"release-artifact-name": writeConfiguredReleaseArtifactName,
 	"release-site":          publishConfiguredSiteVersion,
 	"reset":                 resetConfiguredAppState,
+	"validate-release-tag":  validateConfiguredReleaseTag,
 }
 
 func writeConfiguredReleaseArtifactName() error {
@@ -90,11 +91,18 @@ func publishConfiguredRelease() error {
 	if err := loadDotEnv(projectEnvPath); err != nil {
 		return err
 	}
+	if err := validateConfiguredReleaseTag(); err != nil {
+		return err
+	}
 	facts, err := loadProjectFacts()
 	if err != nil {
 		return fmt.Errorf("read app version: %w", err)
 	}
-	return publishRelease(newReleaseConfig(facts))
+	cfg, err := withExplicitPrerelease(newReleaseConfig(facts), os.Getenv("RELEASE_PRERELEASE"))
+	if err != nil {
+		return err
+	}
+	return publishRelease(cfg)
 }
 
 func publishConfiguredSiteVersion() error {

--- a/cmd/project/main.go
+++ b/cmd/project/main.go
@@ -98,11 +98,7 @@ func publishConfiguredRelease() error {
 	if err != nil {
 		return fmt.Errorf("read app version: %w", err)
 	}
-	cfg, err := withExplicitPrerelease(newReleaseConfig(facts), os.Getenv("RELEASE_PRERELEASE"))
-	if err != nil {
-		return err
-	}
-	return publishRelease(cfg)
+	return publishRelease(newReleaseConfig(facts))
 }
 
 func publishConfiguredSiteVersion() error {

--- a/cmd/project/platform_manifests_test.go
+++ b/cmd/project/platform_manifests_test.go
@@ -45,9 +45,12 @@ func TestRenderProjectPlatformManifestsUsesConfigMetadata(t *testing.T) {
 }
 
 func TestRenderNFPMManifestUsesConfiguredMaintainer(t *testing.T) {
+	configPath := repositoryPath("build", "config.yml")
+	metadata, err := readProjectMetadata(configPath)
+	require.NoError(t, err)
 	outputPath := filepath.Join(t.TempDir(), "nfpm.yaml")
 	require.NoError(t, renderProjectPlatformManifests(
-		repositoryPath("build", "config.yml"),
+		configPath,
 		[]platformManifestSpec{{
 			sourcePath: repositoryPath("build", "linux", "nfpm", "nfpm.yaml"),
 			outputPath: outputPath,
@@ -55,7 +58,7 @@ func TestRenderNFPMManifestUsesConfiguredMaintainer(t *testing.T) {
 	))
 
 	manifest := readTestFile(t, outputPath)
-	require.Contains(t, manifest, `version: "v2.0.0"`)
+	require.Contains(t, manifest, `version: "`+metadata.Info.Version+`"`)
 	require.Contains(t, manifest, `maintainer: "Luxury Yacht <info@luxury-yacht.app>"`)
 	require.NotContains(t, manifest, appMaintainerPlaceholder)
 	require.NotContains(t, manifest, "GIT_COMMITTER")

--- a/cmd/project/release.go
+++ b/cmd/project/release.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
 	"text/template"
 )
@@ -45,19 +44,6 @@ func newReleaseConfig(facts projectFacts) releaseConfig {
 		releaseRepo:   projectReleaseRepo,
 		version:       facts.version,
 	}
-}
-
-func withExplicitPrerelease(cfg releaseConfig, value string) (releaseConfig, error) {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return cfg, nil
-	}
-	prerelease, err := strconv.ParseBool(value)
-	if err != nil {
-		return releaseConfig{}, fmt.Errorf("parse RELEASE_PRERELEASE: %w", err)
-	}
-	cfg.isBeta = cfg.isBeta || prerelease
-	return cfg, nil
 }
 
 func validateReleaseTag(configuredVersion, tag string) error {

--- a/cmd/project/release.go
+++ b/cmd/project/release.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"text/template"
 )
@@ -43,6 +45,37 @@ func newReleaseConfig(facts projectFacts) releaseConfig {
 		releaseRepo:   projectReleaseRepo,
 		version:       facts.version,
 	}
+}
+
+func withExplicitPrerelease(cfg releaseConfig, value string) (releaseConfig, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return cfg, nil
+	}
+	prerelease, err := strconv.ParseBool(value)
+	if err != nil {
+		return releaseConfig{}, fmt.Errorf("parse RELEASE_PRERELEASE: %w", err)
+	}
+	cfg.isBeta = cfg.isBeta || prerelease
+	return cfg, nil
+}
+
+func validateReleaseTag(configuredVersion, tag string) error {
+	if tag == "" {
+		return errors.New("release tag is required")
+	}
+	if tag != configuredVersion {
+		return fmt.Errorf("release tag %q does not exactly match configured version %q", tag, configuredVersion)
+	}
+	return nil
+}
+
+func validateConfiguredReleaseTag() error {
+	metadata, err := readProjectMetadata(projectConfigPath)
+	if err != nil {
+		return fmt.Errorf("read app version: %w", err)
+	}
+	return validateReleaseTag(metadata.Info.Version, os.Getenv("RELEASE_TAG"))
 }
 
 // Make sure the GitHub CLI is installed.

--- a/cmd/project/release_test.go
+++ b/cmd/project/release_test.go
@@ -14,6 +14,30 @@ func TestNewReleaseConfigUsesConfiguredVersionTag(t *testing.T) {
 	require.Equal(t, "v2.0.0", cfg.version)
 }
 
+func TestReleaseConfigHonorsExplicitPrerelease(t *testing.T) {
+	cfg, err := withExplicitPrerelease(
+		newReleaseConfig(projectFacts{version: "v2.0.0"}),
+		"true",
+	)
+
+	require.NoError(t, err)
+	require.True(t, cfg.isBeta)
+}
+
+func TestValidateReleaseTagRequiresExactConfiguredVersion(t *testing.T) {
+	require.NoError(t, validateReleaseTag("v2.0.0-beta.1", "v2.0.0-beta.1"))
+	require.EqualError(
+		t,
+		validateReleaseTag("v2.0.0-beta.1", ""),
+		"release tag is required",
+	)
+	require.EqualError(
+		t,
+		validateReleaseTag("v2.0.0-beta.1", "v2.0.0"),
+		`release tag "v2.0.0" does not exactly match configured version "v2.0.0-beta.1"`,
+	)
+}
+
 func TestFindReleaseAssetsUsesConfiguredDirectory(t *testing.T) {
 	artifactDir := filepath.Join(t.TempDir(), "downloaded")
 	for _, name := range []string{"luxury-yacht.dmg", "luxury-yacht.exe", "notes.txt"} {

--- a/cmd/project/release_test.go
+++ b/cmd/project/release_test.go
@@ -14,16 +14,6 @@ func TestNewReleaseConfigUsesConfiguredVersionTag(t *testing.T) {
 	require.Equal(t, "v2.0.0", cfg.version)
 }
 
-func TestReleaseConfigHonorsExplicitPrerelease(t *testing.T) {
-	cfg, err := withExplicitPrerelease(
-		newReleaseConfig(projectFacts{version: "v2.0.0"}),
-		"true",
-	)
-
-	require.NoError(t, err)
-	require.True(t, cfg.isBeta)
-}
-
 func TestValidateReleaseTagRequiresExactConfiguredVersion(t *testing.T) {
 	require.NoError(t, validateReleaseTag("v2.0.0-beta.1", "v2.0.0-beta.1"))
 	require.EqualError(

--- a/cmd/project/wails_project_contract_test.go
+++ b/cmd/project/wails_project_contract_test.go
@@ -389,11 +389,6 @@ func TestReleaseWorkflowUsesConfiguredVVersionTags(t *testing.T) {
 	require.True(t, strings.HasPrefix(strings.ToLower(metadata.Info.Version), "v"))
 }
 
-func TestReleaseWorkflowExplicitlyMarksBetaTagsAsPrereleases(t *testing.T) {
-	workflow := readTestFile(t, repositoryPath(".github", "workflows", "release.yml"))
-	require.Contains(t, workflow, `RELEASE_PRERELEASE: ${{ contains(github.ref_name, 'beta') }}`)
-}
-
 func TestReleaseWorkflowValidatesTagBeforeTestsAndBuilds(t *testing.T) {
 	workflow := readTestFile(t, repositoryPath(".github", "workflows", "release.yml"))
 	require.NotContains(t, workflow, "  validate-release:\n")

--- a/cmd/project/wails_project_contract_test.go
+++ b/cmd/project/wails_project_contract_test.go
@@ -389,6 +389,23 @@ func TestReleaseWorkflowUsesConfiguredVVersionTags(t *testing.T) {
 	require.True(t, strings.HasPrefix(strings.ToLower(metadata.Info.Version), "v"))
 }
 
+func TestReleaseWorkflowExplicitlyMarksBetaTagsAsPrereleases(t *testing.T) {
+	workflow := readTestFile(t, repositoryPath(".github", "workflows", "release.yml"))
+	require.Contains(t, workflow, `RELEASE_PRERELEASE: ${{ contains(github.ref_name, 'beta') }}`)
+}
+
+func TestReleaseWorkflowValidatesTagBeforeTestsAndBuilds(t *testing.T) {
+	workflow := readTestFile(t, repositoryPath(".github", "workflows", "release.yml"))
+	require.NotContains(t, workflow, "  validate-release:\n")
+	require.Contains(t, workflow, `RELEASE_TAG: ${{ github.ref_type == 'tag' && github.ref_name || '' }}`)
+	require.Contains(t, workflow, "go run ./cmd/project validate-release-tag")
+	require.Less(
+		t,
+		strings.Index(workflow, "      - name: Validate release tag"),
+		strings.Index(workflow, "      - name: Run tests"),
+	)
+}
+
 func TestReleaseArtifactsPreserveVersionPlatformAndArchitectureIdentity(t *testing.T) {
 	workflow := readTestFile(t, repositoryPath(".github", "workflows", "release.yml"))
 	require.Contains(t, workflow, "artifact_path: bin/*-macos-*.dmg")


### PR DESCRIPTION
- the release fails fast if the tag does not exactly match the version in config.yaml
- versions that contain `beta` will be marked as prerelease
- beta releases will skip updating the web site, so the site only offers stable releases