### PR TITLE
Log positional fixes

### DIFF
--- a/docs/workflows/logs/container-logs.md
+++ b/docs/workflows/logs/container-logs.md
@@ -24,7 +24,15 @@ Panel. They are not Application Logs and they are not Node Logs.
   changes.
 - A reconnect handshake with `reset=true` and no entries must preserve the
   existing client buffer and keep the client-visible sequence monotonic. A
-  non-empty reset payload replaces the buffer deliberately.
+  non-empty reset payload replaces the buffer when its content differs. An
+  identical reconnect snapshot preserves entry render identity so reconnecting
+  does not invalidate row measurements or move the viewport.
+- Tail-following is explicit user intent shared by raw, Pretty, and parsed
+  table views. Only a user scroll interaction may pause or resume it; stream
+  reconnects, tab visibility, row measurement, and programmatic scroll events
+  preserve the current intent. Reactivating the Logs tab positions the active
+  scroll container during layout so unchanged content cannot visibly jump or
+  expose the Resume scrolling control.
 
 ## Ownership
 

--- a/frontend/src/core/refresh/streaming/containerLogsStreamManager.test.ts
+++ b/frontend/src/core/refresh/streaming/containerLogsStreamManager.test.ts
@@ -955,6 +955,37 @@ describe('ContainerLogsStreamManager', () => {
     expect(state.data?.entries?.map((e) => e.line)).toEqual(['fresh-a', 'fresh-b']);
   });
 
+  test('applyPayload preserves render identity when a reconnect snapshot is unchanged', async () => {
+    const manager = await seedScopeWithEntries(3);
+    const previousEntries = getScopedDomainState('container-logs', SCOPE).data?.entries ?? [];
+
+    manager.applyPayload(
+      SCOPE,
+      {
+        domain: 'container-logs',
+        scope: SCOPE,
+        sequence: 1,
+        generatedAt: 2_000,
+        reset: true,
+        entries: previousEntries.map(
+          ({ timestamp, pod, container, line, isInit, isEphemeral }) => ({
+            timestamp,
+            pod,
+            container,
+            line,
+            isInit,
+            isEphemeral,
+          })
+        ),
+      },
+      'stream'
+    );
+
+    const nextEntries = getScopedDomainState('container-logs', SCOPE).data?.entries ?? [];
+    expect(nextEntries.map(({ line }) => line)).toEqual(previousEntries.map(({ line }) => line));
+    expect(nextEntries.map(({ _seq }) => _seq)).toEqual(previousEntries.map(({ _seq }) => _seq));
+  });
+
   test('applyPayload preserves truncated total across stream reconnect replacement snapshots', async () => {
     const { eventBus } = await import('@/core/events');
     const manager = await seedScopeWithEntries(5);

--- a/frontend/src/core/refresh/streaming/containerLogsStreamManager.ts
+++ b/frontend/src/core/refresh/streaming/containerLogsStreamManager.ts
@@ -435,7 +435,30 @@ export class ContainerLogsStreamManager {
     if (!reset) {
       return existing.concat(incoming);
     }
-    return incoming.length > 0 ? incoming : existing;
+    if (incoming.length === 0 || this.hasSameEntryContent(existing, incoming)) {
+      return existing;
+    }
+    return incoming;
+  }
+
+  private hasSameEntryContent(
+    existing: ContainerLogsEntry[],
+    incoming: ContainerLogsEntry[]
+  ): boolean {
+    return (
+      existing.length === incoming.length &&
+      existing.every((entry, index) => {
+        const candidate = incoming[index];
+        return (
+          entry.timestamp === candidate.timestamp &&
+          entry.pod === candidate.pod &&
+          entry.container === candidate.container &&
+          entry.line === candidate.line &&
+          entry.isInit === candidate.isInit &&
+          Boolean(entry.isEphemeral) === Boolean(candidate.isEphemeral)
+        );
+      })
+    );
   }
 
   private resolveBufferTotal(
@@ -528,11 +551,12 @@ export class ContainerLogsStreamManager {
 
   applyPayload(scope: string, payload: StreamEventPayload, mode: StreamMode): void {
     // Buffer replacement policy:
-    // - reset=true with non-empty incoming → replace the buffered entries.
-    //   For live streams, this frame is a fresh tail snapshot after a
-    //   reconnect/remount, not an authoritative total, so preserve the
-    //   larger running total instead of letting the count shrink back to
-    //   the tail size.
+    // - reset=true with non-empty incoming → preserve the existing entry
+    //   identities when its content is unchanged; otherwise replace the
+    //   buffered entries. For live streams, this frame is a fresh tail
+    //   snapshot after a reconnect/remount, not an authoritative total, so
+    //   preserve the larger running total instead of letting the count shrink
+    //   back to the tail size.
     // - reset=true with empty incoming → PRESERVE. The server emits the
     //   reset flag as part of its "new connection" handshake on every
     //   stream open, before it has had a chance to tail any lines. Wiping

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.test.tsx
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.test.tsx
@@ -1002,6 +1002,110 @@ describe('LogViewer active pod synchronisation', () => {
     expect(container.textContent).not.toContain('log line 200');
   });
 
+  it('returns a remounted Pretty view to the tail after virtualized layout measurement', async () => {
+    const originalScrollHeight = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'scrollHeight'
+    );
+    const originalClientHeight = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'clientHeight'
+    );
+    let layoutMeasured = true;
+    let nextFrameId = 1;
+    const frames = new Map<number, FrameRequestCallback>();
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      const id = nextFrameId;
+      nextFrameId += 1;
+      frames.set(id, callback);
+      return id;
+    });
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+      frames.delete(id);
+    });
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get() {
+        return this.classList.contains('logs-viewer-content') && layoutMeasured ? 1_200 : 100;
+      },
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      get() {
+        return this.classList.contains('logs-viewer-content') ? 100 : 0;
+      },
+    });
+    const flushFrames = () => {
+      const pending = [...frames.values()];
+      frames.clear();
+      for (const callback of pending) {
+        callback(0);
+      }
+    };
+
+    try {
+      const panelId = 'obj:test:pretty-remount-scroll';
+      setLogViewerPrefs(panelId, {
+        selectedContainer: '',
+        selectedFilters: [],
+        autoRefresh: true,
+        timestampMode: 'default',
+        showTimestamps: true,
+        wrapText: false,
+        textFilter: '',
+        highlightMatches: false,
+        inverseMatches: false,
+        caseSensitiveMatches: false,
+        regexMatches: false,
+        displayMode: 'pretty',
+        isParsedView: false,
+        expandedRows: [],
+        showPreviousContainerLogs: false,
+      });
+      seedLogSnapshot(
+        Array.from({ length: 200 }, (_, index) => ({
+          pod: 'web-1',
+          container: 'app',
+          line: JSON.stringify({ message: `pretty line ${index + 1}` }),
+          timestamp: `2024-05-01T10:00:${String(index % 60).padStart(2, '0')}Z`,
+          isInit: false,
+        }))
+      );
+
+      await renderViewer({ activePodNames: ['web-1'], panelId });
+      act(flushFrames);
+      act(flushFrames);
+      act(flushFrames);
+
+      await act(async () => {
+        root.render(<section>Another object-panel tab</section>);
+      });
+      layoutMeasured = false;
+      await renderViewer({ activePodNames: ['web-1'], panelId });
+      const remountedContent = await waitForElement(() =>
+        container.querySelector<HTMLDivElement>('.logs-viewer-content')
+      );
+      expect(remountedContent.scrollTop).toBe(0);
+
+      layoutMeasured = true;
+      act(flushFrames);
+
+      expect(remountedContent.scrollTop).toBeGreaterThanOrEqual(1_100);
+    } finally {
+      vi.unstubAllGlobals();
+      if (originalScrollHeight) {
+        Object.defineProperty(HTMLElement.prototype, 'scrollHeight', originalScrollHeight);
+      } else {
+        Reflect.deleteProperty(HTMLElement.prototype, 'scrollHeight');
+      }
+      if (originalClientHeight) {
+        Object.defineProperty(HTMLElement.prototype, 'clientHeight', originalClientHeight);
+      } else {
+        Reflect.deleteProperty(HTMLElement.prototype, 'clientHeight');
+      }
+    }
+  });
+
   it('freezes visible log rows while paused and resumes from a bottom overlay', async () => {
     const originalScrollHeight = Object.getOwnPropertyDescriptor(
       HTMLElement.prototype,

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.test.tsx
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.test.tsx
@@ -1145,7 +1145,10 @@ describe('LogViewer active pod synchronisation', () => {
       const content = await waitForElement(() =>
         container.querySelector<HTMLDivElement>('.logs-viewer-content')
       );
-      content.scrollTop = 100;
+      act(() => {
+        content.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY: -100 }));
+        content.scrollTop = 100;
+      });
 
       await act(async () => {
         seedLogSnapshot([entry(2), entry(3), entry(4)]);
@@ -1162,6 +1165,7 @@ describe('LogViewer active pod synchronisation', () => {
       expect(resumeButton).not.toBeNull();
 
       await act(async () => {
+        content.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY: 100 }));
         content.scrollTop = 300;
         content.dispatchEvent(new Event('scroll'));
       });
@@ -1171,6 +1175,7 @@ describe('LogViewer active pod synchronisation', () => {
       expect(container.textContent).not.toContain('anchored line 1');
 
       await act(async () => {
+        content.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY: -100 }));
         content.scrollTop = 100;
         content.dispatchEvent(new Event('scroll'));
       });
@@ -3274,5 +3279,94 @@ describe('LogViewer active pod synchronisation', () => {
       containerLogsStreamManager.stop(defaultScope, true);
       await Promise.resolve();
     });
+  });
+
+  it('keeps unchanged Pretty rows mounted across a stream reconnect', async () => {
+    const { containerLogsStreamManager } = await import(
+      '@/core/refresh/streaming/containerLogsStreamManager'
+    );
+    const panelId = 'obj:test:pretty-reconnect-identity';
+    const entries = Array.from({ length: 200 }, (_, index) => ({
+      pod: 'web-1',
+      container: 'app',
+      line: JSON.stringify({ message: `unchanged entry ${index + 1}` }),
+      timestamp: `2024-05-01T10:00:${String(index % 60).padStart(2, '0')}Z`,
+      isInit: false,
+    }));
+    setLogViewerPrefs(panelId, {
+      selectedContainer: '',
+      selectedFilters: [],
+      autoRefresh: true,
+      timestampMode: 'default',
+      showTimestamps: true,
+      wrapText: false,
+      textFilter: '',
+      highlightMatches: false,
+      inverseMatches: false,
+      caseSensitiveMatches: false,
+      regexMatches: false,
+      displayMode: 'pretty',
+      isParsedView: false,
+      expandedRows: [],
+      showPreviousContainerLogs: false,
+    });
+    containerLogsStreamManager.applyPayload(
+      defaultScope,
+      {
+        domain: 'container-logs',
+        scope: defaultScope,
+        sequence: 3,
+        generatedAt: 1_000,
+        reset: true,
+        entries,
+      },
+      'stream'
+    );
+    activeScope = defaultScope;
+
+    try {
+      await renderViewer({ activePodNames: ['web-1'], panelId });
+      const rowsBeforeReconnect = Array.from(container.querySelectorAll('.log-viewer-row'));
+      expect(rowsBeforeReconnect.length).toBeGreaterThan(0);
+      expect(rowsBeforeReconnect.length).toBeLessThan(entries.length);
+      expect(
+        container.querySelector<HTMLButtonElement>('button[aria-label="Resume scrolling"]')
+      ).toBeNull();
+
+      await renderViewer({ activePodNames: ['web-1'], panelId, isActive: false });
+      await renderViewer({ activePodNames: ['web-1'], panelId, isActive: true });
+      expect(
+        container.querySelector<HTMLButtonElement>('button[aria-label="Resume scrolling"]')
+      ).toBeNull();
+      await act(async () => {
+        containerLogsStreamManager.applyPayload(
+          defaultScope,
+          {
+            domain: 'container-logs',
+            scope: defaultScope,
+            sequence: 1,
+            generatedAt: 2_000,
+            reset: true,
+            entries,
+          },
+          'stream'
+        );
+        await Promise.resolve();
+      });
+
+      const rowsAfterReconnect = Array.from(container.querySelectorAll('.log-viewer-row'));
+      expect(rowsAfterReconnect).toHaveLength(rowsBeforeReconnect.length);
+      rowsAfterReconnect.forEach((row, index) => {
+        expect(row).toBe(rowsBeforeReconnect[index]);
+      });
+      expect(
+        container.querySelector<HTMLButtonElement>('button[aria-label="Resume scrolling"]')
+      ).toBeNull();
+    } finally {
+      await act(async () => {
+        containerLogsStreamManager.stop(defaultScope, true);
+        await Promise.resolve();
+      });
+    }
   });
 });

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.tsx
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.tsx
@@ -95,9 +95,9 @@ import { parseBracketedLogPrefix } from './logLineMetadata';
 import { buildLogSearchRegex, isValidRegexPattern } from './logSearch';
 import {
   getLogViewerPrefs,
-  getLogViewerScrollTop,
+  getLogViewerScrollPosition,
   setLogViewerPrefs,
-  setLogViewerScrollTop,
+  setLogViewerScrollPosition,
 } from './logViewerPrefsCache';
 import {
   ALL_CONTAINERS,
@@ -2483,8 +2483,8 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
     rowCount: isParsedView ? parsedContainerLogs.length : logEntries.length,
     tailFollowSignal: displayLogs,
     cacheKey: panelId,
-    getScrollTop: getLogViewerScrollTop,
-    setScrollTop: setLogViewerScrollTop,
+    getScrollPosition: getLogViewerScrollPosition,
+    setScrollPosition: setLogViewerScrollPosition,
     onTailFollowingChange: setIsTailFollowing,
   });
   const handleResumeScrolling = useCallback(() => {

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.tsx
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/LogViewer.tsx
@@ -78,7 +78,7 @@ import { containsAnsi } from './ansi';
 import { setContainerLogsStreamScopeParams } from './containerLogsStreamScopeParamsCache';
 import { useAnchoredLogEntries } from './hooks/useAnchoredLogEntries';
 import { useLogMessageRenderer } from './hooks/useLogMessageRenderer';
-import { isLogScrollAtBottom, useLogScrollRestoration } from './hooks/useLogScrollRestoration';
+import { useLogScrollRestoration } from './hooks/useLogScrollRestoration';
 import { useTerminalTheme } from './hooks/useTerminalTheme';
 import { buildCsv } from './logExport';
 import {
@@ -1407,19 +1407,6 @@ const getScopedContainerLogSnapshot = (
   ),
 });
 
-const shouldFollowCurrentLogTail = (
-  isParsedView: boolean,
-  logsContent: HTMLDivElement | null,
-  isTailFollowing: boolean
-): boolean => {
-  const activeScrollContainer = isParsedView
-    ? logsContent?.querySelector<HTMLElement>('.gridtable-wrapper')
-    : logsContent;
-  return Boolean(
-    isTailFollowing && (!activeScrollContainer || isLogScrollAtBottom(activeScrollContainer))
-  );
-};
-
 const getContainerLogDisplayError = (snapshotError: string | null | undefined): string | null => {
   if (!snapshotError || isLogDataUnavailable(snapshotError)) {
     return null;
@@ -1745,16 +1732,7 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
       showPreviousContainerLogs,
     ]
   );
-  const shouldFollowTailForCurrentRender = shouldFollowCurrentLogTail(
-    isParsedView,
-    logsContentRef.current,
-    isTailFollowing
-  );
-  const logEntries = useAnchoredLogEntries(
-    rawLogEntries,
-    shouldFollowTailForCurrentRender,
-    anchoredLogSourceKey
-  );
+  const logEntries = useAnchoredLogEntries(rawLogEntries, isTailFollowing, anchoredLogSourceKey);
   const snapshotStatus = scopedSnapshot.status;
   const snapshotError = scopedSnapshot.error;
   // sequence 1 = connected event, sequence >= 2 = initial logs received (may be empty)
@@ -2479,6 +2457,7 @@ const LogViewerInner: React.FC<LogViewerProps> = ({
 
   const { resumeTailFollowing } = useLogScrollRestoration({
     rootRef: logsContentRef,
+    isActive,
     isParsedView,
     rowCount: isParsedView ? parsedContainerLogs.length : logEntries.length,
     tailFollowSignal: displayLogs,

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/hooks/useLogScrollRestoration.test.tsx
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/hooks/useLogScrollRestoration.test.tsx
@@ -10,6 +10,7 @@ const setScrollPosition = vi.fn();
 interface HarnessProps {
   rowCount: number;
   tailFollowSignal: number;
+  isActive?: boolean;
   isParsedView?: boolean;
   scrollHeight?: number;
   showScrollContainer?: boolean;
@@ -35,9 +36,37 @@ const setScrollMetrics = (node: HTMLDivElement, scrollHeight: number, clampScrol
   }
 };
 
+const dispatchUserWheel = (node: HTMLElement, deltaY: number) => {
+  node.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY }));
+};
+
+const collapseScrollMetricsWhenDetached = (node: HTMLDivElement) => {
+  let liveScrollTop = node.scrollTop;
+  const liveScrollHeight = node.scrollHeight;
+  const liveClientHeight = node.clientHeight;
+  Object.defineProperties(node, {
+    scrollTop: {
+      configurable: true,
+      get: () => (node.isConnected ? liveScrollTop : 0),
+      set: (nextScrollTop: number) => {
+        liveScrollTop = Math.min(nextScrollTop, liveScrollHeight - liveClientHeight);
+      },
+    },
+    scrollHeight: {
+      configurable: true,
+      get: () => (node.isConnected ? liveScrollHeight : 0),
+    },
+    clientHeight: {
+      configurable: true,
+      get: () => (node.isConnected ? liveClientHeight : 0),
+    },
+  });
+};
+
 const Harness = ({
   rowCount,
   tailFollowSignal,
+  isActive = true,
   isParsedView = false,
   scrollHeight = 1_000,
   showScrollContainer = true,
@@ -50,6 +79,7 @@ const Harness = ({
     isParsedView,
     rowCount,
     tailFollowSignal,
+    isActive,
     cacheKey: 'panel-a',
     getScrollPosition,
     setScrollPosition,
@@ -170,8 +200,11 @@ describe('useLogScrollRestoration', () => {
       root.render(<Harness rowCount={2} tailFollowSignal={2} />);
     });
 
-    scrollElement.scrollTop = 300;
-    scrollElement.dispatchEvent(new Event('scroll'));
+    act(() => {
+      dispatchUserWheel(scrollElement, -100);
+      scrollElement.scrollTop = 300;
+      scrollElement.dispatchEvent(new Event('scroll'));
+    });
     act(flushFrames);
 
     expect(scrollElement.scrollTop).toBe(300);
@@ -186,7 +219,10 @@ describe('useLogScrollRestoration', () => {
     const scrollElement = container.firstElementChild as HTMLDivElement;
     expect(scrollElement.scrollTop).toBe(1_000);
 
-    scrollElement.scrollTop = 300;
+    act(() => {
+      dispatchUserWheel(scrollElement, -100);
+      scrollElement.scrollTop = 300;
+    });
     await act(async () => {
       root.render(<Harness rowCount={2} tailFollowSignal={2} />);
     });
@@ -210,6 +246,109 @@ describe('useLogScrollRestoration', () => {
     act(flushFrames);
 
     expect(scrollElement.scrollTop).toBe(1_200);
+  });
+
+  it.each([
+    { isParsedView: false, view: 'text' },
+    { isParsedView: true, view: 'table' },
+  ])(
+    'does not pause $view tail-following when inactive layout changes scroll position',
+    async ({ isParsedView }) => {
+      await act(async () => {
+        root.render(
+          <Harness rowCount={200} tailFollowSignal={1} clampScrollTop isParsedView={isParsedView} />
+        );
+      });
+      act(flushFrames);
+
+      const scrollElement = isParsedView
+        ? container.querySelector<HTMLDivElement>('.gridtable-wrapper')
+        : (container.firstElementChild as HTMLDivElement);
+      expect(scrollElement).not.toBeNull();
+      if (!scrollElement) {
+        return;
+      }
+      expect(scrollElement.scrollTop).toBe(900);
+
+      await act(async () => {
+        root.render(
+          <Harness
+            rowCount={200}
+            tailFollowSignal={1}
+            clampScrollTop
+            isActive={false}
+            isParsedView={isParsedView}
+          />
+        );
+      });
+      act(() => {
+        scrollElement.scrollTop = 300;
+        scrollElement.dispatchEvent(new Event('scroll'));
+      });
+
+      expect(
+        container.querySelector<HTMLOutputElement>('[data-testid="tail-follow-state"]')?.textContent
+      ).toBe('following');
+
+      await act(async () => {
+        root.render(
+          <Harness rowCount={200} tailFollowSignal={1} clampScrollTop isParsedView={isParsedView} />
+        );
+      });
+
+      expect(scrollElement.scrollTop).toBe(900);
+    }
+  );
+
+  it('positions a newly selected table view at the followed tail before the next frame', async () => {
+    await act(async () => {
+      root.render(<Harness rowCount={200} tailFollowSignal={1} clampScrollTop />);
+    });
+    act(flushFrames);
+
+    await act(async () => {
+      root.render(<Harness rowCount={200} tailFollowSignal={1} clampScrollTop isParsedView />);
+    });
+
+    const tableScrollElement = container.querySelector<HTMLDivElement>('.gridtable-wrapper');
+    expect(tableScrollElement?.scrollTop).toBe(900);
+  });
+
+  it.each([
+    { isParsedView: false, view: 'text' },
+    { isParsedView: true, view: 'table' },
+  ])('does not treat an active $view layout scroll as user intent', async ({ isParsedView }) => {
+    await act(async () => {
+      root.render(
+        <Harness rowCount={200} tailFollowSignal={1} clampScrollTop isParsedView={isParsedView} />
+      );
+    });
+    act(flushFrames);
+
+    const scrollElement = isParsedView
+      ? container.querySelector<HTMLDivElement>('.gridtable-wrapper')
+      : (container.firstElementChild as HTMLDivElement);
+    expect(scrollElement).not.toBeNull();
+    if (!scrollElement) {
+      return;
+    }
+
+    act(() => {
+      scrollElement.scrollTop = 300;
+      scrollElement.dispatchEvent(new Event('scroll'));
+    });
+    expect(
+      container.querySelector<HTMLOutputElement>('[data-testid="tail-follow-state"]')?.textContent
+    ).toBe('following');
+
+    await act(async () => {
+      root.render(
+        <Harness rowCount={200} tailFollowSignal={2} clampScrollTop isParsedView={isParsedView} />
+      );
+    });
+    act(flushFrames);
+
+    expect(scrollElement.scrollTop).toBe(900);
   });
 
   it('keeps the initial tail pinned while virtualized row measurement grows the content', async () => {
@@ -295,8 +434,11 @@ describe('useLogScrollRestoration', () => {
 
     const scrollElement = container.firstElementChild as HTMLDivElement;
     flushFramesUntilIdle(20);
-    scrollElement.scrollTop = 300;
-    scrollElement.dispatchEvent(new Event('scroll'));
+    act(() => {
+      dispatchUserWheel(scrollElement, -100);
+      scrollElement.scrollTop = 300;
+      scrollElement.dispatchEvent(new Event('scroll'));
+    });
 
     Object.defineProperty(scrollElement, 'scrollHeight', {
       configurable: true,
@@ -410,8 +552,11 @@ describe('useLogScrollRestoration', () => {
     act(flushFrames);
 
     const initialScrollElement = container.firstElementChild as HTMLDivElement;
-    initialScrollElement.scrollTop = 300;
-    initialScrollElement.dispatchEvent(new Event('scroll'));
+    act(() => {
+      dispatchUserWheel(initialScrollElement, -100);
+      initialScrollElement.scrollTop = 300;
+      initialScrollElement.dispatchEvent(new Event('scroll'));
+    });
     expect(cachedPosition).toEqual({ scrollTop: 300, isTailFollowing: false });
 
     await act(async () => {
@@ -431,6 +576,37 @@ describe('useLogScrollRestoration', () => {
     ).toBe('paused');
   });
 
+  it('does not replace a manual position with detached zero metrics during unmount', async () => {
+    let cachedPosition: LogScrollPosition | undefined;
+    getScrollPosition.mockImplementation(() => cachedPosition);
+    setScrollPosition.mockImplementation((_cacheKey, position: LogScrollPosition) => {
+      cachedPosition = position;
+    });
+
+    await act(async () => {
+      root.render(
+        <Harness rowCount={200} tailFollowSignal={1} scrollHeight={1_000} clampScrollTop />
+      );
+    });
+    act(flushFrames);
+
+    const scrollElement = container.firstElementChild as HTMLDivElement;
+    collapseScrollMetricsWhenDetached(scrollElement);
+    act(() => {
+      dispatchUserWheel(scrollElement, -100);
+      scrollElement.scrollTop = 300;
+      scrollElement.dispatchEvent(new Event('scroll'));
+    });
+    expect(cachedPosition).toEqual({ scrollTop: 300, isTailFollowing: false });
+
+    await act(async () => {
+      root.render(<section>Another object-panel tab</section>);
+    });
+
+    expect(scrollElement.isConnected).toBe(false);
+    expect(cachedPosition).toEqual({ scrollTop: 300, isTailFollowing: false });
+  });
+
   it('persists reaching the tail when the Logs tab unmounts before the scroll event', async () => {
     let cachedPosition: LogScrollPosition | undefined = {
       scrollTop: 300,
@@ -447,11 +623,18 @@ describe('useLogScrollRestoration', () => {
       );
     });
     const initialScrollElement = container.firstElementChild as HTMLDivElement;
-    initialScrollElement.scrollTop = 900;
+    collapseScrollMetricsWhenDetached(initialScrollElement);
+    act(() => {
+      dispatchUserWheel(initialScrollElement, 100);
+      initialScrollElement.scrollTop = 900;
+    });
 
     await act(async () => {
       root.render(<section>Another object-panel tab</section>);
     });
+    expect(initialScrollElement.isConnected).toBe(false);
+    expect(cachedPosition).toEqual({ scrollTop: 900, isTailFollowing: true });
+
     await act(async () => {
       root.render(
         <Harness rowCount={210} tailFollowSignal={2} scrollHeight={1_200} clampScrollTop />
@@ -474,12 +657,16 @@ describe('useLogScrollRestoration', () => {
       container.querySelector<HTMLOutputElement>('[data-testid="tail-follow-state"]')?.textContent;
 
     await act(async () => {
+      dispatchUserWheel(scrollElement, -100);
       scrollElement.scrollTop = 300;
       scrollElement.dispatchEvent(new Event('scroll'));
     });
     expect(tailFollowState()).toBe('paused');
 
-    scrollElement.scrollTop = 900;
+    act(() => {
+      dispatchUserWheel(scrollElement, 100);
+      scrollElement.scrollTop = 900;
+    });
     await act(async () => {
       root.render(<Harness rowCount={2} tailFollowSignal={2} scrollHeight={1_200} />);
     });
@@ -501,6 +688,7 @@ describe('useLogScrollRestoration', () => {
 
     const scrollElement = container.firstElementChild as HTMLDivElement;
     await act(async () => {
+      dispatchUserWheel(scrollElement, -100);
       scrollElement.scrollTop = 300;
       scrollElement.dispatchEvent(new Event('scroll'));
     });
@@ -531,8 +719,11 @@ describe('useLogScrollRestoration', () => {
       return;
     }
 
-    scrollElement.scrollTop = 300;
-    scrollElement.dispatchEvent(new Event('scroll'));
+    act(() => {
+      dispatchUserWheel(scrollElement, -100);
+      scrollElement.scrollTop = 300;
+      scrollElement.dispatchEvent(new Event('scroll'));
+    });
     act(flushFrames);
 
     expect(frames.size).toBe(0);

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/hooks/useLogScrollRestoration.test.tsx
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/hooks/useLogScrollRestoration.test.tsx
@@ -1,10 +1,11 @@
 import { act, useRef, useState } from 'react';
 import * as ReactDOM from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { LogScrollPosition } from '../../types';
 import { useLogScrollRestoration } from './useLogScrollRestoration';
 
-const getScrollTop = vi.fn(() => undefined);
-const setScrollTop = vi.fn();
+const getScrollPosition = vi.fn<() => LogScrollPosition | undefined>(() => undefined);
+const setScrollPosition = vi.fn();
 
 interface HarnessProps {
   rowCount: number;
@@ -12,11 +13,26 @@ interface HarnessProps {
   isParsedView?: boolean;
   scrollHeight?: number;
   showScrollContainer?: boolean;
+  clampScrollTop?: boolean;
 }
 
-const setScrollMetrics = (node: HTMLDivElement, scrollHeight: number) => {
+const setScrollMetrics = (node: HTMLDivElement, scrollHeight: number, clampScrollTop = false) => {
   Object.defineProperty(node, 'scrollHeight', { configurable: true, value: scrollHeight });
   Object.defineProperty(node, 'clientHeight', { configurable: true, value: 100 });
+  if (clampScrollTop) {
+    if (Object.getOwnPropertyDescriptor(node, 'scrollTop') === undefined) {
+      let scrollTop = 0;
+      Object.defineProperty(node, 'scrollTop', {
+        configurable: true,
+        get: () => scrollTop,
+        set: (nextScrollTop: number) => {
+          scrollTop = Math.min(nextScrollTop, node.scrollHeight - node.clientHeight);
+        },
+      });
+    }
+    const clampedScrollTop = node.scrollTop;
+    node.scrollTop = clampedScrollTop;
+  }
 };
 
 const Harness = ({
@@ -25,6 +41,7 @@ const Harness = ({
   isParsedView = false,
   scrollHeight = 1_000,
   showScrollContainer = true,
+  clampScrollTop = false,
 }: HarnessProps) => {
   const rootRef = useRef<HTMLDivElement>(null);
   const [isTailFollowing, setIsTailFollowing] = useState(true);
@@ -34,8 +51,8 @@ const Harness = ({
     rowCount,
     tailFollowSignal,
     cacheKey: 'panel-a',
-    getScrollTop,
-    setScrollTop,
+    getScrollPosition,
+    setScrollPosition,
     onTailFollowingChange: setIsTailFollowing,
   });
 
@@ -46,7 +63,7 @@ const Harness = ({
           ref={(node) => {
             rootRef.current = node;
             if (node && !isParsedView) {
-              setScrollMetrics(node, scrollHeight);
+              setScrollMetrics(node, scrollHeight, clampScrollTop);
             }
           }}
         >
@@ -55,11 +72,13 @@ const Harness = ({
               className="gridtable-wrapper"
               ref={(node) => {
                 if (node) {
-                  setScrollMetrics(node, scrollHeight);
+                  setScrollMetrics(node, scrollHeight, clampScrollTop);
                 }
               }}
             />
-          ) : null}
+          ) : (
+            <div className="logs-viewer-text" />
+          )}
         </div>
       ) : null}
       <output data-testid="tail-follow-state">{isTailFollowing ? 'following' : 'paused'}</output>
@@ -93,7 +112,7 @@ describe('useLogScrollRestoration', () => {
     await act(async () => root.unmount());
     container.remove();
     vi.unstubAllGlobals();
-    vi.clearAllMocks();
+    vi.resetAllMocks();
   });
 
   const flushFrames = () => {
@@ -102,6 +121,40 @@ describe('useLogScrollRestoration', () => {
     for (const callback of pending) {
       callback(0);
     }
+  };
+
+  const flushFramesUntilIdle = (maxGenerations: number): number => {
+    let generations = 0;
+    while (frames.size > 0 && generations < maxGenerations) {
+      flushFrames();
+      generations += 1;
+    }
+    return generations;
+  };
+
+  const stubResizeObserver = (): Array<() => void> => {
+    const resizeCallbacks: Array<() => void> = [];
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        constructor(callback: ResizeObserverCallback) {
+          resizeCallbacks.push(() => callback([], this as unknown as ResizeObserver));
+        }
+
+        observe() {
+          // Resize delivery is triggered explicitly by each test.
+        }
+
+        unobserve() {
+          // Resize delivery is triggered explicitly by each test.
+        }
+
+        disconnect() {
+          // Resize delivery is triggered explicitly by each test.
+        }
+      }
+    );
+    return resizeCallbacks;
   };
 
   it('preserves a manual scroll that interrupts queued tail-following', async () => {
@@ -157,6 +210,257 @@ describe('useLogScrollRestoration', () => {
     act(flushFrames);
 
     expect(scrollElement.scrollTop).toBe(1_200);
+  });
+
+  it('keeps the initial tail pinned while virtualized row measurement grows the content', async () => {
+    await act(async () => {
+      root.render(<Harness rowCount={200} tailFollowSignal={1} clampScrollTop />);
+    });
+
+    const scrollElement = container.firstElementChild as HTMLDivElement;
+    act(flushFrames);
+    expect(scrollElement.scrollTop).toBe(900);
+
+    Object.defineProperty(scrollElement, 'scrollHeight', {
+      configurable: true,
+      value: 1_200,
+    });
+    act(flushFrames);
+
+    expect(scrollElement.scrollTop).toBe(1_100);
+  });
+
+  it('stops scheduling frames after the scrollable layout stabilizes', async () => {
+    await act(async () => {
+      root.render(<Harness rowCount={200} tailFollowSignal={1} clampScrollTop />);
+    });
+
+    const generations = flushFramesUntilIdle(20);
+
+    expect(generations).toBe(3);
+    expect(frames.size).toBe(0);
+  });
+
+  it('stops scheduling frames when the layout never stabilizes', async () => {
+    await act(async () => {
+      root.render(<Harness rowCount={200} tailFollowSignal={1} clampScrollTop />);
+    });
+
+    const scrollElement = container.firstElementChild as HTMLDivElement;
+    let changingScrollHeight = 1_000;
+    Object.defineProperty(scrollElement, 'scrollHeight', {
+      configurable: true,
+      get: () => {
+        changingScrollHeight += 1;
+        return changingScrollHeight;
+      },
+    });
+
+    const generations = flushFramesUntilIdle(20);
+
+    expect(generations).toBe(20);
+    expect(frames.size).toBe(0);
+  });
+
+  it('follows Pretty layout growth after the frame-settling window has ended', async () => {
+    const resizeCallbacks = stubResizeObserver();
+    await act(async () => {
+      root.render(<Harness rowCount={200} tailFollowSignal={1} clampScrollTop />);
+    });
+
+    const scrollElement = container.firstElementChild as HTMLDivElement;
+    flushFramesUntilIdle(20);
+    expect(scrollElement.scrollTop).toBe(900);
+    expect(frames.size).toBe(0);
+
+    Object.defineProperty(scrollElement, 'scrollHeight', {
+      configurable: true,
+      value: 1_200,
+    });
+    act(() => {
+      for (const callback of resizeCallbacks) {
+        callback();
+      }
+      flushFrames();
+    });
+
+    expect(scrollElement.scrollTop).toBe(1_100);
+  });
+
+  it('does not follow late layout growth after the user scrolls away from the tail', async () => {
+    const resizeCallbacks = stubResizeObserver();
+    await act(async () => {
+      root.render(<Harness rowCount={200} tailFollowSignal={1} clampScrollTop />);
+    });
+
+    const scrollElement = container.firstElementChild as HTMLDivElement;
+    flushFramesUntilIdle(20);
+    scrollElement.scrollTop = 300;
+    scrollElement.dispatchEvent(new Event('scroll'));
+
+    Object.defineProperty(scrollElement, 'scrollHeight', {
+      configurable: true,
+      value: 1_200,
+    });
+    act(() => {
+      for (const callback of resizeCallbacks) {
+        callback();
+      }
+      flushFrames();
+    });
+
+    expect(scrollElement.scrollTop).toBe(300);
+  });
+
+  it('treats content shorter than the viewport as settled', async () => {
+    await act(async () => {
+      root.render(<Harness rowCount={200} tailFollowSignal={1} clampScrollTop />);
+    });
+    flushFramesUntilIdle(20);
+
+    await act(async () => {
+      root.render(<Harness rowCount={20} tailFollowSignal={2} scrollHeight={100} clampScrollTop />);
+    });
+    expect(frames.size).toBe(1);
+
+    act(flushFrames);
+
+    expect(frames.size).toBe(0);
+  });
+
+  it('waits for the Pretty layout to become scrollable after the Logs tab remounts', async () => {
+    getScrollPosition.mockReturnValue({ scrollTop: 900, isTailFollowing: true });
+    await act(async () => {
+      root.render(<section>Another object-panel tab</section>);
+    });
+    await act(async () => {
+      root.render(
+        <Harness rowCount={200} tailFollowSignal={1} scrollHeight={100} clampScrollTop />
+      );
+    });
+
+    const scrollElement = container.firstElementChild as HTMLDivElement;
+    Object.defineProperty(scrollElement, 'scrollHeight', {
+      configurable: true,
+      value: 1_200,
+    });
+    act(flushFrames);
+
+    expect(scrollElement.scrollTop).toBe(1_100);
+  });
+
+  it('stops waiting when a remounted layout never becomes scrollable', async () => {
+    getScrollPosition.mockReturnValue({ scrollTop: 900, isTailFollowing: true });
+    await act(async () => {
+      root.render(
+        <Harness rowCount={200} tailFollowSignal={1} scrollHeight={100} clampScrollTop />
+      );
+    });
+
+    const generations = flushFramesUntilIdle(20);
+
+    expect(generations).toBe(20);
+    expect(frames.size).toBe(0);
+  });
+
+  it('returns to the current tail after the Logs tab unmounts while tail-following', async () => {
+    let cachedPosition: LogScrollPosition | undefined;
+    getScrollPosition.mockImplementation(() => cachedPosition);
+    setScrollPosition.mockImplementation((_cacheKey, position: LogScrollPosition) => {
+      cachedPosition = position;
+    });
+
+    await act(async () => {
+      root.render(
+        <Harness rowCount={200} tailFollowSignal={1} scrollHeight={1_000} clampScrollTop />
+      );
+    });
+    act(flushFrames);
+
+    const initialScrollElement = container.firstElementChild as HTMLDivElement;
+    initialScrollElement.dispatchEvent(new Event('scroll'));
+    expect(cachedPosition).toEqual({ scrollTop: 900, isTailFollowing: true });
+
+    await act(async () => {
+      root.render(<section>Another object-panel tab</section>);
+    });
+    await act(async () => {
+      root.render(
+        <Harness rowCount={210} tailFollowSignal={2} scrollHeight={1_200} clampScrollTop />
+      );
+    });
+    act(flushFrames);
+
+    const remountedScrollElement = container.firstElementChild as HTMLDivElement;
+    expect(remountedScrollElement.scrollTop).toBe(1_100);
+  });
+
+  it('restores a manual position after the Logs tab unmounts', async () => {
+    let cachedPosition: LogScrollPosition | undefined;
+    getScrollPosition.mockImplementation(() => cachedPosition);
+    setScrollPosition.mockImplementation((_cacheKey, position: LogScrollPosition) => {
+      cachedPosition = position;
+    });
+
+    await act(async () => {
+      root.render(
+        <Harness rowCount={200} tailFollowSignal={1} scrollHeight={1_000} clampScrollTop />
+      );
+    });
+    act(flushFrames);
+
+    const initialScrollElement = container.firstElementChild as HTMLDivElement;
+    initialScrollElement.scrollTop = 300;
+    initialScrollElement.dispatchEvent(new Event('scroll'));
+    expect(cachedPosition).toEqual({ scrollTop: 300, isTailFollowing: false });
+
+    await act(async () => {
+      root.render(<section>Another object-panel tab</section>);
+    });
+    await act(async () => {
+      root.render(
+        <Harness rowCount={210} tailFollowSignal={2} scrollHeight={1_200} clampScrollTop />
+      );
+    });
+    act(flushFrames);
+
+    const remountedScrollElement = container.firstElementChild as HTMLDivElement;
+    expect(remountedScrollElement.scrollTop).toBe(300);
+    expect(
+      container.querySelector<HTMLOutputElement>('[data-testid="tail-follow-state"]')?.textContent
+    ).toBe('paused');
+  });
+
+  it('persists reaching the tail when the Logs tab unmounts before the scroll event', async () => {
+    let cachedPosition: LogScrollPosition | undefined = {
+      scrollTop: 300,
+      isTailFollowing: false,
+    };
+    getScrollPosition.mockImplementation(() => cachedPosition);
+    setScrollPosition.mockImplementation((_cacheKey, position: LogScrollPosition) => {
+      cachedPosition = position;
+    });
+
+    await act(async () => {
+      root.render(
+        <Harness rowCount={200} tailFollowSignal={1} scrollHeight={1_000} clampScrollTop />
+      );
+    });
+    const initialScrollElement = container.firstElementChild as HTMLDivElement;
+    initialScrollElement.scrollTop = 900;
+
+    await act(async () => {
+      root.render(<section>Another object-panel tab</section>);
+    });
+    await act(async () => {
+      root.render(
+        <Harness rowCount={210} tailFollowSignal={2} scrollHeight={1_200} clampScrollTop />
+      );
+    });
+    act(flushFrames);
+
+    const remountedScrollElement = container.firstElementChild as HTMLDivElement;
+    expect(remountedScrollElement.scrollTop).toBe(1_100);
   });
 
   it('resumes when the user reaches the prior bottom before refresh extends it', async () => {

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/hooks/useLogScrollRestoration.ts
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/hooks/useLogScrollRestoration.ts
@@ -1,4 +1,5 @@
 import { type RefObject, useCallback, useEffect, useRef } from 'react';
+import type { LogScrollPosition } from '../../types';
 
 interface LogScrollRestorationOptions {
   rootRef: RefObject<HTMLElement | null>;
@@ -6,13 +7,17 @@ interface LogScrollRestorationOptions {
   rowCount: number;
   tailFollowSignal: unknown;
   cacheKey: string;
-  getScrollTop: (cacheKey: string) => number | undefined;
-  setScrollTop: (cacheKey: string, scrollTop: number) => void;
+  getScrollPosition: (cacheKey: string) => LogScrollPosition | undefined;
+  setScrollPosition: (cacheKey: string, position: LogScrollPosition) => void;
   forceTailOnNextRestore?: boolean;
   onTailFollowingChange?: (isTailFollowing: boolean) => void;
 }
 
 const AT_BOTTOM_THRESHOLD_PX = 16;
+const MAX_LAYOUT_SETTLE_FRAMES = 20;
+// Virtualized rows are measured only after the first bottom jump renders them.
+// Wait for consecutive stable frames so their real height cannot strand the viewport above the tail.
+const REQUIRED_STABLE_LAYOUT_FRAMES = 2;
 
 interface KnownScrollPosition {
   element: HTMLElement;
@@ -45,8 +50,8 @@ export const useLogScrollRestoration = ({
   rowCount,
   tailFollowSignal,
   cacheKey,
-  getScrollTop,
-  setScrollTop,
+  getScrollPosition,
+  setScrollPosition,
   forceTailOnNextRestore = false,
   onTailFollowingChange,
 }: LogScrollRestorationOptions) => {
@@ -105,7 +110,7 @@ export const useLogScrollRestoration = ({
       return;
     }
 
-    const handler = () => {
+    const captureAndPersistPosition = () => {
       const knownPosition = knownScrollPositionRef.current;
       const shouldFollowTail =
         isLogScrollAtBottom(scrollEl) ||
@@ -118,42 +123,51 @@ export const useLogScrollRestoration = ({
       if (!scrollRestoredRef.current) {
         return;
       }
-      setScrollTop(cacheKey, scrollEl.scrollTop);
+      setScrollPosition(cacheKey, {
+        scrollTop: scrollEl.scrollTop,
+        isTailFollowing: shouldFollowTail,
+      });
     };
+    const handler = () => captureAndPersistPosition();
 
     scrollEl.addEventListener('scroll', handler, { passive: true });
     return () => {
       scrollEl.removeEventListener('scroll', handler);
+      captureAndPersistPosition();
     };
-  }, [cacheKey, getScrollContainer, rowCount, setScrollTop, setTailFollowing]);
+  }, [cacheKey, getScrollContainer, rowCount, setScrollPosition, setTailFollowing]);
 
-  useEffect(() => {
+  const restoreScrollPosition = useCallback((): boolean => {
     if (scrollRestoredRef.current || rowCount === 0) {
-      return;
+      return scrollRestoredRef.current;
     }
 
     const scrollEl = getScrollContainer();
     if (!scrollEl || scrollEl.scrollHeight <= scrollEl.clientHeight) {
-      return;
+      return false;
     }
 
     const maxScrollTop = scrollEl.scrollHeight - scrollEl.clientHeight;
-    const savedScrollTop = forceTailRestoreRef.current ? undefined : getScrollTop(cacheKey);
-    const targetScrollTop =
-      savedScrollTop !== null && savedScrollTop !== undefined
-        ? Math.min(savedScrollTop, maxScrollTop)
-        : maxScrollTop;
+    const savedPosition = forceTailRestoreRef.current ? undefined : getScrollPosition(cacheKey);
+    const targetScrollTop = savedPosition?.isTailFollowing
+      ? maxScrollTop
+      : Math.min(savedPosition?.scrollTop ?? maxScrollTop, maxScrollTop);
 
     scrollEl.scrollTop = targetScrollTop;
     knownScrollPositionRef.current = captureScrollPosition(scrollEl);
     setTailFollowing(isLogScrollAtBottom(scrollEl));
     scrollRestoredRef.current = true;
     forceTailRestoreRef.current = false;
-  }, [cacheKey, getScrollContainer, getScrollTop, rowCount, setTailFollowing]);
+    return true;
+  }, [cacheKey, getScrollContainer, getScrollPosition, rowCount, setTailFollowing]);
 
   useEffect(() => {
     void rowCount;
     void tailFollowSignal;
+    if (rowCount === 0) {
+      return;
+    }
+
     const shouldFollowTail = () => {
       const element = getScrollContainer();
       if (!element || !scrollRestoredRef.current) {
@@ -172,17 +186,22 @@ export const useLogScrollRestoration = ({
       knownScrollPositionRef.current = captureScrollPosition(element);
       return wasAtBottomRef.current;
     };
-    if (!shouldFollowTail()) {
-      return;
-    }
-
-    const scrollEl = getScrollContainer();
-    if (!scrollEl) {
+    if (restoreScrollPosition() && !shouldFollowTail()) {
       return;
     }
 
     let rafId: number | undefined;
-    const scrollToBottom = () => {
+    let attempts = 0;
+    let previousScrollHeight: number | undefined;
+    let stableLayoutFrames = 0;
+    const scrollToSettledBottom = () => {
+      if (!restoreScrollPosition()) {
+        attempts += 1;
+        if (attempts < MAX_LAYOUT_SETTLE_FRAMES) {
+          rafId = requestAnimationFrame(scrollToSettledBottom);
+        }
+        return;
+      }
       if (!shouldFollowTail()) {
         return;
       }
@@ -190,36 +209,82 @@ export const useLogScrollRestoration = ({
       if (!element) {
         return;
       }
-      element.scrollTop = element.scrollHeight;
+      const currentScrollHeight = element.scrollHeight;
+      if (currentScrollHeight <= element.clientHeight) {
+        knownScrollPositionRef.current = captureScrollPosition(element);
+        return;
+      }
+      element.scrollTop = currentScrollHeight;
       knownScrollPositionRef.current = captureScrollPosition(element);
+      stableLayoutFrames =
+        previousScrollHeight === currentScrollHeight && isLogScrollAtBottom(element)
+          ? stableLayoutFrames + 1
+          : 0;
+      previousScrollHeight = currentScrollHeight;
+      attempts += 1;
+      if (
+        attempts < MAX_LAYOUT_SETTLE_FRAMES &&
+        stableLayoutFrames < REQUIRED_STABLE_LAYOUT_FRAMES
+      ) {
+        rafId = requestAnimationFrame(scrollToSettledBottom);
+      }
     };
 
-    if (isParsedView) {
-      let attempts = 0;
-      const maxAttempts = 20;
-      const checkAndScroll = () => {
-        if (!shouldFollowTail()) {
-          return;
-        }
-        const element = getScrollContainer();
-        if (element && element.scrollHeight > element.clientHeight) {
-          rafId = requestAnimationFrame(scrollToBottom);
-        } else if (attempts < maxAttempts) {
-          attempts += 1;
-          rafId = requestAnimationFrame(checkAndScroll);
-        }
-      };
-      rafId = requestAnimationFrame(checkAndScroll);
-    } else {
-      rafId = requestAnimationFrame(scrollToBottom);
-    }
+    rafId = requestAnimationFrame(scrollToSettledBottom);
 
     return () => {
       if (rafId !== undefined) {
         cancelAnimationFrame(rafId);
       }
     };
-  }, [getScrollContainer, isParsedView, tailFollowSignal, rowCount, setTailFollowing]);
+  }, [getScrollContainer, restoreScrollPosition, tailFollowSignal, rowCount, setTailFollowing]);
+
+  useEffect(() => {
+    void rowCount;
+    const scrollEl = getScrollContainer();
+    if (!scrollEl || typeof ResizeObserver === 'undefined') {
+      return;
+    }
+
+    let layoutRafId: number | undefined;
+    const observer = new ResizeObserver(() => {
+      if (layoutRafId !== undefined) {
+        return;
+      }
+      layoutRafId = requestAnimationFrame(() => {
+        layoutRafId = undefined;
+        if (!restoreScrollPosition() || !wasAtBottomRef.current) {
+          return;
+        }
+        const element = getScrollContainer();
+        if (!element) {
+          return;
+        }
+        element.scrollTop = element.scrollHeight;
+        knownScrollPositionRef.current = captureScrollPosition(element);
+        setScrollPosition(cacheKey, {
+          scrollTop: element.scrollTop,
+          isTailFollowing: true,
+        });
+      });
+    });
+
+    const layoutElements = Array.from(scrollEl.children);
+    if (layoutElements.length === 0) {
+      observer.observe(scrollEl);
+    } else {
+      for (const element of layoutElements) {
+        observer.observe(element);
+      }
+    }
+
+    return () => {
+      observer.disconnect();
+      if (layoutRafId !== undefined) {
+        cancelAnimationFrame(layoutRafId);
+      }
+    };
+  }, [cacheKey, getScrollContainer, restoreScrollPosition, rowCount, setScrollPosition]);
 
   const resumeTailFollowing = useCallback(() => {
     const scrollEl = getScrollContainer();
@@ -229,9 +294,12 @@ export const useLogScrollRestoration = ({
     scrollEl.scrollTop = scrollEl.scrollHeight;
     knownScrollPositionRef.current = captureScrollPosition(scrollEl);
     scrollRestoredRef.current = true;
-    setScrollTop(cacheKey, scrollEl.scrollTop);
+    setScrollPosition(cacheKey, {
+      scrollTop: scrollEl.scrollTop,
+      isTailFollowing: true,
+    });
     setTailFollowing(true);
-  }, [cacheKey, getScrollContainer, setScrollTop, setTailFollowing]);
+  }, [cacheKey, getScrollContainer, setScrollPosition, setTailFollowing]);
 
   return { getScrollContainer, resetScrollRestoration, resumeTailFollowing };
 };

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/hooks/useLogScrollRestoration.ts
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/hooks/useLogScrollRestoration.ts
@@ -1,8 +1,9 @@
-import { type RefObject, useCallback, useEffect, useRef } from 'react';
+import { type RefObject, useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 import type { LogScrollPosition } from '../../types';
 
 interface LogScrollRestorationOptions {
   rootRef: RefObject<HTMLElement | null>;
+  isActive?: boolean;
   isParsedView: boolean;
   rowCount: number;
   tailFollowSignal: unknown;
@@ -15,6 +16,7 @@ interface LogScrollRestorationOptions {
 
 const AT_BOTTOM_THRESHOLD_PX = 16;
 const MAX_LAYOUT_SETTLE_FRAMES = 20;
+const USER_SCROLL_GESTURE_WINDOW_MS = 500;
 // Virtualized rows are measured only after the first bottom jump renders them.
 // Wait for consecutive stable frames so their real height cannot strand the viewport above the tail.
 const REQUIRED_STABLE_LAYOUT_FRAMES = 2;
@@ -25,7 +27,7 @@ interface KnownScrollPosition {
   scrollHeight: number;
 }
 
-export const isLogScrollAtBottom = (scrollElement: HTMLElement): boolean =>
+const isLogScrollAtBottom = (scrollElement: HTMLElement): boolean =>
   scrollElement.scrollTop + scrollElement.clientHeight >=
   scrollElement.scrollHeight - AT_BOTTOM_THRESHOLD_PX;
 
@@ -44,8 +46,29 @@ const reachedKnownBottom = (
   scrollElement.scrollTop + scrollElement.clientHeight >=
     knownPosition.scrollHeight - AT_BOTTOM_THRESHOLD_PX;
 
+const shouldFollowTailAfterUserScroll = (
+  scrollElement: HTMLElement,
+  knownPosition: KnownScrollPosition | null,
+  isTailFollowing: boolean
+): boolean =>
+  isLogScrollAtBottom(scrollElement) ||
+  reachedKnownBottom(scrollElement, knownPosition) ||
+  (isTailFollowing &&
+    knownPosition?.element === scrollElement &&
+    knownPosition.scrollTop === scrollElement.scrollTop);
+
+const isScrollKey = (event: KeyboardEvent): boolean =>
+  ['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End', ' ', 'Spacebar'].includes(
+    event.key
+  );
+
+const isUpwardScrollKey = (event: KeyboardEvent): boolean =>
+  ['ArrowUp', 'PageUp', 'Home'].includes(event.key) ||
+  ((event.key === ' ' || event.key === 'Spacebar') && event.shiftKey);
+
 export const useLogScrollRestoration = ({
   rootRef,
+  isActive = true,
   isParsedView,
   rowCount,
   tailFollowSignal,
@@ -56,17 +79,20 @@ export const useLogScrollRestoration = ({
   onTailFollowingChange,
 }: LogScrollRestorationOptions) => {
   const scrollRestoredRef = useRef(false);
-  const wasAtBottomRef = useRef(true);
+  const isTailFollowingRef = useRef(true);
   const knownScrollPositionRef = useRef<KnownScrollPosition | null>(null);
   const forceTailRestoreRef = useRef(forceTailOnNextRestore);
   const previousCacheKeyRef = useRef(cacheKey);
+  const previousIsActiveRef = useRef(isActive);
+  const pointerScrollActiveRef = useRef(false);
+  const userScrollGestureDeadlineRef = useRef(0);
 
   const setTailFollowing = useCallback(
     (isTailFollowing: boolean) => {
-      if (wasAtBottomRef.current === isTailFollowing) {
+      if (isTailFollowingRef.current === isTailFollowing) {
         return;
       }
-      wasAtBottomRef.current = isTailFollowing;
+      isTailFollowingRef.current = isTailFollowing;
       onTailFollowingChange?.(isTailFollowing);
     },
     [onTailFollowingChange]
@@ -101,43 +127,119 @@ export const useLogScrollRestoration = ({
     return root;
   }, [isParsedView, rootRef]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     // The scroll container is conditionally mounted after loading. Re-check it
-    // when rows arrive so scrolling does not depend on a later refresh.
+    // when rows arrive so scrolling does not depend on a later refresh. The
+    // layout cleanup also captures the final position before React detaches it.
     void rowCount;
     const scrollEl = getScrollContainer();
     if (!scrollEl) {
       return;
     }
 
-    const captureAndPersistPosition = () => {
+    const persistKnownPosition = () => {
       const knownPosition = knownScrollPositionRef.current;
-      const shouldFollowTail =
-        isLogScrollAtBottom(scrollEl) ||
-        reachedKnownBottom(scrollEl, knownPosition) ||
-        (wasAtBottomRef.current &&
-          knownPosition?.element === scrollEl &&
-          knownPosition.scrollTop === scrollEl.scrollTop);
-      knownScrollPositionRef.current = captureScrollPosition(scrollEl);
-      setTailFollowing(shouldFollowTail);
-      if (!scrollRestoredRef.current) {
+      if (!scrollRestoredRef.current || !knownPosition || knownPosition.element !== scrollEl) {
         return;
       }
       setScrollPosition(cacheKey, {
-        scrollTop: scrollEl.scrollTop,
-        isTailFollowing: shouldFollowTail,
+        scrollTop: knownPosition.scrollTop,
+        isTailFollowing: isTailFollowingRef.current,
       });
     };
-    const handler = () => captureAndPersistPosition();
 
-    scrollEl.addEventListener('scroll', handler, { passive: true });
-    return () => {
-      scrollEl.removeEventListener('scroll', handler);
-      captureAndPersistPosition();
+    const captureAndPersistKnownIntent = () => {
+      if (!isActive || !scrollEl.isConnected || !hasUserScrollGesture()) {
+        persistKnownPosition();
+        return;
+      }
+      const knownPosition = knownScrollPositionRef.current;
+      setTailFollowing(
+        shouldFollowTailAfterUserScroll(scrollEl, knownPosition, isTailFollowingRef.current)
+      );
+      knownScrollPositionRef.current = captureScrollPosition(scrollEl);
+      persistKnownPosition();
     };
-  }, [cacheKey, getScrollContainer, rowCount, setScrollPosition, setTailFollowing]);
+
+    const markUserScrollGesture = () => {
+      userScrollGestureDeadlineRef.current = Date.now() + USER_SCROLL_GESTURE_WINDOW_MS;
+    };
+    const hasUserScrollGesture = () =>
+      pointerScrollActiveRef.current || Date.now() <= userScrollGestureDeadlineRef.current;
+
+    const handleScroll = () => {
+      if (!isActive || !scrollEl.isConnected) {
+        persistKnownPosition();
+        return;
+      }
+      if (!hasUserScrollGesture()) {
+        persistKnownPosition();
+        return;
+      }
+      const knownPosition = knownScrollPositionRef.current;
+      setTailFollowing(
+        shouldFollowTailAfterUserScroll(scrollEl, knownPosition, isTailFollowingRef.current)
+      );
+      markUserScrollGesture();
+      knownScrollPositionRef.current = captureScrollPosition(scrollEl);
+      persistKnownPosition();
+    };
+
+    const handleWheel = (event: WheelEvent) => {
+      if (!isActive || event.deltaY === 0) {
+        return;
+      }
+      markUserScrollGesture();
+      if (event.deltaY < 0 && scrollEl.scrollTop > 0) {
+        setTailFollowing(false);
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!isActive || !isScrollKey(event)) {
+        return;
+      }
+      markUserScrollGesture();
+      if (isUpwardScrollKey(event) && scrollEl.scrollTop > 0) {
+        setTailFollowing(false);
+      }
+    };
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!isActive || (event.pointerType === 'mouse' && event.target !== scrollEl)) {
+        return;
+      }
+      pointerScrollActiveRef.current = true;
+      markUserScrollGesture();
+    };
+    const handlePointerEnd = () => {
+      if (!pointerScrollActiveRef.current) {
+        return;
+      }
+      pointerScrollActiveRef.current = false;
+      markUserScrollGesture();
+    };
+
+    scrollEl.addEventListener('scroll', handleScroll, { passive: true });
+    scrollEl.addEventListener('wheel', handleWheel, { passive: true });
+    scrollEl.addEventListener('keydown', handleKeyDown);
+    scrollEl.addEventListener('pointerdown', handlePointerDown);
+    window.addEventListener('pointerup', handlePointerEnd);
+    window.addEventListener('pointercancel', handlePointerEnd);
+    return () => {
+      scrollEl.removeEventListener('scroll', handleScroll);
+      scrollEl.removeEventListener('wheel', handleWheel);
+      scrollEl.removeEventListener('keydown', handleKeyDown);
+      scrollEl.removeEventListener('pointerdown', handlePointerDown);
+      window.removeEventListener('pointerup', handlePointerEnd);
+      window.removeEventListener('pointercancel', handlePointerEnd);
+      pointerScrollActiveRef.current = false;
+      captureAndPersistKnownIntent();
+    };
+  }, [cacheKey, getScrollContainer, isActive, rowCount, setScrollPosition, setTailFollowing]);
 
   const restoreScrollPosition = useCallback((): boolean => {
+    if (!isActive) {
+      return false;
+    }
     if (scrollRestoredRef.current || rowCount === 0) {
       return scrollRestoredRef.current;
     }
@@ -149,22 +251,77 @@ export const useLogScrollRestoration = ({
 
     const maxScrollTop = scrollEl.scrollHeight - scrollEl.clientHeight;
     const savedPosition = forceTailRestoreRef.current ? undefined : getScrollPosition(cacheKey);
-    const targetScrollTop = savedPosition?.isTailFollowing
+    const shouldFollowTail = savedPosition?.isTailFollowing !== false;
+    const targetScrollTop = shouldFollowTail
       ? maxScrollTop
-      : Math.min(savedPosition?.scrollTop ?? maxScrollTop, maxScrollTop);
+      : Math.min(savedPosition.scrollTop, maxScrollTop);
 
     scrollEl.scrollTop = targetScrollTop;
     knownScrollPositionRef.current = captureScrollPosition(scrollEl);
-    setTailFollowing(isLogScrollAtBottom(scrollEl));
+    setTailFollowing(shouldFollowTail);
     scrollRestoredRef.current = true;
     forceTailRestoreRef.current = false;
     return true;
-  }, [cacheKey, getScrollContainer, getScrollPosition, rowCount, setTailFollowing]);
+  }, [cacheKey, getScrollContainer, getScrollPosition, isActive, rowCount, setTailFollowing]);
+
+  useLayoutEffect(() => {
+    const wasActive = previousIsActiveRef.current;
+    previousIsActiveRef.current = isActive;
+    if (!isActive) {
+      pointerScrollActiveRef.current = false;
+      userScrollGestureDeadlineRef.current = 0;
+      return;
+    }
+
+    if (!wasActive) {
+      pointerScrollActiveRef.current = false;
+      userScrollGestureDeadlineRef.current = 0;
+    }
+
+    const scrollEl = getScrollContainer();
+    if (!scrollEl) {
+      return;
+    }
+    const knownPosition = knownScrollPositionRef.current;
+    const scrollContainerChanged = knownPosition?.element !== scrollEl;
+    if (wasActive && scrollRestoredRef.current && !scrollContainerChanged) {
+      return;
+    }
+    if (!restoreScrollPosition()) {
+      return;
+    }
+
+    if (isTailFollowingRef.current) {
+      scrollEl.scrollTop = scrollEl.scrollHeight;
+    } else {
+      const restoredPosition = knownScrollPositionRef.current;
+      const rememberedScrollTop =
+        restoredPosition?.element === scrollEl
+          ? restoredPosition.scrollTop
+          : getScrollPosition(cacheKey)?.scrollTop;
+      const maxScrollTop = Math.max(0, scrollEl.scrollHeight - scrollEl.clientHeight);
+      if (rememberedScrollTop !== undefined) {
+        scrollEl.scrollTop = Math.min(rememberedScrollTop, maxScrollTop);
+      }
+    }
+    knownScrollPositionRef.current = captureScrollPosition(scrollEl);
+    setScrollPosition(cacheKey, {
+      scrollTop: scrollEl.scrollTop,
+      isTailFollowing: isTailFollowingRef.current,
+    });
+  }, [
+    cacheKey,
+    getScrollContainer,
+    getScrollPosition,
+    isActive,
+    restoreScrollPosition,
+    setScrollPosition,
+  ]);
 
   useEffect(() => {
     void rowCount;
     void tailFollowSignal;
-    if (rowCount === 0) {
+    if (!isActive || rowCount === 0) {
       return;
     }
 
@@ -173,18 +330,7 @@ export const useLogScrollRestoration = ({
       if (!element || !scrollRestoredRef.current) {
         return false;
       }
-
-      // A scrollbar drag or wheel update can change scrollTop before the browser
-      // dispatches its scroll event. Compare the live DOM position with the last
-      // position we observed so a refresh cannot overtake that manual movement.
-      const knownPosition = knownScrollPositionRef.current;
-      if (knownPosition?.element === element && knownPosition.scrollTop !== element.scrollTop) {
-        setTailFollowing(
-          isLogScrollAtBottom(element) || reachedKnownBottom(element, knownPosition)
-        );
-      }
-      knownScrollPositionRef.current = captureScrollPosition(element);
-      return wasAtBottomRef.current;
+      return isTailFollowingRef.current;
     };
     if (restoreScrollPosition() && !shouldFollowTail()) {
       return;
@@ -216,6 +362,10 @@ export const useLogScrollRestoration = ({
       }
       element.scrollTop = currentScrollHeight;
       knownScrollPositionRef.current = captureScrollPosition(element);
+      setScrollPosition(cacheKey, {
+        scrollTop: element.scrollTop,
+        isTailFollowing: true,
+      });
       stableLayoutFrames =
         previousScrollHeight === currentScrollHeight && isLogScrollAtBottom(element)
           ? stableLayoutFrames + 1
@@ -237,10 +387,21 @@ export const useLogScrollRestoration = ({
         cancelAnimationFrame(rafId);
       }
     };
-  }, [getScrollContainer, restoreScrollPosition, tailFollowSignal, rowCount, setTailFollowing]);
+  }, [
+    cacheKey,
+    getScrollContainer,
+    isActive,
+    restoreScrollPosition,
+    rowCount,
+    setScrollPosition,
+    tailFollowSignal,
+  ]);
 
   useEffect(() => {
     void rowCount;
+    if (!isActive) {
+      return;
+    }
     const scrollEl = getScrollContainer();
     if (!scrollEl || typeof ResizeObserver === 'undefined') {
       return;
@@ -253,7 +414,7 @@ export const useLogScrollRestoration = ({
       }
       layoutRafId = requestAnimationFrame(() => {
         layoutRafId = undefined;
-        if (!restoreScrollPosition() || !wasAtBottomRef.current) {
+        if (!restoreScrollPosition() || !isTailFollowingRef.current) {
           return;
         }
         const element = getScrollContainer();
@@ -284,13 +445,16 @@ export const useLogScrollRestoration = ({
         cancelAnimationFrame(layoutRafId);
       }
     };
-  }, [cacheKey, getScrollContainer, restoreScrollPosition, rowCount, setScrollPosition]);
+  }, [cacheKey, getScrollContainer, isActive, restoreScrollPosition, rowCount, setScrollPosition]);
 
   const resumeTailFollowing = useCallback(() => {
     const scrollEl = getScrollContainer();
     if (!scrollEl) {
       return;
     }
+    userScrollGestureDeadlineRef.current = 0;
+    pointerScrollActiveRef.current = false;
+    setTailFollowing(true);
     scrollEl.scrollTop = scrollEl.scrollHeight;
     knownScrollPositionRef.current = captureScrollPosition(scrollEl);
     scrollRestoredRef.current = true;
@@ -298,7 +462,6 @@ export const useLogScrollRestoration = ({
       scrollTop: scrollEl.scrollTop,
       isTailFollowing: true,
     });
-    setTailFollowing(true);
   }, [cacheKey, getScrollContainer, setScrollPosition, setTailFollowing]);
 
   return { getScrollContainer, resetScrollRestoration, resumeTailFollowing };

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/logViewerPrefsCache.test.ts
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/logViewerPrefsCache.test.ts
@@ -7,8 +7,10 @@ import type { LogViewerPrefs } from '../types';
 import {
   clearLogViewerPrefs,
   getLogViewerPrefs,
+  getLogViewerScrollPosition,
   resetLogViewerPrefsCacheForTesting,
   setLogViewerPrefs,
+  setLogViewerScrollPosition,
 } from './logViewerPrefsCache';
 
 const samplePrefs = (overrides: Partial<LogViewerPrefs> = {}): LogViewerPrefs => ({
@@ -65,5 +67,18 @@ describe('logViewerPrefsCache', () => {
 
     expect(getLogViewerPrefs(a)).toBeUndefined();
     expect(getLogViewerPrefs(b)?.textFilter).toBe('second');
+  });
+
+  it('retains tail-following state until the owning panel is cleared', () => {
+    const id = 'obj:cluster-a:pod:default:api';
+    setLogViewerScrollPosition(id, { scrollTop: 900, isTailFollowing: true });
+
+    expect(getLogViewerScrollPosition(id)).toEqual({
+      scrollTop: 900,
+      isTailFollowing: true,
+    });
+
+    clearLogViewerPrefs(id);
+    expect(getLogViewerScrollPosition(id)).toBeUndefined();
   });
 });

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/logViewerPrefsCache.test.ts
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/logViewerPrefsCache.test.ts
@@ -71,6 +71,7 @@ describe('logViewerPrefsCache', () => {
 
   it('retains tail-following state until the owning panel is cleared', () => {
     const id = 'obj:cluster-a:pod:default:api';
+    setLogViewerPrefs(id, samplePrefs());
     setLogViewerScrollPosition(id, { scrollTop: 900, isTailFollowing: true });
 
     expect(getLogViewerScrollPosition(id)).toEqual({
@@ -79,6 +80,17 @@ describe('logViewerPrefsCache', () => {
     });
 
     clearLogViewerPrefs(id);
+    expect(getLogViewerScrollPosition(id)).toBeUndefined();
+  });
+
+  it('does not resurrect a cleared scroll entry when an old unmount cleanup writes late', () => {
+    const id = 'obj:cluster-a:pod:default:api';
+    setLogViewerPrefs(id, samplePrefs());
+    setLogViewerScrollPosition(id, { scrollTop: 300, isTailFollowing: false });
+
+    clearLogViewerPrefs(id);
+    setLogViewerScrollPosition(id, { scrollTop: 0, isTailFollowing: true });
+
     expect(getLogViewerScrollPosition(id)).toBeUndefined();
   });
 });

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/logViewerPrefsCache.ts
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/logViewerPrefsCache.ts
@@ -72,6 +72,11 @@ export const getLogViewerScrollPosition = (panelId: string): LogScrollPosition |
   scrollPositionCache.get(panelId);
 
 export const setLogViewerScrollPosition = (panelId: string, position: LogScrollPosition): void => {
+  // Panel close evicts the owning prefs before React runs old component cleanup.
+  // Reject that stale cleanup write so it cannot recreate only the scroll entry.
+  if (!cache.has(panelId)) {
+    return;
+  }
   scrollPositionCache.set(panelId, position);
 };
 

--- a/frontend/src/modules/object-panel/components/ObjectPanel/Logs/logViewerPrefsCache.ts
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/Logs/logViewerPrefsCache.ts
@@ -27,7 +27,7 @@ import {
   type MultiSelectFilterSelection,
   migrateLegacyMultiSelectFilterSelection,
 } from '@shared/components/dropdowns/multiSelectFilterSelection';
-import type { LogViewerPrefs } from '../types';
+import type { LogScrollPosition, LogViewerPrefs } from '../types';
 
 type LogViewerPrefsInput = Omit<LogViewerPrefs, 'selectedFilters'> & {
   selectedFilters: MultiSelectFilterSelection | string[];
@@ -47,11 +47,11 @@ export const setLogViewerPrefs = (panelId: string, prefs: LogViewerPrefsInput): 
 
 export const clearLogViewerPrefs = (panelId: string): void => {
   cache.delete(panelId);
-  scrollTopCache.delete(panelId);
+  scrollPositionCache.delete(panelId);
 };
 
 /**
- * Per-panel scroll position for the active log content container.
+ * Per-panel scroll position and tail-following state for the active log content container.
  *
  * Kept in a separate Map (not merged into LogViewerPrefs) because:
  *
@@ -66,13 +66,13 @@ export const clearLogViewerPrefs = (panelId: string): void => {
  * Eviction is tied into clearLogViewerPrefs above so the two entries
  * always come and go together.
  */
-const scrollTopCache = new Map<string, number>();
+const scrollPositionCache = new Map<string, LogScrollPosition>();
 
-export const getLogViewerScrollTop = (panelId: string): number | undefined =>
-  scrollTopCache.get(panelId);
+export const getLogViewerScrollPosition = (panelId: string): LogScrollPosition | undefined =>
+  scrollPositionCache.get(panelId);
 
-export const setLogViewerScrollTop = (panelId: string, scrollTop: number): void => {
-  scrollTopCache.set(panelId, scrollTop);
+export const setLogViewerScrollPosition = (panelId: string, position: LogScrollPosition): void => {
+  scrollPositionCache.set(panelId, position);
 };
 
 /**
@@ -81,5 +81,5 @@ export const setLogViewerScrollTop = (panelId: string, scrollTop: number): void 
  */
 export const resetLogViewerPrefsCacheForTesting = (): void => {
   cache.clear();
-  scrollTopCache.clear();
+  scrollPositionCache.clear();
 };

--- a/frontend/src/modules/object-panel/components/ObjectPanel/NodeLogs/NodeLogsTab.tsx
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/NodeLogs/NodeLogsTab.tsx
@@ -976,6 +976,7 @@ const NodeLogsTab = ({
 
   const { resetScrollRestoration } = useLogScrollRestoration({
     rootRef: logsContentRef,
+    isActive,
     isParsedView,
     rowCount,
     tailFollowSignal: `${selectedSource?.path ?? ''}:${parsedLogs.length}:${renderedDisplayRows.length}`,

--- a/frontend/src/modules/object-panel/components/ObjectPanel/NodeLogs/NodeLogsTab.tsx
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/NodeLogs/NodeLogsTab.tsx
@@ -26,7 +26,10 @@ import {
 import { containsAnsi, stripAnsi } from '../Logs/ansi';
 import { buildCsv } from '../Logs/logExport';
 import { buildLogSearchRegex } from '../Logs/logSearch';
-import { getLogViewerScrollTop, setLogViewerScrollTop } from '../Logs/logViewerPrefsCache';
+import {
+  getLogViewerScrollPosition,
+  setLogViewerScrollPosition,
+} from '../Logs/logViewerPrefsCache';
 import type { ParsedLogEntry } from '../Logs/logViewerReducer';
 import { buildParsedLogDataColumns } from '../Logs/parsedLogColumns';
 import {
@@ -977,8 +980,8 @@ const NodeLogsTab = ({
     rowCount,
     tailFollowSignal: `${selectedSource?.path ?? ''}:${parsedLogs.length}:${renderedDisplayRows.length}`,
     cacheKey: panelId,
-    getScrollTop: getLogViewerScrollTop,
-    setScrollTop: setLogViewerScrollTop,
+    getScrollPosition: getLogViewerScrollPosition,
+    setScrollPosition: setLogViewerScrollPosition,
     forceTailOnNextRestore: true,
   });
 

--- a/frontend/src/modules/object-panel/components/ObjectPanel/ObjectPanel.css
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/ObjectPanel.css
@@ -109,6 +109,17 @@
   height: 100%;
 }
 
+.object-panel-retained-tab {
+  height: 100%;
+}
+
+.object-panel-retained-tab--inactive {
+  position: absolute;
+  inset: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
 .object-panel-placeholder {
   display: flex;
   align-items: center;

--- a/frontend/src/modules/object-panel/components/ObjectPanel/ObjectPanelContent.test.tsx
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/ObjectPanelContent.test.tsx
@@ -13,12 +13,14 @@ import { requireValue } from '@/test-utils/requireValue';
 const hoistedRefs = vi.hoisted(() => ({
   detailsTabProps: { current: null as DetailsTabProps | null },
   logViewerProps: { current: null as unknown },
+  logViewerError: { current: null as Error | null },
   eventsTabProps: { current: null as unknown },
   yamlTabProps: { current: null as unknown },
   manifestTabProps: { current: null as unknown },
   valuesTabProps: { current: null as unknown },
   shellTabProps: { current: null as unknown },
   nodeLogsTabProps: { current: null as unknown },
+  nodeLogsError: { current: null as Error | null },
   podsTabProps: { current: null as unknown },
   setScopedDomainEnabled: vi.fn(),
 }));
@@ -38,6 +40,9 @@ vi.mock('@modules/object-panel/components/ObjectPanel/Details/DetailsTab', () =>
 
 vi.mock('@modules/object-panel/components/ObjectPanel/Logs/LogViewer', () => ({
   default: (props: unknown) => {
+    if (hoistedRefs.logViewerError.current) {
+      throw hoistedRefs.logViewerError.current;
+    }
     hoistedRefs.logViewerProps.current = props;
     return <div data-testid="logs-tab" />;
   },
@@ -80,6 +85,9 @@ vi.mock('@modules/object-panel/components/ObjectPanel/Shell/ShellTab', () => ({
 
 vi.mock('@modules/object-panel/components/ObjectPanel/NodeLogs/NodeLogsTab', () => ({
   default: (props: unknown) => {
+    if (hoistedRefs.nodeLogsError.current) {
+      throw hoistedRefs.nodeLogsError.current;
+    }
     hoistedRefs.nodeLogsTabProps.current = props;
     return <div data-testid="node-logs-tab" />;
   },
@@ -184,6 +192,7 @@ describe('ObjectPanelContent', () => {
     expect(hoistedRefs.detailsTabProps.current).toMatchObject(
       requireValue(baseProps.detailTabProps, 'expected test value in ObjectPanelContent.test.tsx')
     );
+    expect(hoistedRefs.logViewerProps.current).toBeNull();
   });
 
   it('renders logs viewer when logs tab is active and capability present', async () => {
@@ -194,8 +203,45 @@ describe('ObjectPanelContent', () => {
     });
   });
 
+  it('preserves the mounted log viewer while another object-panel tab is active', async () => {
+    await renderContent({ activeTab: 'logs' });
+    const mountedLogViewer = requireValue(
+      container.querySelector<HTMLElement>('[data-testid="logs-tab"]'),
+      'expected mounted log viewer'
+    );
+
+    await renderContent({ activeTab: 'details' });
+
+    expect(mountedLogViewer.isConnected).toBe(true);
+    expect(mountedLogViewer.closest('[aria-hidden="true"]')).not.toBeNull();
+    expect(hoistedRefs.logViewerProps.current).toMatchObject({ isActive: false });
+
+    await renderContent({ activeTab: 'logs' });
+
+    expect(container.querySelector('[data-testid="logs-tab"]')).toBe(mountedLogViewer);
+    expect(mountedLogViewer.closest('[aria-hidden="true"]')).toBeNull();
+    expect(hoistedRefs.logViewerProps.current).toMatchObject({ isActive: true });
+  });
+
+  it('can retry the retained log viewer after its tab error boundary catches an error', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    hoistedRefs.logViewerError.current = new Error('render failed');
+
+    await renderContent({ activeTab: 'logs' });
+    expect(container.textContent).toContain('Failed to load Logs');
+
+    hoistedRefs.logViewerError.current = null;
+    const retryButton = requireValue(container.querySelector('button'), 'expected retry button');
+    await act(async () => {
+      retryButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(container.querySelector('[data-testid="logs-tab"]')).not.toBeNull();
+    consoleError.mockRestore();
+  });
+
   it('renders node logs tab when logs tab is active for a node', async () => {
-    await renderContent({
+    const nodeProps: Partial<React.ComponentProps<typeof ObjectPanelContent>> = {
       activeTab: 'logs',
       capabilities: { ...baseProps.capabilities, hasObjPanelLogs: true, hasNodeLogs: false },
       objectData: { kind: 'Node', name: 'node-1', clusterId: 'alpha:ctx' },
@@ -209,7 +255,8 @@ describe('ObjectPanelContent', () => {
           path: 'journal/kubelet',
         },
       ],
-    });
+    };
+    await renderContent(nodeProps);
 
     expect(hoistedRefs.nodeLogsTabProps.current).toMatchObject({
       nodeName: 'node-1',
@@ -218,6 +265,29 @@ describe('ObjectPanelContent', () => {
       availability: { pending: true },
       sources: [{ path: 'journal/kubelet' }],
     });
+
+    const mountedNodeLogs = requireValue(
+      container.querySelector<HTMLElement>('[data-testid="node-logs-tab"]'),
+      'expected mounted node logs'
+    );
+    await renderContent({ ...nodeProps, activeTab: 'details' });
+    expect(mountedNodeLogs.isConnected).toBe(true);
+    expect(mountedNodeLogs.closest('[aria-hidden="true"]')).not.toBeNull();
+    expect(hoistedRefs.nodeLogsTabProps.current).toMatchObject({ isActive: false });
+  });
+
+  it('shows the retained node-log error boundary when node logs fail to render', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    hoistedRefs.nodeLogsError.current = new Error('node logs render failed');
+
+    await renderContent({
+      activeTab: 'logs',
+      objectData: { kind: 'Node', name: 'node-1', clusterId: 'alpha:ctx' },
+      objectKind: 'node',
+    });
+
+    expect(container.textContent).toContain('Failed to load Logs');
+    consoleError.mockRestore();
   });
 
   it('does not render logs viewer when capability is missing', async () => {
@@ -250,6 +320,17 @@ describe('ObjectPanelContent', () => {
       capabilities: { ...baseProps.capabilities, hasShell: false },
     });
     expect(hoistedRefs.shellTabProps.current).toBeNull();
+  });
+
+  it('renders the active events tab with the panel scope', async () => {
+    await renderContent({ activeTab: 'events' });
+
+    expect(hoistedRefs.eventsTabProps.current).toMatchObject({
+      objectData: baseProps.objectData,
+      isActive: true,
+      eventsScope: baseProps.eventsScope,
+      panelId: baseProps.panelId,
+    });
   });
 
   it('passes capability information to YAML tab', async () => {

--- a/frontend/src/modules/object-panel/components/ObjectPanel/ObjectPanelContent.tsx
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/ObjectPanelContent.tsx
@@ -114,6 +114,85 @@ interface ObjectPanelContentProps {
   panelId: string;
 }
 
+interface RetainedLogsTabProps {
+  isVisible: boolean;
+  isAvailable: boolean;
+  isPanelOpen: boolean;
+  objectKind: string | null;
+  objectData: PanelObjectData | null;
+  containerLogsScope: string | null;
+  activePodNames: string[] | null;
+  panelId: string;
+  nodeLogsState: CapabilityState;
+  nodeLogSources: NodeLogSource[];
+}
+
+const RetainedLogsTab = ({
+  isVisible,
+  isAvailable,
+  isPanelOpen,
+  objectKind,
+  objectData,
+  containerLogsScope,
+  activePodNames,
+  panelId,
+  nodeLogsState,
+  nodeLogSources,
+}: Readonly<RetainedLogsTabProps>) => {
+  const hasRenderedRef = React.useRef(false);
+  if (isVisible) {
+    hasRenderedRef.current = true;
+  }
+  if (!hasRenderedRef.current || !isAvailable) {
+    return null;
+  }
+
+  const isActive = isPanelOpen && isVisible;
+  return (
+    <div
+      className={`object-panel-retained-tab${isVisible ? '' : ' object-panel-retained-tab--inactive'}`}
+      aria-hidden={!isVisible}
+      inert={!isVisible}
+    >
+      {objectKind !== 'node' ? (
+        <ErrorBoundary
+          scope="panel-logs"
+          resetKeys={[objectData?.name ?? '', objectData?.namespace ?? ''].filter(Boolean)}
+          fallback={(_, reset) => <TabErrorFallback tabName="Logs" reset={reset} />}
+        >
+          <LazyTabContent name="logs">
+            <LogViewer
+              isActive={isActive}
+              resourceKind={objectKind || 'pod'}
+              containerLogsScope={containerLogsScope}
+              activePodNames={activePodNames}
+              clusterId={objectData?.clusterId ?? null}
+              panelId={panelId}
+            />
+          </LazyTabContent>
+        </ErrorBoundary>
+      ) : (
+        <ErrorBoundary
+          scope="panel-node-logs"
+          resetKeys={[objectData?.name ?? '', objectData?.clusterId ?? ''].filter(Boolean)}
+          fallback={(_, reset) => <TabErrorFallback tabName="Logs" reset={reset} />}
+        >
+          <LazyTabContent name="logs">
+            <NodeLogsTab
+              panelId={panelId}
+              nodeName={objectData?.name || ''}
+              clusterId={objectData?.clusterId ?? null}
+              isActive={isActive}
+              availability={nodeLogsState}
+              sources={nodeLogSources}
+            />
+          </LazyTabContent>
+        </ErrorBoundary>
+      )}
+    </div>
+  );
+};
+
 export function ObjectPanelContent({
   activeTab,
   detailTabProps,
@@ -137,11 +216,6 @@ export function ObjectPanelContent({
   const showDetails = activeTab === 'details' && detailTabProps;
   const logsAvailable = capabilities.hasObjPanelLogs && objectData !== null;
   const showLogs = activeTab === 'logs' && logsAvailable;
-  const hasRenderedLogsRef = React.useRef(false);
-  if (showLogs) {
-    hasRenderedLogsRef.current = true;
-  }
-  const renderRetainedLogs = Boolean(hasRenderedLogsRef.current && logsAvailable);
   const showShell = activeTab === 'shell' && capabilities.hasShell && objectData;
   const showPods = activeTab === 'pods';
   const showJobs = activeTab === 'jobs';
@@ -207,49 +281,18 @@ export function ObjectPanelContent({
         </ErrorBoundary>
       )}
 
-      {renderRetainedLogs && (
-        <div
-          className={`object-panel-retained-tab${showLogs ? '' : ' object-panel-retained-tab--inactive'}`}
-          aria-hidden={!showLogs}
-          inert={!showLogs}
-        >
-          {objectKind !== 'node' ? (
-            <ErrorBoundary
-              scope="panel-logs"
-              resetKeys={[objectData?.name ?? '', objectData?.namespace ?? ''].filter(Boolean)}
-              fallback={(_, reset) => <TabErrorFallback tabName="Logs" reset={reset} />}
-            >
-              <LazyTabContent name="logs">
-                <LogViewer
-                  isActive={isPanelOpen && showLogs}
-                  resourceKind={objectKind || 'pod'}
-                  containerLogsScope={containerLogsScope}
-                  activePodNames={activePodNames}
-                  clusterId={objectData?.clusterId ?? null}
-                  panelId={panelId}
-                />
-              </LazyTabContent>
-            </ErrorBoundary>
-          ) : (
-            <ErrorBoundary
-              scope="panel-node-logs"
-              resetKeys={[objectData?.name ?? '', objectData?.clusterId ?? ''].filter(Boolean)}
-              fallback={(_, reset) => <TabErrorFallback tabName="Logs" reset={reset} />}
-            >
-              <LazyTabContent name="logs">
-                <NodeLogsTab
-                  panelId={panelId}
-                  nodeName={objectData?.name || ''}
-                  clusterId={objectData?.clusterId ?? null}
-                  isActive={isPanelOpen && showLogs}
-                  availability={nodeLogsState}
-                  sources={nodeLogSources}
-                />
-              </LazyTabContent>
-            </ErrorBoundary>
-          )}
-        </div>
-      )}
+      <RetainedLogsTab
+        isVisible={showLogs}
+        isAvailable={logsAvailable}
+        isPanelOpen={isPanelOpen}
+        objectKind={objectKind}
+        objectData={objectData}
+        containerLogsScope={containerLogsScope}
+        activePodNames={activePodNames}
+        panelId={panelId}
+        nodeLogsState={nodeLogsState}
+        nodeLogSources={nodeLogSources}
+      />
 
       {!!showShell && (
         <ErrorBoundary

--- a/frontend/src/modules/object-panel/components/ObjectPanel/ObjectPanelContent.tsx
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/ObjectPanelContent.tsx
@@ -135,7 +135,13 @@ export function ObjectPanelContent({
   panelId,
 }: Readonly<ObjectPanelContentProps>) {
   const showDetails = activeTab === 'details' && detailTabProps;
-  const showLogs = activeTab === 'logs' && capabilities.hasObjPanelLogs && objectData;
+  const logsAvailable = capabilities.hasObjPanelLogs && objectData !== null;
+  const showLogs = activeTab === 'logs' && logsAvailable;
+  const hasRenderedLogsRef = React.useRef(false);
+  if (showLogs) {
+    hasRenderedLogsRef.current = true;
+  }
+  const renderRetainedLogs = Boolean(hasRenderedLogsRef.current && logsAvailable);
   const showShell = activeTab === 'shell' && capabilities.hasShell && objectData;
   const showPods = activeTab === 'pods';
   const showJobs = activeTab === 'jobs';
@@ -201,23 +207,48 @@ export function ObjectPanelContent({
         </ErrorBoundary>
       )}
 
-      {showLogs && objectKind !== 'node' && (
-        <ErrorBoundary
-          scope="panel-logs"
-          resetKeys={[objectData?.name ?? '', objectData?.namespace ?? ''].filter(Boolean)}
-          fallback={(_, reset) => <TabErrorFallback tabName="Logs" reset={reset} />}
+      {renderRetainedLogs && (
+        <div
+          className={`object-panel-retained-tab${showLogs ? '' : ' object-panel-retained-tab--inactive'}`}
+          aria-hidden={!showLogs}
+          inert={!showLogs}
         >
-          <LazyTabContent name="logs">
-            <LogViewer
-              isActive={isPanelOpen && activeTab === 'logs'}
-              resourceKind={objectKind || 'pod'}
-              containerLogsScope={containerLogsScope}
-              activePodNames={activePodNames}
-              clusterId={objectData?.clusterId ?? null}
-              panelId={panelId}
-            />
-          </LazyTabContent>
-        </ErrorBoundary>
+          {objectKind !== 'node' ? (
+            <ErrorBoundary
+              scope="panel-logs"
+              resetKeys={[objectData?.name ?? '', objectData?.namespace ?? ''].filter(Boolean)}
+              fallback={(_, reset) => <TabErrorFallback tabName="Logs" reset={reset} />}
+            >
+              <LazyTabContent name="logs">
+                <LogViewer
+                  isActive={isPanelOpen && showLogs}
+                  resourceKind={objectKind || 'pod'}
+                  containerLogsScope={containerLogsScope}
+                  activePodNames={activePodNames}
+                  clusterId={objectData?.clusterId ?? null}
+                  panelId={panelId}
+                />
+              </LazyTabContent>
+            </ErrorBoundary>
+          ) : (
+            <ErrorBoundary
+              scope="panel-node-logs"
+              resetKeys={[objectData?.name ?? '', objectData?.clusterId ?? ''].filter(Boolean)}
+              fallback={(_, reset) => <TabErrorFallback tabName="Logs" reset={reset} />}
+            >
+              <LazyTabContent name="logs">
+                <NodeLogsTab
+                  panelId={panelId}
+                  nodeName={objectData?.name || ''}
+                  clusterId={objectData?.clusterId ?? null}
+                  isActive={isPanelOpen && showLogs}
+                  availability={nodeLogsState}
+                  sources={nodeLogSources}
+                />
+              </LazyTabContent>
+            </ErrorBoundary>
+          )}
+        </div>
       )}
 
       {!!showShell && (
@@ -235,25 +266,6 @@ export function ObjectPanelContent({
               debugDisabledReason={capabilityReasons.debug}
               availableContainers={availableContainers}
               clusterId={objectData?.clusterId ?? null}
-            />
-          </LazyTabContent>
-        </ErrorBoundary>
-      )}
-
-      {showLogs && objectKind === 'node' && (
-        <ErrorBoundary
-          scope="panel-node-logs"
-          resetKeys={[objectData?.name ?? '', objectData?.clusterId ?? ''].filter(Boolean)}
-          fallback={(_, reset) => <TabErrorFallback tabName="Logs" reset={reset} />}
-        >
-          <LazyTabContent name="logs">
-            <NodeLogsTab
-              panelId={panelId}
-              nodeName={objectData?.name || ''}
-              clusterId={objectData?.clusterId ?? null}
-              isActive={isPanelOpen && activeTab === 'logs'}
-              availability={nodeLogsState}
-              sources={nodeLogSources}
             />
           </LazyTabContent>
         </ErrorBoundary>

--- a/frontend/src/modules/object-panel/components/ObjectPanel/types.ts
+++ b/frontend/src/modules/object-panel/components/ObjectPanel/types.ts
@@ -146,6 +146,11 @@ export type LogDisplayMode = 'raw' | 'structured' | 'pretty' | 'parsed';
 
 export type LogTimestampMode = 'hidden' | 'default' | 'short' | 'localized';
 
+export interface LogScrollPosition {
+  scrollTop: number;
+  isTailFollowing: boolean;
+}
+
 /**
  * Persistent subset of LogViewerState — the user-facing view preferences
  * that should survive ObjectPanelContent unmount/remount caused by


### PR DESCRIPTION
- Keep Logs mounted across object-panel tab switches to preserve viewport state.
- Restore tail-following or manual scroll position without visible jumps across raw, Pretty, and table views.
- Prevent layout changes and unchanged stream reconnects from triggering “Resume scrolling.”
- Harden scroll cache cleanup and preserve row identity across reconnects.