### PR TITLE
Refresh system hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,9 @@ source contract is unclear.
 
 ## Working rules
 
+- Read `docs/workflows/common-mistakes.md` before editing and apply its
+  prevention checks to the affected code. Record recurring mistakes and shared
+  prevention rules there so they travel with the repository.
 - Preserve unrelated worktree changes and existing project patterns.
 - Do not change behavior, appearance, dependencies, or unrelated files unless
   required for the requested contract.
@@ -74,6 +77,13 @@ source contract is unclear.
   with `mise exec -- wails3 task test:backend-coverage` or
   `mise exec -- wails3 task test:frontend-coverage`; target 80% statement coverage or
   report the measured gap and ask for guidance.
+- Check cognitive complexity in every changed production function and new
+  helper before the final gate. Follow `docs/frontend/sonar.md` for the Go and
+  TypeScript checks; target a local score of 12 or lower. Preserve lifecycle and
+  ordering contracts when extracting responsibilities. Do not suppress findings
+  or raise thresholds. A prerelease pass is not evidence of Sonar closure;
+  inspect the PR's current Sonar findings when available and distinguish local
+  results from analysis of the pushed revision.
 - Base final evidence on the latest worktree. Before reporting
   non-documentation work, run
   `mise exec -- wails3 task qc:prerelease`, then inspect the worktree because the gate

--- a/backend/cluster_auth_contract.go
+++ b/backend/cluster_auth_contract.go
@@ -11,6 +11,7 @@ package backend
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/luxury-yacht/app/backend/internal/authstate"
 	"github.com/luxury-yacht/app/backend/internal/errorcapture"
@@ -83,7 +84,7 @@ func authEventPayload(clusterID, clusterName string, diag authstate.FailureDiagn
 }
 
 func (r clusterSubsystemRebuild) run() {
-	newClients, ok := r.rebuildClients()
+	newClients, ok := r.rebuildClients(context.Background())
 	if !ok {
 		return
 	}
@@ -143,11 +144,45 @@ type clusterSubsystemRebuild struct {
 	clusterName string
 	selection   kubeconfigSelection
 	oldClients  *clusterClients
+	failures    *clusterRebuildFailures
 }
 
-func (r clusterSubsystemRebuild) rebuildClients() (*clusterClients, bool) {
+// A permission revalidator owns this state for one cluster generation. Keep
+// retrying, but report an unchanged failure only once until its stage succeeds.
+type clusterRebuildFailures struct {
+	mu   sync.Mutex
+	last map[string]string
+}
+
+func (f *clusterRebuildFailures) shouldReport(component string, err error) bool {
+	if f == nil {
+		return true
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.last == nil {
+		f.last = make(map[string]string)
+	}
+	message := err.Error()
+	if previous, ok := f.last[component]; ok && previous == message {
+		return false
+	}
+	f.last[component] = message
+	return true
+}
+
+func (f *clusterRebuildFailures) clear(component string) {
+	if f == nil {
+		return
+	}
+	f.mu.Lock()
+	delete(f.last, component)
+	f.mu.Unlock()
+}
+
+func (r clusterSubsystemRebuild) rebuildClients(ctx context.Context) (*clusterClients, bool) {
 	clients, err := r.refresh.clusterRuntime.buildClusterClientsWithManager(
-		context.Background(), r.selection, r.oldClients.meta, r.oldClients.authManager,
+		ctx, r.selection, r.oldClients.meta, r.oldClients.authManager,
 	)
 	if err != nil {
 		r.reportBuildError("clients", "client rebuild failed", err)
@@ -157,6 +192,7 @@ func (r clusterSubsystemRebuild) rebuildClients() (*clusterClients, bool) {
 		r.refresh.logger.Warn(fmt.Sprintf("Skipping subsystem rebuild for cluster %s: auth not valid after client rebuild", r.clusterID), logsources.Auth, r.clusterID, r.clusterName)
 		return nil, false
 	}
+	r.failures.clear("clients")
 	return clients, true
 }
 
@@ -170,10 +206,14 @@ func (r clusterSubsystemRebuild) buildSubsystem(clients *clusterClients) (*syste
 		r.reportBuildError("subsystem", "subsystem rebuild failed", err)
 		return nil, false
 	}
+	r.failures.clear("subsystem")
 	return subsystem, true
 }
 
 func (r clusterSubsystemRebuild) reportBuildError(component, capturePrefix string, err error) {
+	if !r.failures.shouldReport(component, err) {
+		return
+	}
 	r.refresh.logger.ErrorWithCause(
 		err, fmt.Sprintf("Failed to rebuild %s for cluster %s", component, r.clusterID),
 		logsources.Auth, r.clusterID, r.clusterName,

--- a/backend/cluster_auth_test.go
+++ b/backend/cluster_auth_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/luxury-yacht/app/backend/internal/authstate"
+	"github.com/luxury-yacht/app/backend/objectcatalog"
 	"github.com/luxury-yacht/app/backend/refresh"
 	"github.com/luxury-yacht/app/backend/refresh/resourcestream"
 	"github.com/luxury-yacht/app/backend/refresh/snapshot"
@@ -147,7 +148,7 @@ func TestClusterSubsystemRebuildHelperPaths(t *testing.T) {
 		oldClients: &clusterClients{meta: ClusterMeta{ID: "cluster-a", Name: "Cluster A"}},
 	}
 
-	clients, ok := rebuild.rebuildClients()
+	clients, ok := rebuild.rebuildClients(context.Background())
 	require.False(t, ok)
 	require.Nil(t, clients)
 
@@ -339,6 +340,13 @@ func TestClusterSubsystemRebuildRoutesReplacementBeforeStoppingPrevious(t *testi
 		Manager:        oldManager,
 		ResourceStream: oldStream,
 	})
+	catalogStopped := make(chan struct{})
+	app.Refresh.storeObjectCatalogEntry(clusterID, &objectCatalogEntry{
+		service: &objectcatalog.Service{},
+		owner:   app.Refresh.getRefreshSubsystem(clusterID),
+		cancel:  func() { close(catalogStopped) },
+		done:    catalogStopped,
+	})
 
 	newManager := refresh.NewManager(nil, nil, nil, nil, nil)
 	next := &system.Subsystem{Manager: newManager, ResourceStream: newStream}
@@ -355,9 +363,16 @@ func TestClusterSubsystemRebuildRoutesReplacementBeforeStoppingPrevious(t *testi
 	}
 	require.Same(t, newStream, resources.managerFor(clusterID),
 		"aggregate routing must publish the replacement before old stream shutdown can trigger resubscription")
+	select {
+	case <-catalogStopped:
+	default:
+		t.Error("old informer shutdown started before its catalog stopped")
+	}
 
 	oldHub.release()
 	require.True(t, <-result)
+	require.Nil(t, app.Refresh.objectCatalogServiceForCluster(clusterID),
+		"failed catalog startup for the replacement must not leave the previous catalog running")
 	app.Refresh.stopRefreshGeneration(clusterID, next)
 	app.Refresh.stopRefreshRuntimeContext()
 }

--- a/backend/cluster_operation_coordinator.go
+++ b/backend/cluster_operation_coordinator.go
@@ -27,12 +27,17 @@ func newClusterOperationCoordinator() *clusterOperationCoordinator {
 	}
 }
 
-// run executes fn under per-cluster singleflight semantics.
-func (c *clusterOperationCoordinator) run(
-	parent context.Context,
-	clusterID string,
-	fn func(context.Context) error,
-) error {
+// run gives foreground operations priority over older work for the same cluster.
+func (c *clusterOperationCoordinator) run(parent context.Context, clusterID string, fn func(context.Context) error) error {
+	return c.runWithAdmission(parent, clusterID, fn, true)
+}
+
+// runWhenIdle skips a busy cluster. The periodic caller retains retry ownership.
+func (c *clusterOperationCoordinator) runWhenIdle(parent context.Context, clusterID string, fn func(context.Context) error) error {
+	return c.runWithAdmission(parent, clusterID, fn, false)
+}
+
+func (c *clusterOperationCoordinator) runWithAdmission(parent context.Context, clusterID string, fn func(context.Context) error, supersede bool) error {
 	if fn == nil {
 		return nil
 	}
@@ -43,9 +48,9 @@ func (c *clusterOperationCoordinator) run(
 		parent = context.Background()
 	}
 
-	slot, token, opCtx, cancel := c.begin(parent, clusterID)
+	slot, token, opCtx, cancel := c.begin(parent, clusterID, supersede)
 	if slot == nil {
-		return fn(opCtx)
+		return nil
 	}
 	defer c.end(clusterID, slot, token, cancel)
 
@@ -61,6 +66,7 @@ func (c *clusterOperationCoordinator) run(
 func (c *clusterOperationCoordinator) begin(
 	parent context.Context,
 	clusterID string,
+	supersede bool,
 ) (*clusterOperationSlot, uint64, context.Context, context.CancelFunc) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -72,6 +78,9 @@ func (c *clusterOperationCoordinator) begin(
 	}
 
 	if slot.cancel != nil {
+		if !supersede {
+			return nil, 0, nil, nil
+		}
 		slot.cancel()
 	}
 
@@ -102,11 +111,15 @@ func (c *clusterOperationCoordinator) end(
 	slot.cancel = nil
 }
 
-func (m *ClusterRuntimeManager) runClusterOperation(
-	ctx context.Context,
-	clusterID string,
-	fn func(context.Context) error,
-) error {
+func (m *ClusterRuntimeManager) runClusterOperation(ctx context.Context, clusterID string, fn func(context.Context) error) error {
+	return m.runClusterOperationWithAdmission(ctx, clusterID, fn, true)
+}
+
+func (m *ClusterRuntimeManager) runBackgroundClusterOperation(ctx context.Context, clusterID string, fn func(context.Context) error) error {
+	return m.runClusterOperationWithAdmission(ctx, clusterID, fn, false)
+}
+
+func (m *ClusterRuntimeManager) runClusterOperationWithAdmission(ctx context.Context, clusterID string, fn func(context.Context) error, supersede bool) error {
 	if fn == nil {
 		return nil
 	}
@@ -123,7 +136,12 @@ func (m *ClusterRuntimeManager) runClusterOperation(
 		}
 		return err
 	}
-	err := m.clusterOps.run(opCtx, clusterID, fn)
+	var err error
+	if supersede {
+		err = m.clusterOps.run(opCtx, clusterID, fn)
+	} else {
+		err = m.clusterOps.runWhenIdle(opCtx, clusterID, fn)
+	}
 	if errors.Is(err, context.Canceled) {
 		return nil
 	}

--- a/backend/cluster_operation_coordinator_test.go
+++ b/backend/cluster_operation_coordinator_test.go
@@ -162,3 +162,27 @@ func TestAppRunClusterOperationSuppressesCancellation(t *testing.T) {
 	require.NoError(t, firstErr)
 	require.NoError(t, secondErr)
 }
+
+func TestBackgroundClusterOperationYieldsToForegroundWork(t *testing.T) {
+	coord := newClusterOperationCoordinator()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	started, done := make(chan struct{}), make(chan struct{})
+	var active context.Context
+	go func() {
+		defer close(done)
+		_ = coord.run(ctx, "cluster-a", func(opCtx context.Context) error { active = opCtx; close(started); <-opCtx.Done(); return opCtx.Err() })
+	}()
+	<-started
+	ran := false
+	require.NoError(t, coord.runWhenIdle(context.Background(), "cluster-a", func(context.Context) error { ran = true; return nil }))
+	require.False(t, ran, "background work must leave a busy cluster alone")
+	require.NoError(t, active.Err(), "background revalidation must not cancel foreground work")
+	require.NoError(t, coord.runWhenIdle(context.Background(), "cluster-b", func(context.Context) error { ran = true; return nil }))
+	require.True(t, ran, "another cluster must remain available")
+	cancel()
+	<-done
+	ran = false
+	require.NoError(t, coord.runWhenIdle(context.Background(), "cluster-a", func(context.Context) error { ran = true; return nil }))
+	require.True(t, ran, "deferred background work must be admitted after foreground completion")
+}

--- a/backend/events.go
+++ b/backend/events.go
@@ -16,6 +16,7 @@ const (
 	clusterHealthDegradedEventName      = "cluster:health:degraded"
 	clusterHealthHealthyEventName       = "cluster:health:healthy"
 	clusterLifecycleEventName           = "cluster:lifecycle"
+	clusterPermissionsChangedEventName  = "cluster:permissions:changed"
 	clusterScopeChangedEventName        = "cluster:scope:changed"
 	kubeconfigAvailableChangedEventName = "kubeconfig:available-changed"
 	appearanceModeChangedEventName      = "settings:appearance-mode-changed"
@@ -60,6 +61,10 @@ type ClusterLifecycleEvent struct {
 	PreviousState string                `json:"previousState"`
 }
 
+type ClusterPermissionsChangedEvent struct {
+	ClusterID string `json:"clusterId"`
+}
+
 type ClusterScopeChangedEvent struct {
 	ClusterID string `json:"clusterId"`
 }
@@ -84,6 +89,7 @@ func init() {
 	application.RegisterEvent[ClusterHealthEvent](clusterHealthDegradedEventName)
 	application.RegisterEvent[ClusterHealthEvent](clusterHealthHealthyEventName)
 	application.RegisterEvent[ClusterLifecycleEvent](clusterLifecycleEventName)
+	application.RegisterEvent[ClusterPermissionsChangedEvent](clusterPermissionsChangedEventName)
 	application.RegisterEvent[ClusterScopeChangedEvent](clusterScopeChangedEventName)
 	application.RegisterEvent[application.Void](kubeconfigAvailableChangedEventName)
 	application.RegisterEvent[AppearanceModeChangedEvent](appearanceModeChangedEventName)

--- a/backend/objectcatalog/ingest_source.go
+++ b/backend/objectcatalog/ingest_source.go
@@ -135,8 +135,7 @@ func requestedNamespaceSet(desc resourceDescriptor, namespaces []string) map[str
 // this kind. It serializes against full syncs the same way watchNotifier.flush does.
 func (s *Service) applyIngestCatalogSummary(gvr schema.GroupVersionResource, summary Summary, deleted bool) {
 	if !s.syncMu.TryLock() {
-		// A full sync is in progress and will reconcile this kind from CatalogRows;
-		// dropping the incremental is safe because the sync reads the same store.
+		s.queueIngestReconciliation(gvr)
 		return
 	}
 	defer s.syncMu.Unlock()
@@ -177,13 +176,14 @@ func (s *Service) applyIngestCatalogSummary(gvr schema.GroupVersionResource, sum
 
 func (s *Service) replaceIngestCatalogSummaries(gvr schema.GroupVersionResource, rows []Summary) {
 	if !s.syncMu.TryLock() {
+		s.queueIngestReconciliation(gvr)
 		return
 	}
 	defer s.syncMu.Unlock()
-	if s.syncInProgress.Load() {
-		return
-	}
+	s.replaceIngestCatalogSummariesLocked(gvr, rows)
+}
 
+func (s *Service) replaceIngestCatalogSummariesLocked(gvr schema.GroupVersionResource, rows []Summary) {
 	desc, ok := s.resolveIngestDescriptor(gvr)
 	if !ok {
 		return
@@ -286,4 +286,66 @@ func (s ingestCatalogSink) Replace(rows []interface{}) {
 		summaries = append(summaries, summary)
 	}
 	s.service.replaceIngestCatalogSummaries(s.gvr, summaries)
+}
+
+// Coalesce contention by kind, then reread its authoritative store after the
+// callback releases the store lock. Waiting for syncMu inside a sink would
+// invert the full-sync -> source-store lock order.
+func (s *Service) queueIngestReconciliation(gvr schema.GroupVersionResource) {
+	s.ingestPendingMu.Lock()
+	defer s.ingestPendingMu.Unlock()
+	if s.ingestStopped || s.deps.IngestSource == nil {
+		return
+	}
+	if s.ingestPending == nil {
+		s.ingestPending = make(map[schema.GroupVersionResource]struct{})
+	}
+	s.ingestPending[gvr] = struct{}{}
+	if s.ingestDrainDone != nil {
+		return
+	}
+	done := make(chan struct{})
+	s.ingestDrainDone = done
+	go s.drainIngestReconciliation(done)
+}
+
+func (s *Service) drainIngestReconciliation(done chan struct{}) {
+	defer close(done)
+	for {
+		s.ingestPendingMu.Lock()
+		if s.ingestStopped || len(s.ingestPending) == 0 {
+			s.ingestDrainDone = nil
+			s.ingestPendingMu.Unlock()
+			return
+		}
+		var gvr schema.GroupVersionResource
+		for candidate := range s.ingestPending {
+			gvr = candidate
+			break
+		}
+		delete(s.ingestPending, gvr)
+		s.ingestPendingMu.Unlock()
+
+		s.syncMu.Lock()
+		rows := s.deps.IngestSource.CatalogRows(gvr)
+		summaries := make([]Summary, 0, len(rows))
+		for _, row := range rows {
+			if summary, ok := row.(Summary); ok {
+				summaries = append(summaries, summary)
+			}
+		}
+		s.replaceIngestCatalogSummariesLocked(gvr, summaries)
+		s.syncMu.Unlock()
+	}
+}
+
+func (s *Service) stopIngestReconciliation() {
+	s.ingestPendingMu.Lock()
+	s.ingestStopped = true
+	s.ingestPending = nil
+	done := s.ingestDrainDone
+	s.ingestPendingMu.Unlock()
+	if done != nil {
+		<-done
+	}
 }

--- a/backend/objectcatalog/ingest_source_test.go
+++ b/backend/objectcatalog/ingest_source_test.go
@@ -7,7 +7,9 @@
 package objectcatalog
 
 import (
+	"sync"
 	"testing"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -22,7 +24,9 @@ type replayIngestSource struct {
 	rows map[schema.GroupVersionResource][]interface{}
 }
 
-func (r replayIngestSource) CatalogRows(schema.GroupVersionResource) []interface{} { return nil }
+func (r replayIngestSource) CatalogRows(gvr schema.GroupVersionResource) []interface{} {
+	return r.rows[gvr]
+}
 func (r replayIngestSource) AddCatalogSink(gvr schema.GroupVersionResource, sink ingest.Sink) bool {
 	if bulk, ok := sink.(ingest.Replacer); ok {
 		bulk.Replace(r.rows[gvr])
@@ -85,5 +89,94 @@ func TestRegisterIngestCatalogSinksRebuildsCacheOnce(t *testing.T) {
 		if !found {
 			t.Fatalf("replayed row for %s missing from the catalog index after batched registration", gvr)
 		}
+	}
+}
+
+func TestConcurrentIngestUpdatesBothReachCatalog(t *testing.T) {
+	rows := make(map[schema.GroupVersionResource][]interface{})
+	svc := NewService(Dependencies{IngestSource: replayIngestSource{rows: rows}}, nil)
+	gvr := schema.GroupVersionResource{Version: "v1", Resource: "pods"}
+	desc := resourceDescriptor{Kind: "Pod", Version: "v1", Resource: "pods", GVR: gvr, Namespaced: true}
+	svc.catalogIndex.setResource(gvr.String(), desc)
+	secondGVR := schema.GroupVersionResource{Version: "v1", Resource: "configmaps"}
+	secondDesc := resourceDescriptor{Kind: "ConfigMap", Version: "v1", Resource: "configmaps", GVR: secondGVR, Namespaced: true}
+	svc.catalogIndex.setResource(secondGVR.String(), secondDesc)
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	svc.now = func() time.Time { once.Do(func() { close(entered); <-release }); return time.Unix(1, 0) }
+	row := func(name string) Summary {
+		return Summary{Ref: resourcemodel.ResourceRef{ClusterID: "cluster-a", Version: "v1", Kind: "Pod", Resource: "pods", Namespace: "default", Name: name}}
+	}
+	rows[gvr] = []interface{}{row("first")}
+	secondRow := row("second")
+	secondRow.Ref.Kind = "ConfigMap"
+	secondRow.Ref.Resource = "configmaps"
+	rows[secondGVR] = []interface{}{secondRow}
+	firstDone := make(chan struct{})
+	go func() { defer close(firstDone); svc.applyIngestCatalogSummary(gvr, row("first"), false) }()
+	<-entered
+	secondDone := make(chan struct{})
+	go func() {
+		defer close(secondDone)
+		secondRow := row("second")
+		secondRow.Ref.Kind = "ConfigMap"
+		secondRow.Ref.Resource = "configmaps"
+		svc.applyIngestCatalogSummary(secondGVR, secondRow, false)
+	}()
+	select {
+	case <-secondDone:
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(release)
+	<-firstDone
+	<-secondDone
+	deadline := time.After(time.Second)
+	for {
+		svc.mu.RLock()
+		count := len(svc.items)
+		svc.mu.RUnlock()
+		if count == 2 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("concurrent callbacks kept %d of 2 rows", count)
+		case <-time.After(time.Millisecond):
+		}
+	}
+}
+
+func TestContendedIngestReplaceReconcilesAuthoritativeRows(t *testing.T) {
+	gvr := schema.GroupVersionResource{Version: "v1", Resource: "pods"}
+	desc := resourceDescriptor{Kind: "Pod", Version: "v1", Resource: "pods", GVR: gvr, Namespaced: true}
+	row := Summary{Ref: resourcemodel.ResourceRef{ClusterID: "cluster-a", Version: "v1", Kind: "Pod", Resource: "pods", Namespace: "default", Name: "latest"}}
+	svc := NewService(Dependencies{IngestSource: replayIngestSource{rows: map[schema.GroupVersionResource][]interface{}{gvr: {row}}}}, nil)
+	svc.catalogIndex.setResource(gvr.String(), desc)
+	svc.syncMu.Lock()
+	svc.replaceIngestCatalogSummaries(gvr, nil)
+	svc.syncMu.Unlock()
+	deadline := time.After(time.Second)
+	for {
+		svc.mu.RLock()
+		count := len(svc.items)
+		svc.mu.RUnlock()
+		if count == 1 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("contended Replace never reconciled authoritative rows")
+		case <-time.After(time.Millisecond):
+		}
+	}
+	svc.stopIngestReconciliation()
+	svc.syncMu.Lock()
+	svc.replaceIngestCatalogSummaries(gvr, nil)
+	svc.syncMu.Unlock()
+	svc.ingestPendingMu.Lock()
+	defer svc.ingestPendingMu.Unlock()
+	if svc.ingestDrainDone != nil || len(svc.ingestPending) != 0 {
+		t.Fatal("retired catalog spawned another reconciliation")
 	}
 }

--- a/backend/objectcatalog/service.go
+++ b/backend/objectcatalog/service.go
@@ -98,8 +98,12 @@ type Service struct {
 	healthMu sync.RWMutex
 	health   healthStatus
 
-	syncMu         sync.Mutex  // serializes full syncs from the run loop and watch recovery path
-	syncInProgress atomic.Bool // true while sync() is running; prevents watch flush races
+	ingestPendingMu sync.Mutex
+	ingestPending   map[schema.GroupVersionResource]struct{}
+	ingestDrainDone chan struct{}
+	ingestStopped   bool
+	syncMu          sync.Mutex  // serializes full syncs from the run loop and watch recovery path
+	syncInProgress  atomic.Bool // true while sync() is running; prevents watch flush races
 
 	startOnce sync.Once
 	doneCh    chan struct{}

--- a/backend/objectcatalog/sync.go
+++ b/backend/objectcatalog/sync.go
@@ -298,6 +298,7 @@ func nextCatalogResyncInterval(syncOK bool, current, retry, full time.Duration) 
 func (s *Service) runLoop(ctx context.Context) error {
 	defer close(s.doneCh)
 	defer s.stopDynamicReflectors()
+	defer s.stopIngestReconciliation()
 
 	// Initial sync.
 	initialSyncErr := s.sync(ctx)
@@ -309,8 +310,8 @@ func (s *Service) runLoop(ctx context.Context) error {
 	// sink-registration replay walks populated ingest stores and can take a while,
 	// and a failed initial sync — the startup race — is exactly when the fast retry
 	// below must fire promptly. Registration racing a sync is safe by design: the
-	// incremental appliers TryLock syncMu and DROP their update while a sync runs
-	// (the sync reconciles from the same stores).
+	// contended ingest callbacks queue a trailing authoritative read, including
+	// changes arriving after the full sync already collected their kind.
 	if s.opts.EnableReactiveUpdates && s.deps.InformerFactory != nil {
 		notifier := newWatchNotifier(s)
 		go func() {

--- a/backend/refresh/domain/maintained_stores.go
+++ b/backend/refresh/domain/maintained_stores.go
@@ -93,11 +93,9 @@ func mmapFileName(dir, name string) string {
 // needed. It is the governor's Cold-tier serving transition: the stores' bulk column data
 // goes off-heap (OS-reclaimable page cache) while the subsystem keeps serving Build queries.
 //
-// It returns one closer per store, which the caller must hold for the cooled subsystem's
-// lifetime and call exactly once on re-warm/teardown (each closer is itself idempotent). On
-// ANY error — mkdir or any store's swap — it closes every mapping it already opened (reverse
-// order) and returns the error with NO closers, so the caller can safely fall back to a full
-// teardown with nothing left half-mapped.
+// It returns closers for every swapped store, including on partial failure.
+// The owner must retire serving before closing them; a swapped store still
+// references its mapping even if a later store fails to cool.
 func (r *Registry) CoolMaintainedStoresToMmap(dir string) ([]func() error, error) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, fmt.Errorf("domain: cool mkdir %q: %w", dir, err)
@@ -106,11 +104,7 @@ func (r *Registry) CoolMaintainedStoresToMmap(dir string) ([]func() error, error
 	for _, ns := range r.maintainedSnapshot() {
 		closer, err := ns.store.SwapToMmap(mmapFileName(dir, ns.name))
 		if err != nil {
-			// Safe-degrade: unmap everything opened so far before reporting the failure.
-			for i := len(closers) - 1; i >= 0; i-- {
-				_ = closers[i]()
-			}
-			return nil, fmt.Errorf("cool %q: %w", ns.name, err)
+			return closers, fmt.Errorf("cool %q: %w", ns.name, err)
 		}
 		closers = append(closers, closer)
 	}

--- a/backend/refresh/domain/maintained_stores_test.go
+++ b/backend/refresh/domain/maintained_stores_test.go
@@ -75,21 +75,19 @@ func TestRegistryCoolMaintainedStoresToMmap(t *testing.T) {
 	require.Equal(t, 1, b.closed)
 }
 
-// TestRegistryCoolMaintainedStoresToMmapErrorClosesOpened proves safe-degrade: if any store
-// fails to swap, the registry closes every mapping it already opened and returns the error
-// with NO closers, so the caller can fall back to a full teardown with nothing left mapped.
-func TestRegistryCoolMaintainedStoresToMmapErrorClosesOpened(t *testing.T) {
+// Partial cooling retains already-swapped mappings until the owner retires reads.
+func TestRegistryCoolFailureRetainsMappingsUntilRetirement(t *testing.T) {
 	reg := New()
-	// dom-a swaps first (sorted order), dom-z fails — dom-a's mapping must be closed.
 	a := &fakeSpillable{rows: []string{"a1"}}
 	z := &fakeSpillable{swapErr: errBoom}
 	reg.RegisterMaintainedStore("dom-a", a)
 	reg.RegisterMaintainedStore("dom-z", z)
-
 	closers, err := reg.CoolMaintainedStoresToMmap(t.TempDir())
 	require.ErrorIs(t, err, errBoom)
-	require.Nil(t, closers, "no closers returned on a failed cool")
-	require.Equal(t, 1, a.closed, "the already-opened mapping is closed on cool failure")
+	require.Zero(t, a.closed, "already-swapped stores remain readable until their owner retires them")
+	require.Len(t, closers, 1)
+	require.NoError(t, closers[0]())
+	require.Equal(t, 1, a.closed)
 }
 
 var errBoom = errBoomType("boom")

--- a/backend/refresh/informer/factory.go
+++ b/backend/refresh/informer/factory.go
@@ -54,9 +54,9 @@ type Factory struct {
 
 	pendingClusterInformers []clusterInformerRegistration
 
-	// permissionAllowed tracks exact permission scopes that have been allowed at least once.
-	permissionAllowed map[PermissionGrant]struct{}
-	permissionMu      sync.RWMutex
+	// permissionDecisions tracks the exact evaluated scopes and their generation's initial decisions.
+	permissionDecisions map[PermissionGrant]bool
+	permissionMu        sync.RWMutex
 
 	runtimePermissions *permissions.Checker
 
@@ -76,7 +76,7 @@ const (
 )
 
 // PermissionGrant preserves the permission evaluator and scope that originally
-// produced an allowed decision so revalidation can repeat the same check.
+// produced a decision so revalidation can repeat the same check.
 type PermissionGrant struct {
 	group     string
 	resource  string
@@ -179,12 +179,12 @@ func New(client kubernetes.Interface, apiextClient apiextensionsclientset.Interf
 	// Projection-at-intake: strip managedFields before any object enters the cache.
 	kubeFactory := informers.NewSharedInformerFactoryWithOptions(client, resync, informers.WithTransform(StripManagedFields))
 	result := &Factory{
-		kubeClient:         client,
-		resync:             resync,
-		factory:            kubeFactory,
-		syncDeadline:       config.RefreshInformerSyncDeadline,
-		permissionAllowed:  make(map[PermissionGrant]struct{}),
-		runtimePermissions: checker,
+		kubeClient:          client,
+		resync:              resync,
+		factory:             kubeFactory,
+		syncDeadline:        config.RefreshInformerSyncDeadline,
+		permissionDecisions: make(map[PermissionGrant]bool),
+		runtimePermissions:  checker,
 	}
 	// nodes is an owned-reflector ingest kind (IngestOwned): the typed node informer is never
 	// instantiated. Node has no Stream descriptor (its table is the bespoke NodeSummary whose
@@ -624,7 +624,7 @@ func (f *Factory) Shutdown() error {
 	f.syncStatesMu.Unlock()
 
 	f.permissionMu.Lock()
-	f.permissionAllowed = nil
+	f.permissionDecisions = nil
 	f.permissionMu.Unlock()
 
 	// Clear factory references to allow GC
@@ -771,20 +771,20 @@ func (f *Factory) recordPermissionDecision(grant PermissionGrant, decision permi
 	if err != nil {
 		return false, err
 	}
-	if decision.Allowed {
-		f.trackAllowedPermission(grant)
-	}
+	f.trackPermissionDecision(grant, decision.Allowed)
 	return decision.Allowed, nil
 }
 
-// trackAllowedPermission records that an exact permission scope has been granted at least once.
-func (f *Factory) trackAllowedPermission(grant PermissionGrant) {
+// trackPermissionDecision preserves denied scopes so restored grants are detected.
+func (f *Factory) trackPermissionDecision(grant PermissionGrant, allowed bool) {
 	if f == nil {
 		return
 	}
 	f.permissionMu.Lock()
-	if f.permissionAllowed != nil {
-		f.permissionAllowed[grant] = struct{}{}
+	if f.permissionDecisions != nil {
+		if _, recorded := f.permissionDecisions[grant]; !recorded {
+			f.permissionDecisions[grant] = allowed
+		}
 	}
 	f.permissionMu.Unlock()
 }
@@ -811,19 +811,19 @@ func (f *Factory) PrimePermissions(ctx context.Context, requests []PermissionReq
 	return g.Wait()
 }
 
-// PermissionAllowedSnapshot returns exact permission scopes that have been allowed at least once.
-func (f *Factory) PermissionAllowedSnapshot() []PermissionGrant {
+// PermissionSnapshot returns recorded decisions at their original evaluation scopes.
+func (f *Factory) PermissionSnapshot() map[PermissionGrant]bool {
 	if f == nil {
 		return nil
 	}
 	f.permissionMu.RLock()
 	defer f.permissionMu.RUnlock()
-	if len(f.permissionAllowed) == 0 {
+	if len(f.permissionDecisions) == 0 {
 		return nil
 	}
-	grants := make([]PermissionGrant, 0, len(f.permissionAllowed))
-	for grant := range f.permissionAllowed {
-		grants = append(grants, grant)
+	grants := make(map[PermissionGrant]bool, len(f.permissionDecisions))
+	for grant, allowed := range f.permissionDecisions {
+		grants[grant] = allowed
 	}
 	return grants
 }

--- a/backend/refresh/informer/factory_test.go
+++ b/backend/refresh/informer/factory_test.go
@@ -592,9 +592,9 @@ func TestHelmStorageSourceSkipsDeniedKinds(t *testing.T) {
 
 func newMinimalFactory(checker *permissions.Checker) *Factory {
 	return &Factory{
-		kubeClient:         fake.NewClientset(),
-		permissionAllowed:  make(map[PermissionGrant]struct{}),
-		runtimePermissions: checker,
+		kubeClient:          fake.NewClientset(),
+		permissionDecisions: make(map[PermissionGrant]bool),
+		runtimePermissions:  checker,
 	}
 }
 
@@ -622,7 +622,7 @@ func TestCanListWatchInNamespaceChecksTheExactInformerScope(t *testing.T) {
 	}
 }
 
-func TestPermissionAllowedSnapshotPreservesEvaluationScope(t *testing.T) {
+func TestPermissionSnapshotPreservesEvaluationScope(t *testing.T) {
 	allows := func(group, resource, namespace string) bool {
 		return (group == "apps" && resource == "deployments" && namespace == "team-b") ||
 			(group == "example.com" && resource == "widgets" && namespace == "team-a")
@@ -646,10 +646,10 @@ func TestPermissionAllowedSnapshotPreservesEvaluationScope(t *testing.T) {
 		return group == "apps" && resource == "deployments"
 	})
 
-	grants := factory.PermissionAllowedSnapshot()
+	grants := factory.PermissionSnapshot()
 	require.Len(t, grants, 4)
 	identities := make([]string, 0, len(grants))
-	for _, grant := range grants {
+	for grant := range grants {
 		decision, err := grant.Revalidate(context.Background(), revalidationChecker)
 		require.NoError(t, err)
 		require.True(t, decision.Allowed)
@@ -671,14 +671,14 @@ func TestPermissionAllowedSnapshotPreservesEvaluationScope(t *testing.T) {
 	}, identities)
 }
 
-func TestPermissionAllowedSnapshotIsEmptyBeforeAnyGrant(t *testing.T) {
+func TestPermissionSnapshotIsEmptyBeforeAnyGrant(t *testing.T) {
 	var nilFactory *Factory
-	require.Nil(t, nilFactory.PermissionAllowedSnapshot())
+	require.Nil(t, nilFactory.PermissionSnapshot())
 
 	checker := permissions.NewCheckerWithReview("test", time.Minute, func(context.Context, string, string, string, string) (bool, error) {
 		return true, nil
 	})
-	require.Nil(t, newMinimalFactory(checker).PermissionAllowedSnapshot())
+	require.Nil(t, newMinimalFactory(checker).PermissionSnapshot())
 }
 
 // TestFactoryGateExemptInformerDoesNotBlockFactorySync pins the events exclusion: an

--- a/backend/refresh/resourcestream/manager.go
+++ b/backend/refresh/resourcestream/manager.go
@@ -105,10 +105,11 @@ const (
 )
 
 type subscription struct {
-	ch      chan Update
-	drops   chan DropReason
-	created time.Time
-	once    sync.Once
+	ch         chan Update
+	drops      chan DropReason
+	created    time.Time
+	deliveryMu sync.Mutex
+	closed     bool
 	// resyncing is set when backpressure triggers a RESET for this subscriber.
 	resyncing uint32
 }
@@ -132,16 +133,20 @@ func (s *subscription) close(reason DropReason) {
 	if s == nil {
 		return
 	}
-	s.once.Do(func() {
-		if reason != "" {
-			select {
-			case s.drops <- reason:
-			default:
-			}
+	s.deliveryMu.Lock()
+	defer s.deliveryMu.Unlock()
+	if s.closed {
+		return
+	}
+	s.closed = true
+	if reason != "" {
+		select {
+		case s.drops <- reason:
+		default:
 		}
-		close(s.drops)
-		close(s.ch)
-	})
+	}
+	close(s.drops)
+	close(s.ch)
 }
 
 func (s *subscription) isResyncing() bool {
@@ -243,9 +248,9 @@ type Manager struct {
 	// discarded and replaced by a fresh one. It gates ensureCustomInformer so a
 	// CRD event arriving after teardown (the shared CRD informer can still fire,
 	// including its resync, until the factory is shut down) cannot resurrect a
-	// custom informer whose stopCh nothing would ever close. Guarded by
-	// customInformerMu.
-	stopped bool
+	// custom informer whose stopCh nothing would ever close. Subscription admission
+	// uses the same atomic gate while holding the hub lock.
+	stopped atomic.Bool
 	// customInvalidator evicts cached YAML/details when custom resources change.
 	customInvalidatorMu sync.RWMutex
 	customInvalidator   func(ref resourcemodel.ResourceRef)
@@ -324,7 +329,7 @@ func NewManager(
 	return mgr
 }
 
-// Stop halts any dynamically managed informers that are not owned by the shared factory.
+// Stop closes subscriptions and halts dynamically managed informers. It is terminal.
 func (m *Manager) Stop() {
 	if m == nil {
 		return
@@ -332,9 +337,20 @@ func (m *Manager) Stop() {
 	if m.jobPodOwnerHealSink != nil {
 		m.jobPodOwnerHealSink.Stop()
 	}
+	m.stopped.Store(true)
+	m.mu.Lock()
+	for domain, scopes := range m.subscribers {
+		for scope, subscribers := range scopes {
+			for _, sub := range subscribers {
+				sub.close(DropReasonClosed)
+			}
+			m.clearScopeStateLocked(domain, scope)
+		}
+	}
+	clear(m.subscribers)
+	m.mu.Unlock()
 	m.customInformerMu.Lock()
 	defer m.customInformerMu.Unlock()
-	m.stopped = true
 	for key, informer := range m.customInformers {
 		informer.stop()
 		delete(m.customInformers, key)
@@ -614,7 +630,7 @@ func (m *Manager) applyCustomInformerPlan(plan customInformerPlan) {
 func (m *Manager) reconcileCustomInformerLocked(plan customInformerPlan) *customResourceInformer {
 	// The stopped gate, replacement, and map insert share Stop's lock so an
 	// informer can never be published after terminal teardown.
-	if m.stopped {
+	if m.stopped.Load() {
 		return nil
 	}
 	if plan.action == customInformerPlanRemove {
@@ -1248,13 +1264,11 @@ func (m *Manager) dropSubscriber(domain, scope string, id uint64, sub *subscript
 }
 
 func (m *Manager) trySend(sub *subscription, update Update) (sent bool, closed bool, reset bool) {
-	defer func() {
-		if recover() != nil {
-			closed = true
-			sent = false
-			reset = false
-		}
-	}()
+	sub.deliveryMu.Lock()
+	defer sub.deliveryMu.Unlock()
+	if sub.closed {
+		return false, true, false
+	}
 	select {
 	case sub.ch <- update:
 		return true, false, false

--- a/backend/refresh/resourcestream/manager_test.go
+++ b/backend/refresh/resourcestream/manager_test.go
@@ -1864,3 +1864,39 @@ func customResourceDefinition(
 func ptrBool(value bool) *bool {
 	return &value
 }
+
+func TestStoppedManagerCompletesSubscribersAndRejectsNewOnes(t *testing.T) {
+	manager := NewManager(nil, nil, nil, snapshot.ClusterMeta{ClusterID: "cluster-a"}, nil, nil)
+	sub, err := subscribeForTest(t, manager, "pods", "namespace:default")
+	require.NoError(t, err)
+	manager.Stop()
+	select {
+	case reason := <-sub.Drops:
+		require.Equal(t, DropReasonClosed, reason)
+	default:
+		t.Fatal("stopped producer left a healthy-looking subscription")
+	}
+	_, err = subscribeForTest(t, manager, "pods", "namespace:default")
+	require.Error(t, err, "a stopped producer must not ACK new subscriptions")
+	sub.Cancel()
+	manager.Stop()
+}
+
+func TestSubscriptionCloseSerializesWithDelivery(t *testing.T) {
+	manager := NewManager(nil, nil, nil, snapshot.ClusterMeta{ClusterID: "cluster-a"}, nil, nil)
+	for range 100 {
+		sub := &subscription{ch: make(chan Update, 1), drops: make(chan DropReason, 1)}
+		started := make(chan struct{})
+		done := make(chan struct{})
+		go func() {
+			close(started)
+			defer close(done)
+			for range 100 {
+				manager.trySend(sub, Update{})
+			}
+		}()
+		<-started
+		sub.close(DropReasonClosed)
+		<-done
+	}
+}

--- a/backend/refresh/resourcestream/stream_hub.go
+++ b/backend/refresh/resourcestream/stream_hub.go
@@ -66,6 +66,9 @@ func validateStreamSelector(m *Manager, selector StreamSelector) error {
 func (m *Manager) addSubscriber(domain, scope string) (uint64, *subscription, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.stopped.Load() {
+		return 0, nil, errors.New("resource stream stopped")
+	}
 	domainSubscribers := m.subscribers[domain]
 	if domainSubscribers == nil {
 		domainSubscribers = make(map[string]map[uint64]*subscription)

--- a/backend/refresh/snapshot/service.go
+++ b/backend/refresh/snapshot/service.go
@@ -44,10 +44,13 @@ type Service struct {
 	cacheMu             sync.RWMutex
 	cache               map[string]cacheEntry
 	cacheTTL            time.Duration
+	invalidations       map[string]uint64
 	epoch               string
 	permissionChecker   *permissions.Checker
 	runtimeAccess       domainpermissions.RuntimeAccess
 	requestSerial       uint64
+	servingMu           sync.RWMutex
+	retired             atomic.Bool
 	generationMu        sync.Mutex
 	generationRequests  map[uint64]context.CancelFunc
 	generationRequestID uint64
@@ -57,6 +60,8 @@ type Service struct {
 // informer caches never reported synced within the configured deadline — for
 // example when one informer's watch is RBAC-forbidden and can never complete.
 var errInformerSyncTimeout = errors.New("refresh informer caches not synced")
+
+var errServiceRetired = errors.New("snapshot service retired")
 
 type cacheEntry struct {
 	snapshot  *refresh.Snapshot
@@ -162,6 +167,9 @@ func (s *Service) Build(ctx context.Context, domainName, scope string) (*refresh
 }
 
 func (s *Service) BuildRequest(ctx context.Context, req BuildRequest) (*refresh.Snapshot, error) {
+	if s.retired.Load() {
+		return nil, errServiceRetired
+	}
 	ctx, cancel := s.withGenerationContext(ctx)
 	defer cancel()
 	ctx, plan, err := s.prepareBuildRequest(ctx, req)
@@ -184,6 +192,22 @@ func (s *Service) BuildRequest(ctx context.Context, req BuildRequest) (*refresh.
 	case <-flight.done:
 		return flight.snapshot, flight.err
 	}
+}
+
+// Retire rejects future reads and waits for builders to release their stores.
+// CancelInFlight alone allows later reads, which cooling requires.
+func (s *Service) Retire() {
+	if s == nil {
+		return
+	}
+	s.retired.Store(true)
+	s.CancelInFlight()
+	s.servingMu.Lock()
+	defer s.servingMu.Unlock()
+	// No builder can repopulate the cache after this drain.
+	s.cacheMu.Lock()
+	clear(s.cache)
+	s.cacheMu.Unlock()
 }
 
 // CancelInFlight aborts and detaches the builds owned by the current subsystem
@@ -225,6 +249,7 @@ type snapshotBuildRequestPlan struct {
 	domain              string
 	scope               string
 	cacheKey            string
+	invalidation        uint64
 	groupKey            string
 	bypassSnapshotCache bool
 	skipCacheLoad       bool
@@ -254,12 +279,16 @@ func (s *Service) prepareBuildRequest(ctx context.Context, req BuildRequest) (co
 	if readinessKey := resourceReadinessFingerprint(readiness); readinessKey != "" {
 		cacheKey += ":readiness:" + readinessKey
 	}
+	s.cacheMu.RLock()
+	invalidation := s.invalidations[req.Domain]
+	s.cacheMu.RUnlock()
 	bypassSnapshotCache := s.shouldBypassSnapshotCache(req.Domain)
 	return ctx, snapshotBuildRequestPlan{
 		domain:              req.Domain,
 		scope:               req.Scope,
 		cacheKey:            cacheKey,
-		groupKey:            s.snapshotBuildGroupKey(ctx, req.Domain, cacheKey),
+		groupKey:            fmt.Sprintf("%s:invalidation:%d", s.snapshotBuildGroupKey(ctx, req.Domain, cacheKey), invalidation),
+		invalidation:        invalidation,
 		bypassSnapshotCache: bypassSnapshotCache,
 		skipCacheLoad:       refresh.HasCacheBypass(ctx) || bypassSnapshotCache,
 		syncWait:            syncWait,
@@ -302,6 +331,11 @@ func (s *Service) loadBuildRequestCache(plan snapshotBuildRequestPlan) *refresh.
 }
 
 func (s *Service) buildRequestSnapshot(ctx context.Context, plan snapshotBuildRequestPlan) (*refresh.Snapshot, error) {
+	s.servingMu.RLock()
+	defer s.servingMu.RUnlock()
+	if s.retired.Load() {
+		return nil, errServiceRetired
+	}
 	if cached := s.loadBuildRequestCache(plan); cached != nil {
 		return cached, nil
 	}
@@ -319,7 +353,7 @@ func (s *Service) buildRequestSnapshot(ctx context.Context, plan snapshotBuildRe
 	s.finalizeBuiltSnapshot(snapshot, start, duration)
 	s.recordBuildSuccess(plan, snapshot, duration)
 	if !plan.bypassSnapshotCache {
-		s.storeCache(plan.cacheKey, snapshot)
+		s.storeCache(plan, snapshot)
 	}
 	return snapshot, nil
 }
@@ -483,7 +517,7 @@ func (s *Service) loadCache(key string) *refresh.Snapshot {
 	return entry.snapshot
 }
 
-func (s *Service) storeCache(key string, snap *refresh.Snapshot) {
+func (s *Service) storeCache(plan snapshotBuildRequestPlan, snap *refresh.Snapshot) {
 	if s.cacheTTL <= 0 || snap == nil {
 		return
 	}
@@ -491,11 +525,14 @@ func (s *Service) storeCache(key string, snap *refresh.Snapshot) {
 		return
 	}
 	s.cacheMu.Lock()
-	s.cache[key] = cacheEntry{
+	defer s.cacheMu.Unlock()
+	if s.invalidations[plan.domain] != plan.invalidation {
+		return
+	}
+	s.cache[plan.cacheKey] = cacheEntry{
 		snapshot:  snap,
 		expiresAt: time.Now().Add(s.cacheTTL),
 	}
-	s.cacheMu.Unlock()
 }
 
 // InvalidateDomainCache drops every cached snapshot for the domain. The
@@ -509,6 +546,10 @@ func (s *Service) InvalidateDomainCache(domain string) {
 		return
 	}
 	s.cacheMu.Lock()
+	if s.invalidations == nil {
+		s.invalidations = make(map[string]uint64)
+	}
+	s.invalidations[domain]++
 	for key, entry := range s.cache {
 		if entry.snapshot != nil && entry.snapshot.Domain == domain {
 			delete(s.cache, key)

--- a/backend/refresh/snapshot/service_test.go
+++ b/backend/refresh/snapshot/service_test.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1209,4 +1210,95 @@ func TestServiceBuildServesRuntimePolicyExemptDomainForDeniedIdentity(t *testing
 	if snap == nil || !called {
 		t.Fatalf("expected the builder to run (called=%v, snap=%v)", called, snap)
 	}
+}
+
+func TestServiceRetirementDrainsBuildersAndRejectsLateReads(t *testing.T) {
+	reg := domain.New()
+	entered, canceled, release := make(chan struct{}), make(chan struct{}), make(chan struct{})
+	require.NoError(t, reg.Register(refresh.DomainConfig{Name: "demo", BuildSnapshot: func(ctx context.Context, scope string) (*refresh.Snapshot, error) {
+		close(entered)
+		<-ctx.Done()
+		close(canceled)
+		<-release
+		return nil, ctx.Err()
+	}}))
+	service := NewServiceWithPermissions(reg, nil, testClusterMeta(), nil)
+	finished := make(chan struct{})
+	go func() { defer close(finished); _, _ = service.Build(context.Background(), "demo", "cluster-a|") }()
+	<-entered
+	retired := make(chan struct{})
+	go func() { service.Retire(); close(retired) }()
+	<-canceled
+	select {
+	case <-retired:
+		t.Error("retired before the builder stopped accessing its store")
+	default:
+	}
+	close(release)
+	<-retired
+	<-finished
+	_, err := service.Build(context.Background(), "demo", "cluster-a|")
+	require.Error(t, err, "a captured old service must reject a new read after retirement")
+}
+
+func TestInvalidationDuringBuildCannotRepopulateOldSnapshot(t *testing.T) {
+	reg := domain.New()
+	captured := make(chan struct{})
+	release := make(chan struct{})
+	builds := 0
+	require.NoError(t, reg.Register(refresh.DomainConfig{Name: "cluster-attention", BuildSnapshot: func(ctx context.Context, scope string) (*refresh.Snapshot, error) {
+		builds++
+		payload := builds
+		if builds == 1 {
+			close(captured)
+			<-release
+		}
+		return &refresh.Snapshot{Domain: "cluster-attention", Scope: scope, Payload: payload}, nil
+	}}))
+	service := NewServiceWithPermissions(reg, nil, testClusterMeta(), nil)
+	service.cacheTTL = time.Minute
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		_, _ = service.Build(context.Background(), "cluster-attention", "cluster-a|")
+	}()
+	<-captured
+	service.InvalidateDomainCache("cluster-attention")
+	close(release)
+	<-finished
+	fresh, err := service.Build(context.Background(), "cluster-attention", "cluster-a|")
+	require.NoError(t, err)
+	require.Equal(t, 2, fresh.Payload, "post-doorbell reconciliation must rebuild, not read the invalidated in-flight result")
+}
+
+func TestInvalidationSeparatesNewRequestsFromOldFlights(t *testing.T) {
+	reg := domain.New()
+	captured, release := make(chan struct{}), make(chan struct{})
+	var builds atomic.Int32
+	require.NoError(t, reg.Register(refresh.DomainConfig{Name: "cluster-attention", BuildSnapshot: func(ctx context.Context, scope string) (*refresh.Snapshot, error) {
+		value := builds.Add(1)
+		if value == 1 {
+			close(captured)
+			<-release
+		}
+		return &refresh.Snapshot{Domain: "cluster-attention", Scope: scope, Payload: value}, nil
+	}}))
+	service := NewServiceWithPermissions(reg, nil, testClusterMeta(), nil)
+	oldDone := make(chan struct{})
+	go func() {
+		defer close(oldDone)
+		_, _ = service.Build(context.Background(), "cluster-attention", "cluster-a|")
+	}()
+	<-captured
+	service.InvalidateDomainCache("cluster-attention")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	fresh, err := service.Build(ctx, "cluster-attention", "cluster-a|")
+	close(release)
+	<-oldDone
+	require.NoError(t, err, "a post-invalidation request must not wait on the old flight")
+	require.Equal(t, int32(2), fresh.Payload)
+	cached, err := service.Build(context.Background(), "cluster-attention", "cluster-a|")
+	require.NoError(t, err)
+	require.Equal(t, int32(2), cached.Payload, "old completion must not replace the new cached snapshot")
 }

--- a/backend/refresh/streammux/handler.go
+++ b/backend/refresh/streammux/handler.go
@@ -439,36 +439,48 @@ func (s *session) forwardSubscription(key string, entry *sessionSubscription, re
 			Error: fmt.Sprintf("subscription ended: %s", reason),
 		}, true)
 	}()
+	reason = s.forwardSubscriptionUpdates(key, entry, resumeHighWater)
+}
+
+func (s *session) forwardSubscriptionUpdates(key string, entry *sessionSubscription, resumeHighWater uint64) DropReason {
 	for {
 		select {
 		case update, ok := <-entry.sub.Updates:
 			if !ok {
-				select {
-				case dropped, open := <-entry.sub.Drops:
-					if open {
-						reason = dropped
-					}
-				default:
-				}
-				return
+				return pendingSubscriptionDropReason(entry.sub.Drops)
 			}
-			if resumeHighWater > 0 {
-				if sequence, ok := parseSequence(update.Sequence); ok && sequence <= resumeHighWater {
-					continue
-				}
-			}
-			if !s.deliverSubscriptionMessage(key, entry, s.withClusterInfo(update, entry.clusterID, entry.clusterName), false) {
-				return
+			if !s.forwardLiveSubscriptionUpdate(key, entry, update, resumeHighWater) {
+				return DropReasonClosed
 			}
 		case dropped, ok := <-entry.sub.Drops:
 			if ok {
-				reason = dropped
+				return dropped
 			}
-			return
+			return DropReasonClosed
 		case <-s.done:
-			return
+			return DropReasonClosed
 		}
 	}
+}
+
+func pendingSubscriptionDropReason(drops <-chan DropReason) DropReason {
+	select {
+	case reason, ok := <-drops:
+		if ok {
+			return reason
+		}
+	default:
+	}
+	return DropReasonClosed
+}
+
+func (s *session) forwardLiveSubscriptionUpdate(key string, entry *sessionSubscription, update ServerMessage, resumeHighWater uint64) bool {
+	if resumeHighWater > 0 {
+		if sequence, ok := parseSequence(update.Sequence); ok && sequence <= resumeHighWater {
+			return true
+		}
+	}
+	return s.deliverSubscriptionMessage(key, entry, s.withClusterInfo(update, entry.clusterID, entry.clusterName), false)
 }
 
 // A replaced or explicitly cancelled subscription cannot deliver into its successor.

--- a/backend/refresh/streammux/handler.go
+++ b/backend/refresh/streammux/handler.go
@@ -172,11 +172,12 @@ type session struct {
 	allowClusterScopedRequest bool
 	resolveClusterName        func(clusterID string) string
 
-	mu        sync.Mutex
-	subs      map[string]*sessionSubscription
-	outgoing  chan ServerMessage
-	done      chan struct{}
-	closeOnce sync.Once
+	deliveryMu sync.Mutex // Orders replacement ACKs after the old subscription's final delivery.
+	mu         sync.Mutex
+	subs       map[string]*sessionSubscription
+	outgoing   chan ServerMessage
+	done       chan struct{}
+	closeOnce  sync.Once
 
 	signalVersionCounter uint64
 }
@@ -296,12 +297,26 @@ func (s *session) handleSubscribe(msg ClientMessage) {
 	}
 
 	key := subscriptionKey(selector)
-	s.storeSubscription(key, sub, clusterID, clusterName)
+	s.deliveryMu.Lock()
+	entry := s.storeSubscription(key, sub, clusterID, clusterName)
+	if entry == nil {
+		s.deliveryMu.Unlock()
+		return
+	}
 	s.enqueueSubscriptionAck(msg.Domain, normalized, clusterID, clusterName)
 	resume := s.resumeSubscription(selector, msg.ResumeToken, msg.Domain, normalized)
+	// A retained resource tail can exceed the shared outgoing queue. Reset that
+	// scope before replaying anything, or reconnect would replay the same backlog
+	// and disconnect again. deliveryMu prevents competing subscription delivery;
+	// the writer may only increase the available capacity while we decide.
+	if s.sendReset && len(resume.updates) > cap(s.outgoing)-len(s.outgoing) {
+		resume.ok = false
+		resume.updates = nil
+	}
 	s.enqueueSubscriptionReset(msg.Domain, normalized, clusterID, clusterName, resume.ok)
 	s.enqueueResumeUpdates(resume.updates, clusterID, clusterName)
-	go s.forwardSubscription(key, resume.highWater)
+	s.deliveryMu.Unlock()
+	go s.forwardSubscription(key, entry, resume.highWater)
 }
 
 func (s *session) enqueueSubscriptionAck(domain, scope, clusterID, clusterName string) {
@@ -393,56 +408,89 @@ func (s *session) handleCancel(msg ClientMessage) {
 	sub.sub.Cancel()
 }
 
-func (s *session) storeSubscription(key string, sub *Subscription, clusterID, clusterName string) {
+func (s *session) storeSubscription(key string, sub *Subscription, clusterID, clusterName string) *sessionSubscription {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.doneError() != nil {
+		sub.Cancel()
+		return nil
+	}
 	if existing := s.subs[key]; existing != nil {
 		existing.sub.Cancel()
 	}
-	s.subs[key] = &sessionSubscription{
+	entry := &sessionSubscription{
 		sub:         sub,
 		clusterID:   clusterID,
 		clusterName: clusterName,
 	}
+	s.subs[key] = entry
+	return entry
 }
 
-func (s *session) forwardSubscription(key string, resumeHighWater uint64) {
-	s.mu.Lock()
-	entry := s.subs[key]
-	s.mu.Unlock()
+func (s *session) forwardSubscription(key string, entry *sessionSubscription, resumeHighWater uint64) {
 	if entry == nil {
 		return
 	}
+	reason := DropReasonClosed
+	defer func() {
+		s.deliverSubscriptionMessage(key, entry, ServerMessage{
+			Type: MessageTypeComplete, Domain: entry.sub.Domain, Scope: entry.sub.Scope,
+			ClusterID: entry.clusterID, ClusterName: entry.clusterName,
+			Error: fmt.Sprintf("subscription ended: %s", reason),
+		}, true)
+	}()
 	for {
 		select {
 		case update, ok := <-entry.sub.Updates:
 			if !ok {
+				select {
+				case dropped, open := <-entry.sub.Drops:
+					if open {
+						reason = dropped
+					}
+				default:
+				}
 				return
 			}
 			if resumeHighWater > 0 {
-				// Skip updates already replayed from the resume buffer.
 				if sequence, ok := parseSequence(update.Sequence); ok && sequence <= resumeHighWater {
 					continue
 				}
 			}
-			s.enqueue(s.withClusterInfo(update, entry.clusterID, entry.clusterName))
-		case reason, ok := <-entry.sub.Drops:
-			if !ok {
+			if !s.deliverSubscriptionMessage(key, entry, s.withClusterInfo(update, entry.clusterID, entry.clusterName), false) {
 				return
 			}
-			s.enqueue(ServerMessage{
-				Type:        MessageTypeComplete,
-				Domain:      entry.sub.Domain,
-				Scope:       entry.sub.Scope,
-				ClusterID:   entry.clusterID,
-				ClusterName: entry.clusterName,
-				Error:       fmt.Sprintf("subscription ended: %s", reason),
-			})
+		case dropped, ok := <-entry.sub.Drops:
+			if ok {
+				reason = dropped
+			}
 			return
 		case <-s.done:
 			return
 		}
 	}
+}
+
+// A replaced or explicitly cancelled subscription cannot deliver into its successor.
+func (s *session) deliverSubscriptionMessage(key string, entry *sessionSubscription, msg ServerMessage, terminal bool) bool {
+	s.deliveryMu.Lock()
+	defer s.deliveryMu.Unlock()
+	s.mu.Lock()
+	current := s.subs[key] == entry
+	if current && terminal {
+		delete(s.subs, key)
+	}
+	s.mu.Unlock()
+	if !current {
+		return false
+	}
+	select {
+	case <-s.done:
+		return false
+	default:
+	}
+	s.enqueue(msg)
+	return true
 }
 
 func (s *session) enqueue(msg ServerMessage) {
@@ -471,46 +519,15 @@ func (s *session) nextSignalVersion(source Source) string {
 
 func (s *session) handleBackpressure(msg ServerMessage) {
 	if msg.Type == MessageTypeHeartbeat {
-		s.logger.Warn("stream mux: outgoing buffer full, dropping heartbeat", logsources.StreamMux, s.clusterID, s.clusterName)
 		return
-	}
-
-	// Drop the oldest message and issue a RESET so only the hot scope resyncs.
-	select {
-	case <-s.outgoing:
-	default:
 	}
 	if s.telemetry != nil {
 		s.telemetry.RecordStreamDelivery(s.streamName, 0, 1)
 	}
-
-	if msg.Domain == "" || msg.Scope == "" {
-		s.logger.Warn("stream mux: outgoing buffer full, dropping message", logsources.StreamMux, s.clusterID, s.clusterName)
-		return
-	}
-
-	clusterID := strings.TrimSpace(msg.ClusterID)
-	if clusterID == "" {
-		clusterID = s.clusterID
-	}
-	clusterName := msg.ClusterName
-	if clusterName == "" {
-		clusterName = s.clusterNameFor(clusterID)
-	}
-	reset := ServerMessage{
-		Type:        MessageTypeReset,
-		Domain:      msg.Domain,
-		Scope:       msg.Scope,
-		ClusterID:   clusterID,
-		ClusterName: clusterName,
-	}
-	reset = s.prepareOutgoingMessage(reset)
-	select {
-	case s.outgoing <- reset:
-		s.logger.Warn(fmt.Sprintf("stream mux: outgoing buffer full, issued reset for %s/%s", msg.Domain, msg.Scope), logsources.StreamMux, clusterID, clusterName)
-	default:
-		s.logger.Warn("stream mux: outgoing buffer full, dropping message", logsources.StreamMux, clusterID, clusterName)
-	}
+	// A shared queue may contain another cluster's last signal. Disconnecting
+	// forces every subscription to resume or reset; dropping one frame cannot.
+	s.logger.Warn("stream mux: outgoing buffer full, reconnect required", logsources.StreamMux, s.clusterID, s.clusterName)
+	s.shutdown()
 }
 
 func (s *session) writeLoop(ctx context.Context) {

--- a/backend/refresh/streammux/handler_test.go
+++ b/backend/refresh/streammux/handler_test.go
@@ -3,6 +3,8 @@ package streammux
 import (
 	"context"
 	"errors"
+	"fmt"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -64,52 +66,16 @@ func (stubAdapter) Resume(Selector, uint64) ([]ServerMessage, bool) {
 	return nil, false
 }
 
-func TestSessionBackpressureKeepsSessionOpenAndResetsScope(t *testing.T) {
-	session := newSession(stubConn{}, Config{Adapter: nil, Logger: applog.Noop, Telemetry: nil, ClusterID: "cluster-1", ClusterName: "cluster-a", StreamName: "resources", SendReset: true, AllowClusterScopedRequests: false, ResolveClusterName: nil})
-	// Match production buffer sizing for backpressure behavior.
-	for i := 0; i < config.StreamMuxOutgoingBufferSize; i++ {
-		session.outgoing <- ServerMessage{
-			Type:   MessageTypeAdded,
-			Domain: "pods",
-			Scope:  "default",
-		}
-	}
-
-	session.enqueue(ServerMessage{
-		Type:   MessageTypeModified,
-		Domain: "pods",
-		Scope:  "default",
-	})
-
+func TestSessionBackpressureDisconnectsBeforeSilentlyLosingSignals(t *testing.T) {
+	s := newSession(stubConn{}, Config{Logger: applog.Noop, StreamName: "resources"})
+	s.outgoing = make(chan ServerMessage, 2)
+	s.enqueue(ServerMessage{Type: MessageTypeModified, Domain: "pods", Scope: "namespace:quiet", ClusterID: "cluster-a"})
+	s.enqueue(ServerMessage{Type: MessageTypeModified, Domain: "nodes", Scope: "", ClusterID: "cluster-b"})
+	s.enqueue(ServerMessage{Type: MessageTypeModified, Domain: "nodes", Scope: "", ClusterID: "cluster-b"})
 	select {
-	case <-session.done:
-		t.Fatal("expected session to remain open under backpressure")
+	case <-s.done:
 	default:
-	}
-
-	foundReset := false
-	for i := 0; i < config.StreamMuxOutgoingBufferSize; i++ {
-		select {
-		case msg := <-session.outgoing:
-			if msg.Type == MessageTypeReset && msg.Domain == "pods" && msg.Scope == "default" {
-				if msg.Source != SourceObject {
-					t.Fatalf("expected reset source %q, got %q", SourceObject, msg.Source)
-				}
-				if msg.Signal != SignalReset {
-					t.Fatalf("expected reset signal %q, got %q", SignalReset, msg.Signal)
-				}
-				if msg.Version == "" {
-					t.Fatal("expected reset version")
-				}
-				foundReset = true
-			}
-		default:
-			t.Fatalf("expected %d queued messages, got %d", config.StreamMuxOutgoingBufferSize, i)
-		}
-	}
-
-	if !foundReset {
-		t.Fatal("expected reset message after backpressure")
+		t.Fatal("overflow must disconnect so every scope reconciles on reconnect")
 	}
 }
 
@@ -222,6 +188,169 @@ func (a ackStubAdapter) Resume(Selector, uint64) ([]ServerMessage, bool) {
 	return a.resumeUpdates, a.resumeOK
 }
 
+func TestSessionOversizedResourceResumeResetsWithoutDisconnecting(t *testing.T) {
+	for _, queued := range []int{0, config.StreamMuxOutgoingBufferSize - 2} {
+		t.Run(fmt.Sprintf("queued=%d", queued), func(t *testing.T) {
+			updates := make([]ServerMessage, config.ResourceStreamResumeBufferSize)
+			for i := range updates {
+				updates[i] = ServerMessage{Type: MessageTypeModified, Domain: "pods", Scope: "namespace:default", Sequence: fmt.Sprint(i + 2)}
+			}
+			s := newSession(stubConn{}, Config{
+				Adapter: ackStubAdapter{resumeOK: true, resumeUpdates: updates}, Logger: applog.Noop,
+				ClusterID: "cluster-a", StreamName: "resources", SendReset: true,
+			})
+			t.Cleanup(s.shutdown)
+			// No writer drains this queue: model a stalled renderer during resume.
+			for range queued {
+				s.enqueue(ServerMessage{Type: MessageTypeModified, Domain: "nodes", ClusterID: "cluster-a"})
+			}
+			s.handleSubscribe(ClientMessage{Type: MessageTypeRequest, Domain: "pods", Scope: "namespace:default", ResumeToken: "1"})
+			select {
+			case <-s.done:
+				t.Fatal("oversized replay disconnected; reconnect would replay the same backlog again")
+			default:
+			}
+			for range queued {
+				if msg := <-s.outgoing; msg.Domain != "nodes" {
+					t.Fatalf("another scope's queued update was lost: %+v", msg)
+				}
+			}
+			if types := drainOutgoingTypes(s); !slices.Equal(types, []MessageType{MessageTypeAck, MessageTypeReset}) {
+				t.Fatalf("expected ACK then RESET, got %v", types)
+			}
+		})
+	}
+}
+
+func TestSessionResourceResumeThatFitsPreservesEveryFrame(t *testing.T) {
+	updates := make([]ServerMessage, config.StreamMuxOutgoingBufferSize-1)
+	for i := range updates {
+		updates[i] = ServerMessage{Type: MessageTypeModified, Domain: "pods", Scope: "namespace:default", Sequence: fmt.Sprint(i + 2)}
+	}
+	s := newSession(stubConn{}, Config{
+		Adapter: ackStubAdapter{resumeOK: true, resumeUpdates: updates}, Logger: applog.Noop,
+		ClusterID: "cluster-a", StreamName: "resources", SendReset: true,
+	})
+	t.Cleanup(s.shutdown)
+	s.handleSubscribe(ClientMessage{Type: MessageTypeRequest, Domain: "pods", Scope: "namespace:default", ResumeToken: "1"})
+	if msg := <-s.outgoing; msg.Type != MessageTypeAck {
+		t.Fatalf("expected ACK before replay, got %+v", msg)
+	}
+	for _, expected := range updates {
+		msg := <-s.outgoing
+		if msg.Type != expected.Type || msg.Sequence != expected.Sequence || msg.ClusterID != "cluster-a" {
+			t.Fatalf("replay changed or lost a frame: %+v", msg)
+		}
+	}
+	if len(s.outgoing) != 0 || s.doneError() != nil {
+		t.Fatal("a replay that fits must keep the session open without a reset")
+	}
+}
+
+type channelConn struct {
+	requests  chan ClientMessage
+	responses chan ServerMessage
+	closed    chan struct{}
+	closeOnce sync.Once
+}
+
+func (c *channelConn) ReceiveJSON(value interface{}) error {
+	select {
+	case msg := <-c.requests:
+		*value.(*ClientMessage) = msg
+		return nil
+	case <-c.closed:
+		return errors.New("connection closed")
+	}
+}
+
+func (c *channelConn) SendJSON(value interface{}) error {
+	select {
+	case c.responses <- value.(ServerMessage):
+		return nil
+	case <-c.closed:
+		return errors.New("connection closed")
+	}
+}
+
+func (c *channelConn) Close() error {
+	c.closeOnce.Do(func() { close(c.closed) })
+	return nil
+}
+
+type liveResumeAdapter struct {
+	ackStubAdapter
+	sub *Subscription
+}
+
+func (a liveResumeAdapter) Subscribe(Selector) (*Subscription, error) { return a.sub, nil }
+
+func TestSessionOversizedResumeContinuesLiveDeliveryAndCancellation(t *testing.T) {
+	backlog := make([]ServerMessage, config.ResourceStreamResumeBufferSize)
+	for i := range backlog {
+		backlog[i] = ServerMessage{Type: MessageTypeModified, Domain: "pods", Scope: "namespace:default", Sequence: fmt.Sprint(i + 2)}
+	}
+	updates := make(chan ServerMessage, 2)
+	canceled := make(chan struct{})
+	var cancelOnce sync.Once
+	sub := &Subscription{
+		Domain: "pods", Scope: "namespace:default", Updates: updates,
+		Cancel: func() { cancelOnce.Do(func() { close(canceled); close(updates) }) },
+	}
+	handler, err := NewHandler(Config{
+		Adapter: liveResumeAdapter{ackStubAdapter: ackStubAdapter{resumeOK: true, resumeUpdates: backlog}, sub: sub},
+		Logger:  applog.Noop, ClusterID: "cluster-a", StreamName: "resources", SendReset: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn := &channelConn{
+		requests: make(chan ClientMessage, 1), responses: make(chan ServerMessage), closed: make(chan struct{}),
+	}
+	done := make(chan struct{})
+	go func() { defer close(done); handler.Handle(conn, context.Background()) }()
+	t.Cleanup(func() {
+		handler.Stop()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Error("session did not stop")
+		}
+	})
+	read := func() ServerMessage {
+		t.Helper()
+		select {
+		case msg := <-conn.responses:
+			return msg
+		case <-conn.closed:
+			t.Fatal("session disconnected")
+		case <-time.After(time.Second):
+			t.Fatal("session delivery stalled")
+		}
+		return ServerMessage{}
+	}
+	conn.requests <- ClientMessage{Type: MessageTypeRequest, Domain: "pods", Scope: "namespace:default", ResumeToken: "1"}
+	for _, expected := range []MessageType{MessageTypeAck, MessageTypeReset} {
+		if msg := read(); msg.Type != expected || msg.ClusterID != "cluster-a" {
+			t.Fatalf("unexpected handshake: %+v", msg)
+		}
+	}
+	// Live delivery overlaps the replay tail. It must skip the duplicate, then
+	// deliver the first new sequence over the same connection after RESET.
+	updates <- backlog[len(backlog)-1]
+	live := ServerMessage{Type: MessageTypeModified, Domain: "pods", Scope: "namespace:default", Sequence: fmt.Sprint(len(backlog) + 2)}
+	updates <- live
+	if msg := read(); msg.Type != live.Type || msg.Sequence != live.Sequence || msg.ClusterID != "cluster-a" {
+		t.Fatalf("live delivery did not resume after RESET: %+v", msg)
+	}
+	conn.requests <- ClientMessage{Type: MessageTypeCancel, Domain: "pods", Scope: "namespace:default"}
+	select {
+	case <-canceled:
+	case <-time.After(time.Second):
+		t.Fatal("client cancellation was not processed after replay")
+	}
+}
+
 func drainOutgoingTypes(s *session) []MessageType {
 	types := []MessageType{}
 	for {
@@ -254,5 +383,56 @@ func TestHandleSubscribeAcksEveryAcceptedSubscribe(t *testing.T) {
 	resumedTypes := drainOutgoingTypes(resumed)
 	if len(resumedTypes) != 1 || resumedTypes[0] != MessageTypeAck {
 		t.Fatalf("resumed-empty subscribe must send exactly ACK, got %v", resumedTypes)
+	}
+}
+
+func TestClosedSubscriptionAlwaysNotifiesClient(t *testing.T) {
+	missing := 0
+	for i := 0; i < 100; i++ {
+		s := newSession(stubConn{}, Config{Logger: applog.Noop, StreamName: "resources"})
+		updates := make(chan ServerMessage)
+		drops := make(chan DropReason, 1)
+		drops <- DropReasonClosed
+		close(drops)
+		close(updates)
+		s.subs["test"] = &sessionSubscription{sub: &Subscription{Domain: "pods", Scope: "namespace:default", Updates: updates, Drops: drops, Cancel: func() {}}, clusterID: "cluster-a"}
+		s.forwardSubscription("test", s.subs["test"], 0)
+		if len(s.outgoing) == 0 {
+			missing++
+		}
+	}
+	if missing != 0 {
+		t.Fatalf("%d/100 closed subscriptions emitted no COMPLETE frame", missing)
+	}
+}
+
+func TestOldSubscriptionCannotDeliverIntoReplacement(t *testing.T) {
+	s := newSession(stubConn{}, Config{Logger: applog.Noop, StreamName: "resources"})
+	updates := make(chan ServerMessage)
+	drops := make(chan DropReason, 1)
+	drops <- DropReasonClosed
+	close(drops)
+	close(updates)
+	old := s.storeSubscription("key", &Subscription{Domain: "pods", Updates: updates, Drops: drops, Cancel: func() {}}, "cluster-a", "")
+	next := s.storeSubscription("key", &Subscription{Domain: "pods", Cancel: func() {}}, "cluster-a", "")
+	s.forwardSubscription("key", old, 0)
+	if len(s.outgoing) != 0 {
+		t.Fatal("old completion reached the replacement")
+	}
+	if s.subs["key"] != next {
+		t.Fatal("old completion removed the replacement")
+	}
+	if s.deliverSubscriptionMessage("key", old, ServerMessage{Type: MessageTypeModified}, false) {
+		t.Fatal("old data reached the replacement")
+	}
+}
+
+func TestLateSubscriptionCannotOutliveSessionShutdown(t *testing.T) {
+	s := newSession(stubConn{}, Config{Logger: applog.Noop})
+	s.shutdown()
+	canceled := false
+	entry := s.storeSubscription("late", &Subscription{Cancel: func() { canceled = true }}, "cluster-a", "Alpha")
+	if entry != nil || !canceled || len(s.subs) != 0 {
+		t.Fatal("late subscription survived a closed session")
 	}
 }

--- a/backend/refresh/streammux/handler_test.go
+++ b/backend/refresh/streammux/handler_test.go
@@ -406,6 +406,65 @@ func TestClosedSubscriptionAlwaysNotifiesClient(t *testing.T) {
 	}
 }
 
+func TestForwardSubscriptionPreservesCompletionReason(t *testing.T) {
+	closed := make(chan DropReason)
+	close(closed)
+	queued := make(chan DropReason, 1)
+	queued <- DropReasonBackpressure
+	close(queued)
+	for _, test := range []struct {
+		name  string
+		drops <-chan DropReason
+		want  DropReason
+	}{
+		{name: "absent", want: DropReasonClosed},
+		{name: "open without reason", drops: make(chan DropReason), want: DropReasonClosed},
+		{name: "closed without reason", drops: closed, want: DropReasonClosed},
+		{name: "queued reason", drops: queued, want: DropReasonBackpressure},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			s := newSession(stubConn{}, Config{Logger: applog.Noop})
+			updates := make(chan ServerMessage)
+			close(updates)
+			entry := s.storeSubscription("key", &Subscription{
+				Domain: "pods", Updates: updates, Drops: test.drops, Cancel: func() {},
+			}, "cluster-a", "")
+			s.forwardSubscription("key", entry, 0)
+			if len(s.outgoing) != 1 {
+				t.Fatalf("expected one completion, got %d messages", len(s.outgoing))
+			}
+			msg := <-s.outgoing
+			if msg.Type != MessageTypeComplete || msg.Error != "subscription ended: "+string(test.want) {
+				t.Fatalf("completion lost the drop reason: %+v", msg)
+			}
+		})
+	}
+}
+
+func TestForwardSubscriptionPreservesUnsequencedLiveUpdates(t *testing.T) {
+	s := newSession(stubConn{}, Config{Logger: applog.Noop})
+	updates := make(chan ServerMessage, 3)
+	for _, sequence := range []string{"7", "invalid", "9"} {
+		updates <- ServerMessage{Type: MessageTypeModified, Domain: "pods", Sequence: sequence}
+	}
+	close(updates)
+	entry := s.storeSubscription("key", &Subscription{
+		Domain: "pods", Updates: updates, Cancel: func() {},
+	}, "cluster-a", "")
+	s.forwardSubscription("key", entry, 8)
+	if len(s.outgoing) != 3 {
+		t.Fatalf("expected unsequenced and new live updates, then completion; got %d messages", len(s.outgoing))
+	}
+	for _, sequence := range []string{"invalid", "9"} {
+		if msg := <-s.outgoing; msg.Type != MessageTypeModified || msg.Sequence != sequence {
+			t.Fatalf("unexpected live update after replay: %+v", msg)
+		}
+	}
+	if msg := <-s.outgoing; msg.Type != MessageTypeComplete {
+		t.Fatalf("expected completion after live updates, got %+v", msg)
+	}
+}
+
 func TestOldSubscriptionCannotDeliverIntoReplacement(t *testing.T) {
 	s := newSession(stubConn{}, Config{Logger: applog.Noop, StreamName: "resources"})
 	updates := make(chan ServerMessage)

--- a/backend/refresh/system/manager.go
+++ b/backend/refresh/system/manager.go
@@ -688,3 +688,12 @@ func HealthHandler(hub refresh.InformerHub) http.HandlerFunc {
 		_, _ = w.Write([]byte("ok"))
 	}
 }
+
+// RetireSnapshotServing ends reads permanently before a generation releases stores.
+func (s *Subsystem) RetireSnapshotServing() {
+	if s != nil {
+		if service, ok := s.SnapshotService.(interface{ Retire() }); ok {
+			service.Retire()
+		}
+	}
+}

--- a/backend/refresh/system/permission_revalidator.go
+++ b/backend/refresh/system/permission_revalidator.go
@@ -9,20 +9,20 @@ import (
 	"github.com/luxury-yacht/app/backend/internal/config"
 )
 
-// StartPermissionRevalidation periodically rechecks cached permission grants and shuts down
-// the subsystem when previously allowed access is revoked.
-func (s *Subsystem) StartPermissionRevalidation(ctx context.Context) {
-	if s == nil || s.RuntimePerms == nil || s.InformerFactory == nil || s.Manager == nil {
+// StartPermissionRevalidation delegates permission changes to the generation owner.
+// The owner publishes replacement routing before retiring this subsystem.
+func (s *Subsystem) StartPermissionRevalidation(ctx context.Context, onChanged func(context.Context)) {
+	if s == nil || s.RuntimePerms == nil || s.InformerFactory == nil || s.Manager == nil || onChanged == nil {
 		return
 	}
 	interval := config.PermissionCacheTTL
 	if interval <= 0 {
 		return
 	}
-	go s.runPermissionRevalidation(ctx, interval)
+	go s.runPermissionRevalidation(ctx, interval, onChanged)
 }
 
-func (s *Subsystem) runPermissionRevalidation(ctx context.Context, interval time.Duration) {
+func (s *Subsystem) runPermissionRevalidation(ctx context.Context, interval time.Duration, onChanged func(context.Context)) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
@@ -33,42 +33,29 @@ func (s *Subsystem) runPermissionRevalidation(ctx context.Context, interval time
 		case <-ticker.C:
 		}
 
-		if s.permissionRevoked(ctx) {
-			s.stopForPermissionRevocation()
-			return
+		if s.permissionsChanged(ctx) {
+			onChanged(ctx)
 		}
 	}
 }
 
-// permissionRevoked returns true when a previously allowed permission is now denied.
-func (s *Subsystem) permissionRevoked(ctx context.Context) bool {
-	grants := s.InformerFactory.PermissionAllowedSnapshot()
+// permissionsChanged compares access with the decisions used to build this generation.
+func (s *Subsystem) permissionsChanged(ctx context.Context) bool {
+	grants := s.InformerFactory.PermissionSnapshot()
 	if len(grants) == 0 {
 		return false
 	}
 
-	for _, grant := range grants {
+	for grant, wasAllowed := range grants {
 		decision, err := grant.Revalidate(ctx, s.RuntimePerms)
 		if err != nil {
 			continue
 		}
-		if !decision.Allowed {
+		if decision.Allowed != wasAllowed {
 			group, resource, verb := grant.Identity()
-			klog.V(1).Infof("Permission revoked for %s/%s verb %s; stopping refresh subsystem", group, resource, verb)
+			klog.V(1).Infof("Permission changed for %s/%s verb %s; requesting refresh replacement", group, resource, verb)
 			return true
 		}
 	}
 	return false
-}
-
-// stopForPermissionRevocation shuts down refresh services that rely on informers/streams.
-func (s *Subsystem) stopForPermissionRevocation() {
-	if s.ResourceStream != nil {
-		s.ResourceStream.Stop()
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), config.PermissionCheckTimeout)
-	defer cancel()
-	if err := s.Manager.Shutdown(ctx); err != nil {
-		klog.V(1).Infof("Permission revocation shutdown failed: %v", err)
-	}
 }

--- a/backend/refresh/system/permission_revalidator_test.go
+++ b/backend/refresh/system/permission_revalidator_test.go
@@ -2,12 +2,14 @@ package system
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/kubernetes/fake"
 
+	"github.com/luxury-yacht/app/backend/refresh"
 	"github.com/luxury-yacht/app/backend/refresh/informer"
 	"github.com/luxury-yacht/app/backend/refresh/permissions"
 )
@@ -27,7 +29,7 @@ func TestPermissionRevalidationUsesRecordedNamespace(t *testing.T) {
 		RuntimePerms:    checker,
 		InformerFactory: factory,
 	}
-	require.False(t, subsystem.permissionRevoked(context.Background()),
+	require.False(t, subsystem.permissionsChanged(context.Background()),
 		"a namespace-scoped grant must not be rechecked cluster-wide")
 }
 
@@ -46,7 +48,7 @@ func TestPermissionRevalidationPreservesDefaultScopeEvaluation(t *testing.T) {
 		RuntimePerms:    checker,
 		InformerFactory: factory,
 	}
-	require.False(t, subsystem.permissionRevoked(context.Background()),
+	require.False(t, subsystem.permissionsChanged(context.Background()),
 		"a default permission grant must retain the checker's configured scope fan-out")
 }
 
@@ -58,8 +60,10 @@ func TestPermissionRevalidationDetectsRevocationAtRecordedNamespace(t *testing.T
 	require.True(t, factory.CanListWatchInNamespace("example.com", "widgets", "team-a"))
 
 	var checkedNamespaces []string
-	revalidationChecker := permissions.NewCheckerWithReview("cluster-a", time.Minute, func(_ context.Context, _, _, _, namespace string) (bool, error) {
-		checkedNamespaces = append(checkedNamespaces, namespace)
+	revalidationChecker := permissions.NewCheckerWithReview("cluster-a", time.Minute, func(_ context.Context, group, resource, _, namespace string) (bool, error) {
+		if group == "example.com" && resource == "widgets" {
+			checkedNamespaces = append(checkedNamespaces, namespace)
+		}
 		return false, nil
 	})
 	subsystem := &Subsystem{
@@ -67,9 +71,91 @@ func TestPermissionRevalidationDetectsRevocationAtRecordedNamespace(t *testing.T
 		InformerFactory: factory,
 	}
 
-	require.True(t, subsystem.permissionRevoked(context.Background()))
+	require.True(t, subsystem.permissionsChanged(context.Background()))
 	require.NotEmpty(t, checkedNamespaces)
 	for _, namespace := range checkedNamespaces {
 		require.Equal(t, "team-a", namespace, "revocation must be checked at the recorded informer namespace")
+	}
+}
+
+func TestPermissionRevalidationDetectsRestoredGrant(t *testing.T) {
+	denied := permissions.NewCheckerWithReview("cluster-a", time.Minute, func(context.Context, string, string, string, string) (bool, error) { return false, nil })
+	factory := informer.New(fake.NewClientset(), nil, 0, denied)
+	require.False(t, factory.CanListWatchInNamespace("example.com", "widgets", "team-a"))
+	allowed := permissions.NewCheckerWithReview("cluster-a", time.Minute, func(context.Context, string, string, string, string) (bool, error) { return true, nil })
+	subsystem := &Subsystem{RuntimePerms: allowed, InformerFactory: factory}
+	require.True(t, subsystem.permissionsChanged(context.Background()), "restoring a denied scope must trigger reconstruction too")
+}
+
+func TestDeniedPermissionRevalidationReviewsEachScopeOncePerCacheWindow(t *testing.T) {
+	denied := permissions.NewCheckerWithReview("cluster-a", time.Minute, func(context.Context, string, string, string, string) (bool, error) { return false, nil })
+	factory := informer.New(fake.NewClientset(), nil, 0, denied)
+	const namespaces = 100
+	for range 5 {
+		for i := range namespaces {
+			require.False(t, factory.CanListWatchInNamespace("example.com", "widgets", fmt.Sprintf("team-%d", i)))
+		}
+	}
+	for window := range 2 {
+		reviews := 0
+		// A fresh checker models an empty/expired cache without timing a TTL.
+		checker := permissions.NewCheckerWithReview("cluster-a", time.Minute, func(_ context.Context, group, resource, verb, namespace string) (bool, error) {
+			if group == "example.com" && resource == "widgets" {
+				reviews++
+				require.Equal(t, "list", verb, "a denied LIST must not introduce a WATCH review")
+				require.NotEmpty(t, namespace)
+			}
+			return false, nil
+		})
+		subsystem := &Subsystem{RuntimePerms: checker, InformerFactory: factory}
+		require.False(t, subsystem.permissionsChanged(context.Background()))
+		require.Equal(t, namespaces, reviews)
+		require.False(t, subsystem.permissionsChanged(context.Background()))
+		require.Equal(t, namespaces, reviews, "repeated decisions must reuse the permission cache")
+		t.Logf("window %d: %d denied namespaces, %d reviews across two revalidation passes", window+1, namespaces, reviews)
+	}
+}
+
+type permissionRevalidationHub struct {
+	fakeInformerHub
+	stopped chan struct{}
+}
+
+func (h *permissionRevalidationHub) Shutdown() error { close(h.stopped); return nil }
+
+func TestPermissionChangesDelegateReplacementBeforeStoppingProducers(t *testing.T) {
+	allowed := permissions.NewCheckerWithReview("cluster-a", time.Minute, func(context.Context, string, string, string, string) (bool, error) { return true, nil })
+	factory := informer.New(fake.NewClientset(), nil, 0, allowed)
+	require.True(t, factory.CanListWatch("", "pods"))
+	denied := permissions.NewCheckerWithReview("cluster-a", time.Minute, func(context.Context, string, string, string, string) (bool, error) { return false, nil })
+	hub := &permissionRevalidationHub{stopped: make(chan struct{})}
+	manager := refresh.NewManager(nil, hub, nil, nil, nil)
+	require.NoError(t, manager.Start(context.Background()))
+	defer manager.Shutdown(context.Background())
+	s := &Subsystem{RuntimePerms: denied, InformerFactory: factory, Manager: manager}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	notified := make(chan struct{}, 1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.runPermissionRevalidation(ctx, time.Millisecond, func(context.Context) {
+			select {
+			case notified <- struct{}{}:
+			default:
+			}
+		})
+	}()
+	select {
+	case <-notified:
+	case <-time.After(time.Second):
+		t.Fatal("owner was not notified")
+	}
+	cancel()
+	<-done
+	select {
+	case <-hub.stopped:
+		t.Fatal("producers stopped before the owner could publish replacement routing")
+	default:
 	}
 }

--- a/backend/refresh_auth.go
+++ b/backend/refresh_auth.go
@@ -13,12 +13,6 @@ func (a *RefreshCoordinator) teardownClusterSubsystem(clusterID string) {
 		return
 	}
 
-	// A cluster torn down while cooled (e.g. closed, or pressure-collapsed after cooling)
-	// must release its mmap mappings FIRST, before its stores are discarded — otherwise the
-	// closers would never run. takeCooledClosers returns each closer exactly once, so this
-	// never double-unmaps a subsequent re-warm.
-	a.closeCooledClosers(clusterID)
-
 	// Get and remove the subsystem for this cluster.
 	subsystem := a.takeRefreshSubsystem(clusterID)
 	if subsystem == nil {
@@ -30,8 +24,14 @@ func (a *RefreshCoordinator) teardownClusterSubsystem(clusterID string) {
 
 	a.logger.Info(fmt.Sprintf("Tearing down subsystem for cluster %s", clusterID), logsources.Auth, clusterID, clusterID)
 
+	if aggregates := a.refreshAggregates.Load(); aggregates != nil {
+		subsystems, order := refreshSubsystemTopology(a.snapshotRefreshSubsystems())
+		_ = aggregates.Update(order, subsystems)
+	}
+
 	// Stop all feeds through the shared reverse-order generation contract.
-	a.stopRefreshGeneration(clusterID, subsystem)
+	a.stopRefreshGenerationProducers(clusterID, subsystem)
+	subsystem.RetireSnapshotServing()
 
 	// Spill this cluster's stores to disk now that the subsystem is quiescent, so a re-warm
 	// re-paints them fast before its informers re-sync (the heap they hold is reclaimed by the
@@ -40,6 +40,7 @@ func (a *RefreshCoordinator) teardownClusterSubsystem(clusterID string) {
 	// delta instead of a full re-LIST.
 	a.spillClusterStores(clusterID, subsystem.Registry)
 	a.spillClusterIngestStores(clusterID, subsystem.IngestManager)
+	a.closeCooledClosers(clusterID, subsystem)
 }
 
 // rebuildClusterSubsystem rebuilds the cluster clients and refresh subsystem

--- a/backend/refresh_coordinator.go
+++ b/backend/refresh_coordinator.go
@@ -28,7 +28,7 @@ type refreshClusterRuntime interface {
 	replaceClusterClient(string, *clusterClients)
 	replayClusterLifecycle(string)
 	resourceDependenciesForSelection(kubeconfigSelection, *clusterClients, string) common.Dependencies
-	runClusterOperation(context.Context, string, func(context.Context) error) error
+	runBackgroundClusterOperation(context.Context, string, func(context.Context) error) error
 	setClusterLifecycleState(string, ClusterLifecycleState)
 	snapshotClusterIDs() []string
 	startHeartbeatLoop(context.Context)
@@ -105,7 +105,7 @@ type RefreshCoordinator struct {
 	spillFormat         string
 
 	cooledMu          sync.Mutex
-	cooledMmapClosers map[string][]func() error
+	cooledMmapClosers map[*system.Subsystem][]func() error
 
 	objectCatalogMu      sync.Mutex
 	objectCatalogEntries map[string]*objectCatalogEntry

--- a/backend/refresh_generation.go
+++ b/backend/refresh_generation.go
@@ -331,32 +331,36 @@ func (a *RefreshCoordinator) rebuildForPermissionChange(ctx context.Context, clu
 		return
 	}
 	err := a.clusterRuntime.runBackgroundClusterOperation(ctx, clusterID, func(opCtx context.Context) error {
-		if opCtx.Err() != nil || a.getRefreshSubsystem(clusterID) != expected {
-			return nil
-		}
-		rebuild, ok := a.prepareClusterSubsystemRebuild(clusterID)
-		if !ok {
-			return nil
-		}
-		rebuild.failures = failures
-		clients, ok := rebuild.rebuildClients(opCtx)
-		if !ok || opCtx.Err() != nil || a.getRefreshSubsystem(clusterID) != expected {
-			return nil
-		}
-		next, ok := rebuild.buildSubsystem(clients)
-		if !ok {
-			return nil
-		}
-		if opCtx.Err() != nil || a.getRefreshSubsystem(clusterID) != expected {
-			a.stopRefreshGeneration(clusterID, next)
-			return nil
-		}
-		if rebuild.activateSubsystem(clients, next) && a.emitEventFn != nil {
-			a.emitEventFn(clusterPermissionsChangedEventName, ClusterPermissionsChangedEvent{ClusterID: clusterID})
-		}
+		a.replacePermissionGeneration(opCtx, clusterID, expected, failures)
 		return nil
 	})
 	if err != nil {
 		a.logger.Warn(fmt.Sprintf("Permission refresh replacement for cluster %s failed: %v", clusterID, err), logsources.Refresh, clusterID, expected.ClusterMeta.ClusterName)
+	}
+}
+
+func (a *RefreshCoordinator) replacePermissionGeneration(ctx context.Context, clusterID string, expected *system.Subsystem, failures *clusterRebuildFailures) {
+	if ctx.Err() != nil || a.getRefreshSubsystem(clusterID) != expected {
+		return
+	}
+	rebuild, ok := a.prepareClusterSubsystemRebuild(clusterID)
+	if !ok {
+		return
+	}
+	rebuild.failures = failures
+	clients, ok := rebuild.rebuildClients(ctx)
+	if !ok || ctx.Err() != nil || a.getRefreshSubsystem(clusterID) != expected {
+		return
+	}
+	next, ok := rebuild.buildSubsystem(clients)
+	if !ok {
+		return
+	}
+	if ctx.Err() != nil || a.getRefreshSubsystem(clusterID) != expected {
+		a.stopRefreshGeneration(clusterID, next)
+		return
+	}
+	if rebuild.activateSubsystem(clients, next) && a.emitEventFn != nil {
+		a.emitEventFn(clusterPermissionsChangedEventName, ClusterPermissionsChangedEvent{ClusterID: clusterID})
 	}
 }

--- a/backend/refresh_generation.go
+++ b/backend/refresh_generation.go
@@ -62,7 +62,10 @@ func (a *RefreshCoordinator) startRefreshGeneration(
 	go a.runRefreshGenerationManager(managerCtx, clusterID, clusterName, subsystem.Manager, subsystem.Registry)
 
 	permissionCtx, permissionCancel := context.WithCancel(ctx)
-	subsystem.StartPermissionRevalidation(permissionCtx)
+	failures := &clusterRebuildFailures{}
+	subsystem.StartPermissionRevalidation(permissionCtx, func(ctx context.Context) {
+		a.rebuildForPermissionChange(ctx, clusterID, subsystem, failures)
+	})
 	return &refreshGenerationActivation{
 		refresh:          a,
 		clusterID:        clusterID,
@@ -258,6 +261,19 @@ func (a *RefreshCoordinator) stopRefreshGeneration(clusterID string, subsystem *
 	if a == nil || subsystem == nil {
 		return
 	}
+	a.stopRefreshGenerationProducers(clusterID, subsystem)
+	subsystem.RetireSnapshotServing()
+	a.closeCooledClosers(clusterID, subsystem)
+}
+
+// stopRefreshGenerationProducers is also used by cooling, which keeps reads live.
+func (a *RefreshCoordinator) stopRefreshGenerationProducers(clusterID string, subsystem *system.Subsystem) {
+	if a == nil || subsystem == nil {
+		return
+	}
+	// Catalog sync and its bridges retain this generation's informer and ingest
+	// producers. Join them first, without touching a replacement's catalog.
+	a.stopObjectCatalogEntry(a.removeObjectCatalogEntry(clusterID, subsystem))
 	runtime := a.takeRefreshGenerationRuntime(subsystem)
 	subsystem.CancelColdPreparation()
 	subsystem.CancelInFlightSnapshots()
@@ -305,5 +321,42 @@ func (a *RefreshCoordinator) shutdownRefreshGenerationManager(
 		}
 	case <-timer.C:
 		a.logger.Warn(fmt.Sprintf("Timed out waiting for refresh manager shutdown for cluster %s", clusterID), logsources.Refresh, clusterID, subsystem.ClusterMeta.ClusterName)
+	}
+}
+
+// A revalidator belongs to one generation. Failed builds leave that generation
+// serving and revalidating; stale callbacks cannot replace a newer generation.
+func (a *RefreshCoordinator) rebuildForPermissionChange(ctx context.Context, clusterID string, expected *system.Subsystem, failures *clusterRebuildFailures) {
+	if a == nil || clusterID == "" || expected == nil || ctx.Err() != nil {
+		return
+	}
+	err := a.clusterRuntime.runBackgroundClusterOperation(ctx, clusterID, func(opCtx context.Context) error {
+		if opCtx.Err() != nil || a.getRefreshSubsystem(clusterID) != expected {
+			return nil
+		}
+		rebuild, ok := a.prepareClusterSubsystemRebuild(clusterID)
+		if !ok {
+			return nil
+		}
+		rebuild.failures = failures
+		clients, ok := rebuild.rebuildClients(opCtx)
+		if !ok || opCtx.Err() != nil || a.getRefreshSubsystem(clusterID) != expected {
+			return nil
+		}
+		next, ok := rebuild.buildSubsystem(clients)
+		if !ok {
+			return nil
+		}
+		if opCtx.Err() != nil || a.getRefreshSubsystem(clusterID) != expected {
+			a.stopRefreshGeneration(clusterID, next)
+			return nil
+		}
+		if rebuild.activateSubsystem(clients, next) && a.emitEventFn != nil {
+			a.emitEventFn(clusterPermissionsChangedEventName, ClusterPermissionsChangedEvent{ClusterID: clusterID})
+		}
+		return nil
+	})
+	if err != nil {
+		a.logger.Warn(fmt.Sprintf("Permission refresh replacement for cluster %s failed: %v", clusterID, err), logsources.Refresh, clusterID, expected.ClusterMeta.ClusterName)
 	}
 }

--- a/backend/refresh_generation_test.go
+++ b/backend/refresh_generation_test.go
@@ -326,3 +326,72 @@ func TestPermissionReplacementFailurePreservesServingGeneration(t *testing.T) {
 	app.Refresh.rebuildForPermissionChange(ctx, "cluster-a", next, &clusterRebuildFailures{})
 	require.Same(t, next, app.Refresh.getRefreshSubsystem("cluster-a"))
 }
+
+func TestPermissionReplacementConstructionOutcomesPreserveOwnership(t *testing.T) {
+	for _, test := range []struct {
+		name             string
+		buildError       error
+		cancelBuild      bool
+		wantPublished    bool
+		wantNextCanceled bool
+	}{
+		{name: "published", wantPublished: true},
+		{name: "construction failed", buildError: errors.New("subsystem construction failed")},
+		{name: "canceled during construction", cancelBuild: true, wantNextCanceled: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			const clusterID = "cluster-a"
+			app := newWorkspaceCoordinatorTestFixture(t)
+			setTestAppRuntimeReady(t, app.Lifecycle, context.Background())
+			oldService, newService := &cancelTrackingSnapshotService{}, &cancelTrackingSnapshotService{}
+			previous := &system.Subsystem{SnapshotService: oldService}
+			next := &system.Subsystem{Manager: refresh.NewManager(nil, nil, nil, nil, nil), SnapshotService: newService}
+			app.Refresh.setRefreshSubsystem(clusterID, previous)
+			setRefreshServiceReadyForTest(app.Refresh)
+			aggregate := newAggregateSnapshotService([]string{clusterID}, map[string]*system.Subsystem{clusterID: previous})
+			app.Refresh.refreshAggregates.Store(&refreshAggregateHandlers{snapshot: aggregate})
+			oldClients := &clusterClients{meta: ClusterMeta{ID: clusterID}, kubeconfigPath: "/test/config"}
+			newClients := &clusterClients{meta: oldClients.meta, kubeconfigPath: oldClients.kubeconfigPath}
+			app.ClusterRuntime.clusterClients = map[string]*clusterClients{clusterID: oldClients}
+			app.Refresh.clusterRuntime = &failingPermissionRebuildRuntime{refreshClusterRuntime: app.ClusterRuntime, clients: newClients}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			originalBuilder := newRefreshSubsystemWithServices
+			newRefreshSubsystemWithServices = func(system.Config) (*system.Subsystem, error) {
+				if test.buildError != nil {
+					return nil, test.buildError
+				}
+				if test.cancelBuild {
+					cancel()
+				}
+				return next, nil
+			}
+			t.Cleanup(func() {
+				app.Refresh.stopRefreshGeneration(clusterID, next)
+				app.Refresh.stopRefreshRuntimeContext()
+				newRefreshSubsystemWithServices = originalBuilder
+			})
+			emitted := false
+			app.Refresh.emitEventFn = func(name string, args ...interface{}) {
+				emitted = true
+				require.Equal(t, clusterPermissionsChangedEventName, name)
+				require.Equal(t, []interface{}{ClusterPermissionsChangedEvent{ClusterID: clusterID}}, args)
+				require.Same(t, next, app.Refresh.getRefreshSubsystem(clusterID))
+				require.Same(t, newService, aggregate.snapshotConfig()[clusterID], "route before notifying consumers")
+				require.Same(t, newClients, app.ClusterRuntime.clusterClientsForID(clusterID))
+				require.True(t, oldService.canceled, "retire the previous generation before announcing recovery")
+			}
+
+			app.Refresh.rebuildForPermissionChange(ctx, clusterID, previous, &clusterRebuildFailures{})
+
+			expected := previous
+			if test.wantPublished {
+				expected = next
+			}
+			require.Same(t, expected, app.Refresh.getRefreshSubsystem(clusterID))
+			require.Equal(t, test.wantPublished, emitted)
+			require.Equal(t, test.wantPublished, oldService.canceled)
+			require.Equal(t, test.wantNextCanceled, newService.canceled)
+		})
+	}
+}

--- a/backend/refresh_generation_test.go
+++ b/backend/refresh_generation_test.go
@@ -2,12 +2,84 @@ package backend
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/luxury-yacht/app/backend/internal/authstate"
 	"github.com/luxury-yacht/app/backend/refresh"
 	"github.com/luxury-yacht/app/backend/refresh/system"
 	"github.com/stretchr/testify/require"
 )
+
+type failingPermissionRebuildRuntime struct {
+	refreshClusterRuntime
+	attempts int
+	err      error
+	clients  *clusterClients
+}
+
+func (r *failingPermissionRebuildRuntime) buildClusterClientsWithManager(context.Context, kubeconfigSelection, ClusterMeta, *authstate.Manager) (*clusterClients, error) {
+	r.attempts++
+	return r.clients, r.err
+}
+
+func TestPermissionReplacementReportsRepeatedBuildFailureOnce(t *testing.T) {
+	app := newWorkspaceCoordinatorTestFixture(t)
+	reporter := &recordingErrorReporter{}
+	app.Refresh.logger = NewLogger(100, reporter)
+	app.ClusterRuntime.clusterClients = map[string]*clusterClients{
+		"cluster-a": {meta: ClusterMeta{ID: "cluster-a"}, kubeconfigPath: "/missing/config"},
+	}
+	runtime := &failingPermissionRebuildRuntime{refreshClusterRuntime: app.ClusterRuntime, err: errors.New("client construction failed")}
+	app.Refresh.clusterRuntime = runtime
+	previous := &system.Subsystem{}
+	app.Refresh.setRefreshSubsystem("cluster-a", previous)
+	failures := &clusterRebuildFailures{}
+	for range 3 {
+		app.Refresh.rebuildForPermissionChange(context.Background(), "cluster-a", previous, failures)
+	}
+	require.Equal(t, 3, runtime.attempts, "report suppression must not suppress recovery attempts")
+	require.Len(t, app.Refresh.logger.GetEntries(), 1)
+	runtime.err = errors.New("different construction failure")
+	app.Refresh.rebuildForPermissionChange(context.Background(), "cluster-a", previous, failures)
+	require.Len(t, app.Refresh.logger.GetEntries(), 2, "changed failures must remain visible")
+
+	app.ClusterRuntime.clusterClients["cluster-b"] = &clusterClients{meta: ClusterMeta{ID: "cluster-b"}, kubeconfigPath: "/missing/config"}
+	other := &system.Subsystem{}
+	app.Refresh.setRefreshSubsystem("cluster-b", other)
+	app.Refresh.rebuildForPermissionChange(context.Background(), "cluster-b", other, &clusterRebuildFailures{})
+	require.Len(t, app.Refresh.logger.GetEntries(), 3, "another cluster owns independent failure reporting")
+
+	next := &system.Subsystem{}
+	app.Refresh.setRefreshSubsystem("cluster-a", next)
+	app.Refresh.rebuildForPermissionChange(context.Background(), "cluster-a", next, &clusterRebuildFailures{})
+	require.Len(t, app.Refresh.logger.GetEntries(), 4, "a replacement generation must report its own failures")
+	reporter.mu.Lock()
+	defer reporter.mu.Unlock()
+	require.Len(t, reporter.exceptions, 4)
+}
+
+func TestRebuildFailureReportingResetsOnlyTheRecoveredStage(t *testing.T) {
+	app := newWorkspaceCoordinatorTestFixture(t)
+	app.Refresh.logger = NewLogger(100)
+	app.Refresh.clusterRuntime = &failingPermissionRebuildRuntime{
+		refreshClusterRuntime: app.ClusterRuntime,
+		clients:               &clusterClients{},
+	}
+	r := clusterSubsystemRebuild{
+		refresh: app.Refresh, clusterID: "cluster-a", oldClients: &clusterClients{},
+		failures: &clusterRebuildFailures{},
+	}
+	err := errors.New("construction failed")
+	r.reportBuildError("clients", "client rebuild failed", err)
+	r.reportBuildError("subsystem", "subsystem rebuild failed", err)
+	_, ok := r.rebuildClients(context.Background())
+	require.True(t, ok)
+	r.reportBuildError("clients", "client rebuild failed", err)
+	r.reportBuildError("subsystem", "subsystem rebuild failed", err)
+	require.Len(t, app.Refresh.logger.GetEntries(), 3,
+		"client recovery must rearm its report while leaving the unrecovered subsystem failure suppressed")
+}
 
 type cancelTrackingSnapshotService struct {
 	canceled bool
@@ -229,4 +301,28 @@ func TestRefreshGenerationOrphansUseNormalStopContract(t *testing.T) {
 	app.Refresh.stopRemainingRefreshGenerationRuntimes()
 	require.True(t, managerCanceledB)
 	require.True(t, permissionCanceledB)
+}
+
+func TestPermissionReplacementFailurePreservesServingGeneration(t *testing.T) {
+	app := newWorkspaceCoordinatorTestFixture(t)
+	service := &cancelTrackingSnapshotService{}
+	previous := &system.Subsystem{SnapshotService: service}
+	app.Refresh.setRefreshSubsystem("cluster-a", previous)
+	emitted := false
+	app.Refresh.emitEventFn = func(string, ...interface{}) { emitted = true }
+	failures := &clusterRebuildFailures{}
+	for range 2 {
+		app.Refresh.rebuildForPermissionChange(context.Background(), "cluster-a", previous, failures)
+	}
+	require.Same(t, previous, app.Refresh.getRefreshSubsystem("cluster-a"))
+	require.False(t, service.canceled)
+	require.False(t, emitted, "failed replacement must not announce a new permission epoch")
+	next := &system.Subsystem{}
+	app.Refresh.setRefreshSubsystem("cluster-a", next)
+	app.Refresh.rebuildForPermissionChange(context.Background(), "cluster-a", previous, failures)
+	require.Same(t, next, app.Refresh.getRefreshSubsystem("cluster-a"))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	app.Refresh.rebuildForPermissionChange(ctx, "cluster-a", next, &clusterRebuildFailures{})
+	require.Same(t, next, app.Refresh.getRefreshSubsystem("cluster-a"))
 }

--- a/backend/refresh_governor.go
+++ b/backend/refresh_governor.go
@@ -373,32 +373,13 @@ func (e *refreshGovernorExecutor) ensureRunning(clusterID string) bool {
 	return true
 }
 
-// rewarmCooledClusterSubsystem replaces a cooled (mmap-serving) subsystem with a fresh, live
-// one. ORDERING is the safety contract for the mmap closers, whose mappings the cooled stores'
-// rows alias (a read after unmap is a use-after-free):
-//  1. takeRefreshSubsystem removes the cooled subsystem from a.refreshSubsystems, so no NEW
-//     Build resolves it via the per-cluster getter.
-//  2. rebuildClusterSubsystem builds the fresh subsystem, sets it in the map, and calls
-//     refreshAggregates.Update — after which the aggregate snapshot router resolves the FRESH
-//     subsystem's stores, never the cooled mmap stores. The cooled subsystem (and its snapshot
-//     cache holding any mmap-aliased rows) is now fully unreachable for serving.
-//  3. closeCooledClosers takes the closers (exactly once) and runs them. Each store-level
-//     closer waits for the store's write lock, so it serializes after any straggler in-flight
-//     Build that was already reconstructing rows when the swap happened — only then unmapping.
+// rewarmCooledClusterSubsystem retains the cooled generation until replacement
+// routing succeeds. A failed rebuild must leave its mappings available.
 func (a *RefreshCoordinator) rewarmCooledClusterSubsystem(clusterID string) {
 	if a == nil || clusterID == "" {
 		return
 	}
-	// (1) unroute the cooled subsystem so no new Build can reach its mmap stores.
-	a.takeRefreshSubsystem(clusterID)
-	if a.logger != nil {
-		a.logger.Info(fmt.Sprintf("Governor re-warming cooled cluster %s", clusterID), logsources.Refresh, clusterID, a.clusterRuntime.clusterNameForID(clusterID))
-	}
-	// (2) build + start a fresh live subsystem and re-point the aggregate router at it.
 	a.rebuildClusterSubsystem(clusterID)
-	// (3) the cooled subsystem is now unrouted; release its mappings (waits for any straggler
-	// in-flight Build via each closer's store-lock, then unmaps once).
-	a.closeCooledClosers(clusterID)
 }
 
 // teardown moves the cluster to the governor's Cold tier. It first attempts to COOL the
@@ -568,13 +549,14 @@ func (a *RefreshCoordinator) coolClusterToMmapServing(clusterID string) {
 
 	// Stop the generation's feeds WITHOUT removing the subsystem — it stays
 	// registered to serve cooled queries.
-	a.stopRefreshGeneration(clusterID, subsystem)
+	a.stopRefreshGenerationProducers(clusterID, subsystem)
 
 	// Swap the maintained stores to mmap. On error, safe-degrade to full teardown.
 	dir, err := a.clusterCooledMmapDir(clusterID)
 	if err == nil {
 		var closers []func() error
 		closers, err = subsystem.Registry.CoolMaintainedStoresToMmap(dir)
+		a.setCooledClosers(subsystem, closers)
 		if err == nil {
 			// The feeds are stopped, so the manager + informer factory are shut down and the
 			// original hub's HasSynced now reports false — install a cooled hub so the
@@ -583,14 +565,11 @@ func (a *RefreshCoordinator) coolClusterToMmapServing(clusterID string) {
 			if svc, ok := subsystem.SnapshotService.(*snapshot.Service); ok {
 				svc.SetInformerHub(system.NewCooledInformerHub())
 			}
-			a.setCooledClosers(clusterID, closers)
 			subsystem.Cooled = true
 		}
 	}
 	if err != nil {
-		// Cooling failed at some step (mkdir or a store swap). CoolMaintainedStoresToMmap already
-		// closed any mapping it opened, so nothing is left half-mapped. Fall back to a full
-		// teardown: the subsystem is discarded and its heap fully reclaimed.
+		// Retire and spill any partially swapped stores before releasing their mappings.
 		if a.logger != nil {
 			a.logger.Warn(fmt.Sprintf("Governor cool failed for cluster %s, falling back to full teardown: %v", clusterID, err), logsources.Refresh, clusterID, a.clusterRuntime.clusterNameForID(clusterID))
 		}

--- a/backend/refresh_governor_test.go
+++ b/backend/refresh_governor_test.go
@@ -855,3 +855,32 @@ func TestSetVisibleClusterReplaysCurrentLifecycleState(t *testing.T) {
 		previous:  ClusterStateReady,
 	}}, events)
 }
+
+func TestCooledMappingsOutliveSnapshotRouting(t *testing.T) {
+	for _, action := range []string{"teardown", "failed-rewarm"} {
+		t.Run(action, func(t *testing.T) {
+			app := newRefreshCoordinatorTestFixture(t)
+			old := &coldPreparationSnapshotService{}
+			subsystem := &system.Subsystem{Cooled: true, SnapshotService: old, Registry: domain.New()}
+			app.Refresh.spillRoot = t.TempDir()
+			app.Refresh.setRefreshSubsystem("cluster-a", subsystem)
+			aggregate := newAggregateSnapshotService([]string{"cluster-a"}, map[string]*system.Subsystem{"cluster-a": subsystem})
+			app.Refresh.refreshAggregates.Store(&refreshAggregateHandlers{snapshot: aggregate})
+			closed, closedWhileRouted := false, false
+			app.Refresh.setCooledClosers(subsystem, []func() error{func() error {
+				closed = true
+				closedWhileRouted = aggregate.snapshotConfig()["cluster-a"] == old
+				return nil
+			}})
+			if action == "teardown" {
+				app.Refresh.teardownClusterSubsystem("cluster-a")
+				require.True(t, closed)
+			} else {
+				app.Refresh.rewarmCooledClusterSubsystem("cluster-a")
+				require.False(t, closed, "failed rewarm must retain the serving mapping")
+				require.Same(t, subsystem, app.Refresh.getRefreshSubsystem("cluster-a"))
+			}
+			require.False(t, closedWhileRouted, "mmap closer ran while the old store was routed")
+		})
+	}
+}

--- a/backend/refresh_object_catalog.go
+++ b/backend/refresh_object_catalog.go
@@ -17,6 +17,7 @@ import (
 	refreshinformer "github.com/luxury-yacht/app/backend/refresh/informer"
 	"github.com/luxury-yacht/app/backend/refresh/resourcestream"
 	"github.com/luxury-yacht/app/backend/refresh/snapshot"
+	"github.com/luxury-yacht/app/backend/refresh/system"
 	"github.com/luxury-yacht/app/backend/refresh/telemetry"
 	"github.com/luxury-yacht/app/backend/resourcemodel"
 	"github.com/luxury-yacht/app/backend/resources/customresource"
@@ -84,6 +85,7 @@ type CatalogQueryCSVExport struct {
 
 type objectCatalogEntry struct {
 	service *objectcatalog.Service
+	owner   *system.Subsystem
 	cancel  context.CancelFunc
 	done    chan struct{}
 	meta    ClusterMeta
@@ -200,16 +202,21 @@ func (a *RefreshCoordinator) startObjectCatalogForTarget(target catalogTarget) e
 	svc := objectcatalog.NewService(deps, nil)
 	ctx, cancel := context.WithCancel(a.CtxOrBackground())
 	done := make(chan struct{})
+	var bridges sync.WaitGroup
 	if subsystem.ResourceStream != nil {
 		catalogUpdates, cancelCatalogUpdates := svc.SubscribeStreaming()
+		bridges.Add(1)
 		go func() {
+			defer bridges.Done()
 			defer cancelCatalogUpdates()
 			runCatalogDoorbellBridge(ctx, catalogUpdates, subsystem.ResourceStream)
 		}()
 	}
 	if subsystem.AttentionIndex != nil {
 		finalizerUpdates, cancelFinalizerUpdates := svc.SubscribeFinalizerBlockers()
+		bridges.Add(1)
 		go func() {
+			defer bridges.Done()
 			defer cancelFinalizerUpdates()
 			runCatalogFinalizerBridge(ctx, finalizerUpdates, svc.FinalizerBlockers, subsystem.AttentionIndex)
 		}()
@@ -217,6 +224,7 @@ func (a *RefreshCoordinator) startObjectCatalogForTarget(target catalogTarget) e
 
 	a.storeObjectCatalogEntry(target.meta.ID, &objectCatalogEntry{
 		service: svc,
+		owner:   subsystem,
 		cancel:  cancel,
 		done:    done,
 		meta:    target.meta,
@@ -227,7 +235,11 @@ func (a *RefreshCoordinator) startObjectCatalogForTarget(target catalogTarget) e
 	}
 
 	go func() {
-		defer close(done)
+		defer func() {
+			cancel()
+			bridges.Wait()
+			close(done)
+		}()
 		// No cache wait here: the service starts immediately so discovery and the
 		// RBAC preflight overlap the informer factory's initial sync; sync() itself
 		// waits for caches just before the collect (deps.WaitForCaches above).
@@ -320,9 +332,13 @@ func (a *RefreshCoordinator) storeObjectCatalogEntry(clusterID string, entry *ob
 	if a.objectCatalogEntries == nil {
 		a.objectCatalogEntries = make(map[string]*objectCatalogEntry)
 	}
+	previous := a.objectCatalogEntries[clusterID]
 	a.objectCatalogEntries[clusterID] = entry
-	a.objectCatalogMu.Unlock()
 	a.resourceProjection.publishCatalogEntry(clusterID, entry)
+	a.objectCatalogMu.Unlock()
+	if previous != entry {
+		a.stopObjectCatalogEntry(previous)
+	}
 }
 
 func (a *RefreshCoordinator) clearObjectCatalogEntries() []*objectCatalogEntry {
@@ -332,16 +348,19 @@ func (a *RefreshCoordinator) clearObjectCatalogEntries() []*objectCatalogEntry {
 		entries = append(entries, entry)
 	}
 	a.objectCatalogEntries = make(map[string]*objectCatalogEntry)
-	a.objectCatalogMu.Unlock()
 	a.resourceProjection.clearCatalogEntries()
+	a.objectCatalogMu.Unlock()
 	return entries
 }
 
-func (a *RefreshCoordinator) removeObjectCatalogEntry(clusterID string) *objectCatalogEntry {
+func (a *RefreshCoordinator) removeObjectCatalogEntry(clusterID string, owner *system.Subsystem) *objectCatalogEntry {
 	a.objectCatalogMu.Lock()
+	defer a.objectCatalogMu.Unlock()
 	entry := a.objectCatalogEntries[clusterID]
+	if owner != nil && (entry == nil || entry.owner != owner) {
+		return nil
+	}
 	delete(a.objectCatalogEntries, clusterID)
-	a.objectCatalogMu.Unlock()
 	a.resourceProjection.removeCatalogEntry(clusterID)
 	return entry
 }
@@ -350,7 +369,10 @@ func (a *RefreshCoordinator) stopObjectCatalogForCluster(clusterID string) {
 	if a == nil || clusterID == "" {
 		return
 	}
-	entry := a.removeObjectCatalogEntry(clusterID)
+	a.stopObjectCatalogEntry(a.removeObjectCatalogEntry(clusterID, nil))
+}
+
+func (a *RefreshCoordinator) stopObjectCatalogEntry(entry *objectCatalogEntry) {
 	if entry == nil {
 		return
 	}

--- a/backend/refresh_object_catalog_test.go
+++ b/backend/refresh_object_catalog_test.go
@@ -271,6 +271,41 @@ func TestStopObjectCatalogCancelsAndResets(t *testing.T) {
 	}
 }
 
+func TestCatalogReplacementStopsPreviousRun(t *testing.T) {
+	app, target := catalogLifecycleTestApp(t, system.TierForeground, false)
+	require.NoError(t, app.Refresh.startObjectCatalogForTarget(target))
+	previous := app.Refresh.snapshotObjectCatalogEntries()[0]
+	require.NoError(t, app.Refresh.startObjectCatalogForTarget(target))
+	require.NotSame(t, previous.service, app.Refresh.objectCatalogServiceForCluster(target.meta.ID))
+	select {
+	case <-previous.done:
+	default:
+		t.Fatal("replacing a catalog must cancel and join its previous run")
+	}
+}
+
+func TestCatalogStopsOnlyWithOwningGeneration(t *testing.T) {
+	app, target := catalogLifecycleTestApp(t, system.TierForeground, false)
+	owner := app.Refresh.getRefreshSubsystem(target.meta.ID)
+	require.NoError(t, app.Refresh.startObjectCatalogForTarget(target))
+	entry := app.Refresh.snapshotObjectCatalogEntries()[0]
+	other := &objectcatalog.Service{}
+	app.Refresh.storeObjectCatalogEntry("cluster-b", &objectCatalogEntry{service: other})
+
+	app.Refresh.stopRefreshGeneration(target.meta.ID, &system.Subsystem{})
+	require.Same(t, entry.service, app.Refresh.objectCatalogServiceForCluster(target.meta.ID),
+		"retiring another generation must preserve the catalog's owner")
+	app.Refresh.stopRefreshGeneration(target.meta.ID, owner)
+	require.Nil(t, app.Refresh.objectCatalogServiceForCluster(target.meta.ID))
+	require.Nil(t, app.Refresh.resourceProjection.objectCatalogServiceForCluster(target.meta.ID))
+	require.Same(t, other, app.Refresh.objectCatalogServiceForCluster("cluster-b"))
+	select {
+	case <-entry.done:
+	default:
+		t.Fatal("catalog survived retirement of its informer generation")
+	}
+}
+
 func TestStopObjectCatalogDoesNotBlockForeverWaitingForDone(t *testing.T) {
 	app := newWorkspaceCoordinatorTestFixture(t)
 	app.AppLogs = NewAppLogService(NewLogger(10))

--- a/backend/refresh_spill.go
+++ b/backend/refresh_spill.go
@@ -10,6 +10,7 @@ import (
 	"github.com/luxury-yacht/app/backend/internal/logsources"
 	"github.com/luxury-yacht/app/backend/refresh/domain"
 	"github.com/luxury-yacht/app/backend/refresh/ingest"
+	"github.com/luxury-yacht/app/backend/refresh/system"
 )
 
 // refresh_spill.go wires the querypage maintained-store spill into the governor's
@@ -193,40 +194,40 @@ func (a *RefreshCoordinator) clusterCooledMmapDir(clusterID string) (string, err
 	return filepath.Join(dir, "cooled"), nil
 }
 
-// setCooledClosers records the mmap closers for a cooled cluster so the re-warm/teardown path
+// setCooledClosers records the mmap closers for the current generation so the re-warm/teardown path
 // can release the mappings exactly once. Guarded by cooledMu.
-func (a *RefreshCoordinator) setCooledClosers(clusterID string, closers []func() error) {
-	if a == nil || clusterID == "" {
+func (a *RefreshCoordinator) setCooledClosers(subsystem *system.Subsystem, closers []func() error) {
+	if a == nil || subsystem == nil {
 		return
 	}
 	a.cooledMu.Lock()
 	defer a.cooledMu.Unlock()
 	if a.cooledMmapClosers == nil {
-		a.cooledMmapClosers = make(map[string][]func() error)
+		a.cooledMmapClosers = make(map[*system.Subsystem][]func() error)
 	}
-	a.cooledMmapClosers[clusterID] = closers
+	a.cooledMmapClosers[subsystem] = append(a.cooledMmapClosers[subsystem], closers...)
 }
 
 // takeCooledClosers removes and returns a cooled cluster's mmap closers, returning nil after
 // the first call — so a re-warm followed by a teardown (or vice versa) closes each mapping
 // exactly once and never double-unmaps. Guarded by cooledMu.
-func (a *RefreshCoordinator) takeCooledClosers(clusterID string) []func() error {
-	if a == nil || clusterID == "" {
+func (a *RefreshCoordinator) takeCooledClosers(subsystem *system.Subsystem) []func() error {
+	if a == nil || subsystem == nil {
 		return nil
 	}
 	a.cooledMu.Lock()
 	defer a.cooledMu.Unlock()
-	closers := a.cooledMmapClosers[clusterID]
-	delete(a.cooledMmapClosers, clusterID)
+	closers := a.cooledMmapClosers[subsystem]
+	delete(a.cooledMmapClosers, subsystem)
 	return closers
 }
 
-// closeCooledClosers takes and runs a cooled cluster's mmap closers (a no-op if it was never
+// closeCooledClosers takes and runs a generation's mmap closers (a no-op if it was never
 // cooled or already re-warmed). Each store-level closer waits for any in-flight Query and
 // unmaps once, so this is safe to call only AFTER the cooled subsystem is unrouted (no new
 // Build can reach the mmap stores). Best-effort: a closer error is logged, not propagated.
-func (a *RefreshCoordinator) closeCooledClosers(clusterID string) {
-	for _, closer := range a.takeCooledClosers(clusterID) {
+func (a *RefreshCoordinator) closeCooledClosers(clusterID string, subsystem *system.Subsystem) {
+	for _, closer := range a.takeCooledClosers(subsystem) {
 		if closer == nil {
 			continue
 		}

--- a/backend/refresh_spill_test.go
+++ b/backend/refresh_spill_test.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"encoding/gob"
+	"github.com/luxury-yacht/app/backend/refresh/system"
 	"os"
 	"path/filepath"
 	"testing"
@@ -61,18 +62,20 @@ func (s *spillFake) SwapToMmap(path string) (func() error, error) {
 func TestAppCloseCooledClosersRunsEachExactlyOnce(t *testing.T) {
 	app := newRefreshCoordinatorTestFixture(t)
 
+	subsystem := &system.Subsystem{Cooled: true}
+	app.Refresh.setRefreshSubsystem("cluster-1", subsystem)
 	var aCount, bCount int
-	app.Refresh.setCooledClosers("cluster-1", []func() error{
+	app.Refresh.setCooledClosers(subsystem, []func() error{
 		func() error { aCount++; return nil },
 		func() error { bCount++; return nil },
 	})
 
-	app.Refresh.closeCooledClosers("cluster-1")
+	app.Refresh.closeCooledClosers("cluster-1", subsystem)
 	require.Equal(t, 1, aCount)
 	require.Equal(t, 1, bCount)
 
 	// Second call: the closers were already taken, so this is a no-op (no double-unmap).
-	app.Refresh.closeCooledClosers("cluster-1")
+	app.Refresh.closeCooledClosers("cluster-1", subsystem)
 	require.Equal(t, 1, aCount, "closer must not run twice")
 	require.Equal(t, 1, bCount, "closer must not run twice")
 }
@@ -182,4 +185,20 @@ func TestResetSpillRootForFormat(t *testing.T) {
 	app.Refresh.resetSpillRootForFormat()
 	require.NoFileExists(t, filepath.Join(dir, "namespace-config.spill"),
 		"a format change must clear the incompatible spill")
+}
+
+func TestRetiringGenerationClosesOnlyItsOwnMappings(t *testing.T) {
+	app := newRefreshCoordinatorTestFixture(t)
+	old, next := &system.Subsystem{Cooled: true}, &system.Subsystem{Cooled: true}
+	oldClosed, nextClosed := 0, 0
+	app.Refresh.setRefreshSubsystem("cluster-a", old)
+	app.Refresh.setRefreshSubsystem("cluster-a", next)
+	app.Refresh.setCooledClosers(old, []func() error{func() error { oldClosed++; return nil }})
+	app.Refresh.setCooledClosers(next, []func() error{func() error { nextClosed++; return nil }})
+	app.Refresh.stopRefreshGeneration("cluster-a", old)
+	require.Equal(t, 1, oldClosed)
+	require.Zero(t, nextClosed)
+	app.Refresh.stopRefreshGeneration("cluster-a", next)
+	require.Equal(t, 1, oldClosed)
+	require.Equal(t, 1, nextClosed)
 }

--- a/backend/resource_gateway_test.go
+++ b/backend/resource_gateway_test.go
@@ -131,7 +131,7 @@ func TestRefreshCoordinatorPublishesCatalogAndTelemetryToResourceProjection(t *t
 	require.Same(t, catalog, refresh.resourceProjection.objectCatalogServiceForCluster("cluster-a"))
 	require.Same(t, recorder, refresh.resourceProjection.currentTelemetry())
 
-	refresh.removeObjectCatalogEntry("cluster-a")
+	refresh.removeObjectCatalogEntry("cluster-a", nil)
 	refresh.setTelemetryRecorder(nil)
 	require.Nil(t, refresh.resourceProjection.objectCatalogServiceForCluster("cluster-a"))
 	require.Nil(t, refresh.resourceProjection.currentTelemetry())

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,7 @@ completed phase plans, or test lists that can be discovered with `rg`.
 
 | Question | Start here |
 | --- | --- |
+| Which recurring implementation mistakes must agents prevent? | [workflows/common-mistakes.md](workflows/common-mistakes.md) |
 | How does the object map work? | [workflows/object-map.md](workflows/object-map.md) |
 | How are live operations tracked and cleaned up? | [workflows/operation-lifecycle.md](workflows/operation-lifecycle.md) |
 | How do shell exec and debug containers work? | [workflows/shell-debug.md](workflows/shell-debug.md) |

--- a/docs/architecture/application-lifecycle.md
+++ b/docs/architecture/application-lifecycle.md
@@ -117,7 +117,7 @@ window registry, keeps window-local commands in the sender, and routes workspace
 owner. The panel renderer keeps its Windows/Linux application-menu accelerators
 disabled until the panel's native ready acknowledgement.
 
-The pinned beta.16 runtime supplies edge and corner hit testing and native
+The pinned beta.17 runtime supplies edge and corner hit testing and native
 resize invocation for resizable Windows/Linux windows without a CSS resize
 opt-in. Because that runtime collapses the eight hit regions to four axis cursors,
 the custom-frame shell projects its result to the matching

--- a/docs/architecture/catalog.md
+++ b/docs/architecture/catalog.md
@@ -17,6 +17,10 @@ Keep `catalog-first`. Do not turn that into `catalog-only`.
   identity.
 - Backend lookups that cross app boundaries must require `clusterId`; do not
   guess from current selection.
+- Each running catalog belongs to the exact refresh subsystem whose informer
+  and ingest feeds it reads. Generation retirement cancels and joins that catalog
+  and its bridges before stopping the feeds. Replacing a catalog entry also stops
+  the displaced run; retiring an older generation cannot stop the new catalog.
 - If discovery is degraded, preserve known identity where safe and surface
   degraded confidence instead of acting on ambiguous objects.
 - After discovery and permission preflight, collection waits up to the ingest
@@ -44,6 +48,16 @@ Keep `catalog-first`. Do not turn that into `catalog-only`.
   selection before the dependent query runs.
 - `unfilteredTotal` removes search, Kind, user namespace, and API-group filters
   while retaining the structural boundary.
+
+## Ingest callback ordering
+
+An ingest callback may run while its source store is write-locked. It cannot block
+on the catalog's full-sync lock, because full sync reads those same source stores.
+If the catalog lock is busy, coalesce a pending reconciliation by GVR and reread
+the authoritative kind store after acquiring the sync lock. This applies to
+incremental changes and whole-kind replacement, including changes arriving after
+a full sync collected that kind. Catalog shutdown drains this worker before
+signaling completion.
 
 ## Layer Model
 

--- a/docs/architecture/data-freshness.md
+++ b/docs/architecture/data-freshness.md
@@ -144,6 +144,10 @@ application transport between them.
   advancing one of the domain's declared signal clocks; consumers then perform
   one `stream-signal` reconciliation. A reset must never be accepted as only an
   acknowledgement while retained data remains visible.
+- If a resource replay cannot fit in the remaining outgoing queue, the mux sends
+  an ACK followed by a RESET for that scope instead of enqueueing a partial replay.
+  Updates already queued for other scopes remain intact. Live delivery overflow
+  still closes the session so every subscription recovers through resume or reset.
 - Replacing one cluster's backend stream manager invalidates subscriptions bound
   to the previous manager. After routing the replacement, affected subscriptions
   re-establish against the current manager over the existing aggregate
@@ -183,7 +187,8 @@ application transport between them.
   and replayed after activation with its original `user` or `stream-signal`
   intent; passive background work is dropped. Releasing the boundary also
   restarts retained stream-only leases, which have no snapshot request to queue.
-- A typed permission denial is a settled domain state, not a retry loop.
+- A typed permission denial is settled until manual refresh or a cluster-scoped
+  auth, namespace-scope, or permission recovery resets its epoch.
 - Error notifications are deduplicated by full refresh scope. Re-selecting a
   retained failing scope does not repeat the same notification; leaving the
   error state clears that scope's dedupe so a later failure can notify again.
@@ -256,3 +261,16 @@ For a freshness change, test the contract at the producer/consumer seam:
     transition or the bounded full-teardown fallback completes.
 
 Finish non-documentation changes with `wails3 task qc:prerelease`.
+
+## Snapshot and cooled-store lifetime
+
+Cache invalidation advances a domain generation as well as deleting cache entries.
+New requests cannot join pre-invalidation builds, and those builds cannot populate
+the new generation's cache after completion.
+
+Cooled mmap stores belong to the exact subsystem generation. Replacement publishes
+new aggregate routes before retiring old snapshot serving; retirement rejects late
+reads and drains active builders before releasing mappings. Failed rewarm retains
+the old routed generation and its mappings. Partial cooling returns ownership of
+already-swapped mappings to the coordinator, which retires and spills those stores
+before closing them during fallback teardown.

--- a/docs/architecture/permissions.md
+++ b/docs/architecture/permissions.md
@@ -53,6 +53,20 @@ shape, failure behavior, and diagnostics differ.
   informer namespace. Denied namespaces start no informer while permitted
   namespaces continue to provide partial change signals.
 
+Permission revalidation compares both allowed and denied decisions with the exact
+scopes used to build the generation. Revocation and restoration delegate replacement
+to `RefreshCoordinator`; the revalidator does not stop a still-routed subsystem.
+Background revalidation skips a busy cluster instead of canceling its foreground
+operation, and client reconstruction receives the operation cancellation context.
+A failed replacement leaves the old generation serving and revalidating. An
+unchanged construction error is logged and captured once per failing stage in
+that generation; recovery rearms that stage's report, and a changed error is
+reported immediately. Reporting suppression does not suppress rebuild attempts.
+Denied decisions share the normal permission cache and remain part of revalidation
+so restored grants can be detected. After successful publication,
+`cluster:permissions:changed` clears only that cluster's
+frontend denial and stream latches. It does not change namespace-scope revisions.
+
 ## UI Permission Rules
 
 - `QueryPermissions` is the backend query surface for UI permissions.

--- a/docs/architecture/refresh-system.md
+++ b/docs/architecture/refresh-system.md
@@ -103,7 +103,8 @@ That record is the source of truth for:
 
 - activation plus independent query and snapshot demand counts;
 - deferred cluster-readiness intent and the scoped permission epoch;
-- snapshot request ownership and its coalesced trailing stream signal;
+- snapshot request ownership, coalesced trailing reads, and pending reconciliation
+  with bounded retry backoff;
 - stream policy, scheduled initialization, connection ownership, cancellation,
   and health.
 
@@ -115,8 +116,8 @@ no-op.
 
 Cluster auth availability belongs to its `ClusterRefreshRuntime`. Auth recovery
 resets only that runtime's scoped permission epoch before enabled scopes are
-reconciled. A namespace-scope rebuild is a new permission epoch for every
-runtime. Store `permissionDenied` remains a presentation projection, not the
+reconciled. Namespace-scope and permission rebuilds reset only the affected
+cluster runtime. Store `permissionDenied` remains a presentation projection, not the
 retry gate.
 
 `RefreshManager` separately reduces scheduler intent (`enabled`, `paused`, or
@@ -125,6 +126,16 @@ retry gate.
 states plus refresh metadata. Global metrics demand is independently reduced as
 `idle`, `requesting`, or `waiting-retry`; only the matching demand key may
 complete or schedule a retry.
+
+One-shot broker reads hold independent scope leases through completion. Overlapping
+reads coalesce without aborting their owners; a caller that arrives during a read
+waits for the trailing snapshot before releasing its lease. Explicit manual refresh
+commands retain their separate stream-refresh behavior.
+
+A failed snapshot keeps reconciliation pending even when its stream is healthy.
+Scheduled attempts retry with backoff capped at 60 seconds; a successful snapshot
+or settled permission denial clears that pending state. Typed query errors surface
+as errors while retaining displayed rows; missing warm-up data is a separate state.
 
 ### Frontend resource-stream protocol
 
@@ -144,7 +155,7 @@ An ACK makes a quiet subscription healthy. Advancing sequences reject replayed
 changes. A token-less first RESET completes the initial handshake, while a
 later RESET or manager-replacement COMPLETE re-arms the subscription. Pending
 source clocks are emitted before resync clears coalescing state. Permission
-denial remains terminal until the owning scope/auth lifecycle replaces the
+denial remains terminal until the owning scope/auth/permission lifecycle replaces the
 subscription, and stopping is terminal so late frames or timers cannot affect a
 replacement owner.
 
@@ -280,3 +291,15 @@ Four rules keep the two views joinable:
 4. Add contract parity plus behavior tests at the real snapshot/stream/consumer
    seams.
 5. Run focused backend/frontend tests and `wails3 task qc:prerelease`.
+
+### Backend subscription lifetime
+
+A subscription's closed update channel always produces COMPLETE, even when its
+reason channel closes simultaneously. Delivery is tied to the exact subscription
+owner so an old frame or COMPLETE cannot affect its replacement. Resource-manager
+shutdown closes subscribers, rejects new subscriptions, and serializes channel
+closure with delivery.
+
+When the shared session's outgoing queue overflows, close the session. Reconnection
+must reconcile every scope whose queued signal could have been lost. A reset of
+only the incoming frame's scope cannot repair an evicted frame from another scope.

--- a/docs/frontend/sonar.md
+++ b/docs/frontend/sonar.md
@@ -70,15 +70,47 @@ Sonar's `buildCatalogSummary` finding. Therefore:
 - do not expand the Sonar inventory with Biome-only findings during this plan;
 - wait for the completed Sonar analysis before checking off remediation.
 
+## Local Go signal
+
+Use a pinned gocognit invocation to inspect changed Go production functions and
+their new helpers. This does not add a dependency to the application's module:
+
+```sh
+mise exec -- go run github.com/uudashr/gocognit/cmd/gocognit@v1.2.1 \
+  -json backend/path/to/file.go
+```
+
+gocognit is a directional check, not the Sonar Go analyzer. Its scores can differ
+from Sonar, particularly for nested control flow. Target 12 or lower in changed
+functions; review their scores rather than treating unrelated existing findings
+in the same file as part of the task. Keep Sonar's configured threshold and
+exclusions unchanged. The pinned version's
+[release notes](https://github.com/uudashr/gocognit/releases/tag/v1.2.1) include
+support for integer and iterator range loops.
+
+## Prevent complexity regressions while implementing
+
+Run the applicable local check after adding recovery branches, loops/selects,
+or callback logic, and again before the prerelease gate. A passing gate does not
+include this separate complexity check. Split cohesive responsibilities such as
+operation admission, generation replacement, live delivery, and terminal cleanup
+before adding more nesting. Preserve the timing of stale-generation guards,
+cancellation, publication, and completion while moving code.
+
+Recurring mistakes and their prevention steps are recorded in
+[the shared workflow guidance](../workflows/common-mistakes.md); read it before
+editing.
+
 ## Required remediation loop
 
 1. Record the Sonar key, score, owning contract, consumers, and directly affected
    coverage.
 2. Add or confirm characterization cases before moving branches.
 3. Refactor one responsibility at a time and rerun focused tests.
-4. Run the local Biome signal for the touched function.
+4. Run the applicable local complexity signal for every changed function and
+   new helper, not only the function Sonar originally flagged.
 5. Run frontend check, typecheck, coverage, and the full prerelease gate.
-6. Push the smallest reviewable batch and wait for Sonar.
+6. After an explicitly authorized push, wait for Sonar analysis of that revision.
 7. Run the all-rule PR audit.
 8. After merge and main analysis, run the monotonic main audit and update the
    baseline.

--- a/docs/release/pending.md
+++ b/docs/release/pending.md
@@ -4,8 +4,3 @@
 - Failed data refreshes retry with backoff while retaining the last available data.
 - Resource streams reconnect after delivery overflow; oversized reconnect replays request a fresh snapshot to avoid repeated disconnects.
 - Replacing a cluster connection now stops the previous object catalog and releases its generation's resources.
-
-- The Linux portable installer did not properly register the app icon, so it was showing the generic Wails icon. In order to fix this, you'll need to uninstall and reinstall the app.
-  - `cd $HOME/.local/share/luxury-yacht`
-  - run `./manage-installation uninstall`
-  - Reinstall from the portable installer's `install.sh` script.

--- a/docs/release/pending.md
+++ b/docs/release/pending.md
@@ -1,5 +1,10 @@
 ### Fixed
 
+- Refresh now recovers automatically when Kubernetes permissions are restored, without requiring an app restart.
+- Failed data refreshes retry with backoff while retaining the last available data.
+- Resource streams reconnect after delivery overflow; oversized reconnect replays request a fresh snapshot to avoid repeated disconnects.
+- Replacing a cluster connection now stops the previous object catalog and releases its generation's resources.
+
 - The Linux portable installer did not properly register the app icon, so it was showing the generic Wails icon. In order to fix this, you'll need to uninstall and reinstall the app.
   - `cd $HOME/.local/share/luxury-yacht`
   - run `./manage-installation uninstall`

--- a/docs/workflows/common-mistakes.md
+++ b/docs/workflows/common-mistakes.md
@@ -1,0 +1,40 @@
+# Common implementation mistakes
+
+Read this before editing. When user feedback identifies a recurring mistake,
+record the pattern and a concrete prevention check here. Keep entries focused
+on reusable rules; omit transient logs, credentials, and session history.
+
+## Adding cognitive complexity without measuring it
+
+Recovery guards and channel-close handling can become deeply nested inside
+loops, selects, and operation callbacks. Relying only on the prerelease gate
+misses this: its task list in [Taskfile.yml](../../Taskfile.yml) does not run a
+local cognitive-complexity analyzer or fetch Sonar findings.
+
+Prevention:
+
+- Identify separate responsibilities and extract cohesive helpers before
+  adding more nesting.
+- Measure every changed production function and new helper after editing and
+  before the final gate. Target a local score of 12 or lower using the commands
+  in [the Sonar remediation contract](../frontend/sonar.md).
+- Preserve guard timing, cancellation ownership, publication order, and terminal
+  cleanup. Confirm characterization cases before refactoring and rerun them
+  afterward.
+- Refactor responsibilities instead of suppressing the rule, raising thresholds,
+  weakening tests, or accepting increased complexity in a baseline.
+- Treat local scores as directional. Confirm remote closure with Sonar analysis
+  of the pushed revision; commit and push only when explicitly authorized.
+
+## Putting shared prevention rules in ignored memory
+
+Shared guidance must travel with the repository. `.agents/memory/` is ignored
+by Git and is reserved for per-clone context under the
+[agent memory policy](../../.agents/setup/agent-memory.md).
+
+Prevention:
+
+- Keep recurring mistakes and shared prevention checks in this document, with
+  an entry point in `AGENTS.md`.
+- Check `git status --short` and `git check-ignore` when adding shared guidance
+  to confirm it can be included in the repository's normal changes.

--- a/frontend/bindings/github.com/luxury-yacht/app/backend/index.ts
+++ b/frontend/bindings/github.com/luxury-yacht/app/backend/index.ts
@@ -27,6 +27,7 @@ export type {
     ClusterAuthProgressEvent,
     ClusterHealthEvent,
     ClusterLifecycleEvent,
+    ClusterPermissionsChangedEvent,
     ClusterScopeChangedEvent,
     ClusterWorkspaceAuthState,
     ClusterWorkspaceClusterState,

--- a/frontend/bindings/github.com/luxury-yacht/app/backend/models.ts
+++ b/frontend/bindings/github.com/luxury-yacht/app/backend/models.ts
@@ -293,6 +293,10 @@ export enum ClusterLifecycleState {
     ClusterStateReconnecting = "reconnecting",
 };
 
+export interface ClusterPermissionsChangedEvent {
+    "clusterId": string;
+}
+
 export interface ClusterScopeChangedEvent {
     "clusterId": string;
 }

--- a/frontend/bindings/github.com/wailsapp/wails/v3/internal/eventdata.d.ts
+++ b/frontend/bindings/github.com/wailsapp/wails/v3/internal/eventdata.d.ts
@@ -25,6 +25,7 @@ declare module "@wailsio/runtime" {
             "cluster:health:degraded": backend$0.ClusterHealthEvent;
             "cluster:health:healthy": backend$0.ClusterHealthEvent;
             "cluster:lifecycle": backend$0.ClusterLifecycleEvent;
+            "cluster:permissions:changed": backend$0.ClusterPermissionsChangedEvent;
             "cluster:scope:changed": backend$0.ClusterScopeChangedEvent;
             "debug:open-inspector": void;
             "debug:toggle-error-overlay": void;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,7 +18,7 @@
         "@lezer/highlight": "^1.2.3",
         "@sentry/react": "^10.73.0",
         "@uiw/react-codemirror": "^4.25.11",
-        "@wailsio/runtime": "3.0.0-beta.16",
+        "@wailsio/runtime": "3.0.0-beta.17",
         "@xterm/addon-clipboard": "^0.2.0",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
@@ -4142,9 +4142,9 @@
       }
     },
     "node_modules/@wailsio/runtime": {
-      "version": "3.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@wailsio/runtime/-/runtime-3.0.0-beta.16.tgz",
-      "integrity": "sha512-IzaYrUKYDmvWDXf3Pqfl0onT1R5T5YHTx+AnK9vX4MyuE1PF3lXZmQrtvtfYNAsBnL+9e+iCJvIROGhjyf1rew==",
+      "version": "3.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@wailsio/runtime/-/runtime-3.0.0-beta.17.tgz",
+      "integrity": "sha512-Q7aL/8PjIQiYYIneeu3a9ximNT4vjTQbjhIWkzKBAu9XkBQlvW8tGOSt+ORCv/S27y/dumlEK1eO71GSJ9E+jA==",
       "license": "MIT"
     },
     "node_modules/@webcontainer/env": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,7 @@
     "@lezer/highlight": "^1.2.3",
     "@sentry/react": "^10.73.0",
     "@uiw/react-codemirror": "^4.25.11",
-    "@wailsio/runtime": "3.0.0-beta.16",
+    "@wailsio/runtime": "3.0.0-beta.17",
     "@xterm/addon-clipboard": "^0.2.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",

--- a/frontend/src/core/cluster-workspace/clusterWorkspaceStore.test.ts
+++ b/frontend/src/core/cluster-workspace/clusterWorkspaceStore.test.ts
@@ -14,6 +14,29 @@ afterEach(() => {
 });
 
 describe('ClusterWorkspaceStore', () => {
+  it('bridges permission recovery without changing namespace scope revisions', async () => {
+    const runtime = createWailsRuntimeHarness();
+    const store = new ClusterWorkspaceStore({
+      read: async () => emptyState(),
+      onEvent: runtime.onEvent,
+    });
+    const changed = vi.fn();
+    const unsubscribe = eventBus.on('cluster:permissions-changed', changed);
+    const release = store.acquire();
+    try {
+      await store.hydrate();
+      const before = store.getSnapshot();
+      runtime.emit('cluster:permissions:changed', { clusterId: 'cluster-a' });
+      expect(changed).toHaveBeenCalledExactlyOnceWith({ clusterId: 'cluster-a' });
+      expect(store.getSnapshot()).toBe(before);
+      runtime.emit('cluster:permissions:changed', { clusterId: '' });
+      expect(changed).toHaveBeenCalledOnce();
+    } finally {
+      release();
+      unsubscribe();
+    }
+  });
+
   it('emits lifecycle only when an authoritative read changes the state', async () => {
     const workspaceState = (lifecycle: 'ready' | 'loading'): ClusterWorkspaceWireState => ({
       ...emptyState(),

--- a/frontend/src/core/cluster-workspace/clusterWorkspaceStore.ts
+++ b/frontend/src/core/cluster-workspace/clusterWorkspaceStore.ts
@@ -171,7 +171,8 @@ type ClusterWorkspaceEventName =
   | 'cluster:auth:progress'
   | 'cluster:health:healthy'
   | 'cluster:health:degraded'
-  | 'cluster:scope:changed';
+  | 'cluster:scope:changed'
+  | 'cluster:permissions:changed';
 
 type ClusterWorkspaceEventSubscriber = <E extends ClusterWorkspaceEventName>(
   event: E,
@@ -460,6 +461,11 @@ export class ClusterWorkspaceStore {
     on('cluster:auth:progress', (payload) => this.handleAuthProgress(payload));
     on('cluster:health:healthy', (payload) => this.handleHealth(payload, 'healthy'));
     on('cluster:health:degraded', (payload) => this.handleHealth(payload, 'degraded'));
+    on('cluster:permissions:changed', (payload) => {
+      if (payload.clusterId?.trim()) {
+        eventBus.emit('cluster:permissions-changed', { clusterId: payload.clusterId });
+      }
+    });
     on('cluster:scope:changed', (payload) => this.handleScopeChanged(payload));
 
     void this.hydrate().catch((error) => {

--- a/frontend/src/core/contexts/AuthErrorContext.test.tsx
+++ b/frontend/src/core/contexts/AuthErrorContext.test.tsx
@@ -105,7 +105,8 @@ describe('AuthErrorContext', () => {
       root.unmount();
     });
 
-    expect(runtimeHarness.disposerCalls).toHaveLength(8);
+    expect(runtimeHarness.disposerCalls).toHaveLength(9);
+    expect(runtimeHarness.disposerCalls).toContain('cluster:permissions:changed');
     expect(runtimeHarness.disposerCalls).toContain('cluster:auth:failed');
     expect(runtimeHarness.disposerCalls).toContain('cluster:auth:recovering');
     expect(runtimeHarness.disposerCalls).toContain('cluster:auth:recovered');

--- a/frontend/src/core/data-access/dataAccess.test.ts
+++ b/frontend/src/core/data-access/dataAccess.test.ts
@@ -13,6 +13,8 @@ import {
 const hoisted = vi.hoisted(() => ({
   fetchScopedDomain: vi.fn(),
   setScopedDomainEnabled: vi.fn(),
+  acquireScopedDomainLease: vi.fn(),
+  releaseScopedDomainLease: vi.fn(),
   triggerManualRefreshForContext: vi.fn(),
   getScopedDomainState: vi.fn(),
   getAutoRefreshEnabled: vi.fn(),
@@ -21,6 +23,8 @@ const hoisted = vi.hoisted(() => ({
 vi.mock('@/core/refresh', () => ({
   refreshOrchestrator: {
     fetchScopedDomain: (...args: unknown[]) => hoisted.fetchScopedDomain(...args),
+    acquireScopedDomainLease: (...args: unknown[]) => hoisted.acquireScopedDomainLease(...args),
+    releaseScopedDomainLease: (...args: unknown[]) => hoisted.releaseScopedDomainLease(...args),
     setScopedDomainEnabled: (...args: unknown[]) => hoisted.setScopedDomainEnabled(...args),
     triggerManualRefreshForContext: (...args: unknown[]) =>
       hoisted.triggerManualRefreshForContext(...args),
@@ -161,34 +165,31 @@ describe('dataAccess', () => {
       data: state,
     });
 
-    expect(hoisted.setScopedDomainEnabled).toHaveBeenNthCalledWith(
-      1,
+    expect(hoisted.acquireScopedDomainLease).toHaveBeenCalledWith(
       'catalog',
       'cluster:alpha|limit=2',
-      true,
       { preserveState: true }
     );
     expect(hoisted.fetchScopedDomain).toHaveBeenCalledWith('catalog', 'cluster:alpha|limit=2', {
+      coalesce: true,
       isManual: true,
       streamSignal: false,
       correlationId: 'broker-read-1',
     });
     expect(hoisted.getScopedDomainState).toHaveBeenCalledWith('catalog', 'cluster:alpha|limit=2');
-    expect(hoisted.setScopedDomainEnabled).toHaveBeenNthCalledWith(
-      2,
+    expect(hoisted.releaseScopedDomainLease).toHaveBeenCalledWith(
       'catalog',
       'cluster:alpha|limit=2',
-      false,
       { preserveState: true }
     );
-    expect(hoisted.setScopedDomainEnabled.mock.invocationCallOrder[0]).toBeLessThan(
+    expect(hoisted.acquireScopedDomainLease.mock.invocationCallOrder[0]).toBeLessThan(
       hoisted.fetchScopedDomain.mock.invocationCallOrder[0]
     );
     expect(hoisted.fetchScopedDomain.mock.invocationCallOrder[0]).toBeLessThan(
       hoisted.getScopedDomainState.mock.invocationCallOrder[0]
     );
     expect(hoisted.getScopedDomainState.mock.invocationCallOrder[0]).toBeLessThan(
-      hoisted.setScopedDomainEnabled.mock.invocationCallOrder[1]
+      hoisted.releaseScopedDomainLease.mock.invocationCallOrder[0]
     );
   });
 

--- a/frontend/src/core/data-access/dataAccess.ts
+++ b/frontend/src/core/data-access/dataAccess.ts
@@ -85,12 +85,10 @@ export const requestData = async <T>({
   }
 };
 
-export const requestRefreshDomain = async ({
-  domain,
-  scope,
-  reason,
-  label,
-}: RefreshDomainRequest): Promise<DataRequestResult> => {
+const performRefreshDomainRequest = async (
+  { domain, scope, reason, label }: RefreshDomainRequest,
+  coalesce = false
+): Promise<DataRequestResult> => {
   const result = await requestData<void>({
     resource: domain,
     reason,
@@ -99,6 +97,7 @@ export const requestRefreshDomain = async ({
     scope,
     read: async (requestId) => {
       await refreshOrchestrator.fetchScopedDomain(domain, scope, {
+        ...(coalesce ? { coalesce: true } : {}),
         isManual: reason === 'user',
         streamSignal: reason === 'stream-signal',
         ...(requestId ? { correlationId: requestId } : {}),
@@ -112,6 +111,9 @@ export const requestRefreshDomain = async ({
   };
 };
 
+export const requestRefreshDomain = (request: RefreshDomainRequest): Promise<DataRequestResult> =>
+  performRefreshDomainRequest(request);
+
 export const requestRefreshDomainState = async <K extends RefreshDomain>({
   domain,
   scope,
@@ -120,10 +122,14 @@ export const requestRefreshDomainState = async <K extends RefreshDomain>({
   cleanup = true,
   preserveState = false,
 }: RefreshDomainStateRequest<K>): Promise<RefreshDomainStateResult<K>> => {
-  setRefreshDomainEnabled({ domain, scope, enabled: true, preserveState });
+  if (cleanup) {
+    acquireRefreshDomainLease({ domain, scope, preserveState });
+  } else {
+    setRefreshDomainEnabled({ domain, scope, enabled: true, preserveState });
+  }
 
   try {
-    const result = await requestRefreshDomain({ domain, scope, reason, label });
+    const result = await performRefreshDomainRequest({ domain, scope, reason, label }, true);
     if (result.status !== 'executed') {
       return {
         status: result.status,
@@ -137,7 +143,7 @@ export const requestRefreshDomainState = async <K extends RefreshDomain>({
     };
   } finally {
     if (cleanup) {
-      setRefreshDomainEnabled({ domain, scope, enabled: false, preserveState });
+      releaseRefreshDomainLease({ domain, scope, preserveState });
     }
   }
 };

--- a/frontend/src/core/events/eventBus.ts
+++ b/frontend/src/core/events/eventBus.ts
@@ -76,6 +76,7 @@ export interface AppEvents {
   // rebuilding (docs/architecture/namespace-scope.md) — bridged from the Wails
   // cluster:scope:changed event by KubeconfigContext. Streams must restart
   // and the cluster's domains refetch.
+  'cluster:permissions-changed': { clusterId: string };
   'cluster:scope-changed': { clusterId: string };
 
   // View events

--- a/frontend/src/core/refresh/hooks/useStreamSignalRefetch.ts
+++ b/frontend/src/core/refresh/hooks/useStreamSignalRefetch.ts
@@ -33,7 +33,7 @@ import type { RefreshDomain } from '../types';
 
 export const useStreamSignalRefetch = (domain: RefreshDomain, scopes: readonly string[]): void => {
   const domainStates = useRefreshScopedDomainStates(domain);
-  const consumedKeysRef = useRef<Map<string, string>>(new Map());
+  const dispatchedKeysRef = useRef<Map<string, string>>(new Map());
 
   useEffect(() => {
     const clocks = doorbellSourceClocks(domain);
@@ -51,18 +51,19 @@ export const useStreamSignalRefetch = (domain: RefreshDomain, scopes: readonly s
       const signalVersions = domainStates[scope]?.signalVersions;
       const key = clocks.map((clock) => `${clock}:${signalVersions?.[clock] ?? ''}`).join(' ');
       const hasSignal = clocks.some((clock) => Boolean(signalVersions?.[clock]));
-      const consumed = consumedKeysRef.current;
-      if (!consumed.has(scope)) {
+      const dispatched = dispatchedKeysRef.current;
+      if (!dispatched.has(scope)) {
         // First observation: whatever doorbell values exist arrived before
         // this consumer mounted — the data it reads was fetched at or after
         // them, fresh by construction.
-        consumed.set(scope, key);
+        dispatched.set(scope, key);
         return;
       }
-      if (consumed.get(scope) === key || !hasSignal) {
+      if (dispatched.get(scope) === key || !hasSignal) {
         return;
       }
-      consumed.set(scope, key);
+      dispatched.set(scope, key);
+      // The runtime retains failed reconciliation and owns its retry backoff.
       void requestRefreshDomain({ domain, scope, reason: 'stream-signal' });
     });
   }, [domainStates, scopes, domain]);

--- a/frontend/src/core/refresh/orchestrator.test.ts
+++ b/frontend/src/core/refresh/orchestrator.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { requestRefreshDomainState } from '@/core/data-access/dataAccess';
 import { eventBus } from '@/core/events';
 import {
   resetAppPreferencesCacheForTesting,
@@ -787,6 +788,39 @@ describe('refreshOrchestrator', () => {
 
     expect(clientMocks.fetchSnapshotMock).toHaveBeenCalledTimes(2);
   });
+
+  it.each(['cluster:scope-changed', 'cluster:permissions-changed'] as const)(
+    'recovers only the affected cluster on %s',
+    async (event) => {
+      registerCatalogDomain();
+      const scopeA = buildClusterScope('cluster-a', '');
+      const scopeB = buildClusterScope('cluster-b', '');
+      for (const scope of [scopeA, scopeB]) {
+        setRuntimeScopeEnabled('catalog', scope, true);
+        setScopedDomainState('catalog', scope, (previous) => ({
+          ...previous,
+          status: 'error',
+          permissionDenied: true,
+        }));
+      }
+      const controllerB = new AbortController();
+      const runtimeB = orchestratorInternals.getRuntimeForScope('catalog', scopeB);
+      runtimeB.setInFlight({
+        controller: controllerB,
+        isManual: false,
+        requestId: 999,
+        contextVersion: orchestratorInternals.contextVersion,
+        domain: 'catalog',
+        scope: scopeB,
+      });
+      const version = orchestratorInternals.contextVersion;
+      eventBus.emit(event, { clusterId: 'cluster-a' });
+      expect(getScopedDomainState('catalog', scopeA).permissionDenied).not.toBe(true);
+      expect(getScopedDomainState('catalog', scopeB).permissionDenied).toBe(true);
+      expect(controllerB.signal.aborted).toBe(false);
+      expect(orchestratorInternals.contextVersion).toBe(version);
+    }
+  );
 
   it('a stream-signal fetch latches a trailing refetch behind an in-flight fetch — never dropped, never aborting', async () => {
     clusterReadiness.resetForTests();
@@ -3185,6 +3219,25 @@ describe('refreshOrchestrator', () => {
     expect(clientMocks.fetchSnapshotMock).not.toHaveBeenCalled();
   });
 
+  it.each(SNAPSHOT_REFRESH_DOMAINS)(
+    'rejects multi-cluster %s scopes before they can acquire a denial latch',
+    async (domain) => {
+      registerAllSnapshotDomains();
+      const scope = 'clusters=cluster-a,cluster-b|namespace:default';
+      expect(() => refreshOrchestrator.acquireScopedDomainLease(domain, scope)).toThrow(
+        'single cluster'
+      );
+      expect(() => refreshOrchestrator.setScopedDomainEnabled(domain, scope, true)).toThrow(
+        'single cluster'
+      );
+      await expect(refreshOrchestrator.fetchScopedDomain(domain, scope)).rejects.toThrow(
+        'single cluster'
+      );
+      expect(clientMocks.fetchSnapshotMock).not.toHaveBeenCalled();
+      expect(getScopedDomainState(domain, scope).permissionDenied).toBeFalsy();
+    }
+  );
+
   it('refreshes background resource domains one cluster at a time', async () => {
     registerPodsDomain();
 
@@ -3698,5 +3751,179 @@ describe('refreshOrchestrator', () => {
 
     stopAllSpy.mockRestore();
     teardownSpy.mockRestore();
+  });
+  it('retries failed signal reconciliation while transport stays healthy', async () => {
+    registerStreamingClusterConfigDomain();
+    const scope = buildClusterScope('cluster-a', '');
+    eventBus.emit('cluster:lifecycle', { clusterId: 'cluster-a', state: 'loading' });
+    orchestratorInternals.context = {
+      currentView: 'cluster',
+      activeClusterView: 'config',
+      selectedClusterIds: ['cluster-a'],
+      objectPanel: { isOpen: false },
+    };
+    setRuntimeScopeEnabled('cluster-config', scope, true);
+    markResourceStreamActive('cluster-config', scope);
+    resourceStreamMocks.isHealthy.mockReturnValue(true);
+    setScopedDomainState('cluster-config', scope, (prev) => ({
+      ...prev,
+      status: 'ready',
+      scope,
+      data: { clusterId: 'cluster-a', rows: [] } as never,
+    }));
+    clientMocks.fetchSnapshotMock.mockRejectedValueOnce(
+      new Error('server temporarily unavailable')
+    );
+    await refreshOrchestrator.fetchScopedDomain('cluster-config', scope, {
+      isManual: false,
+      streamSignal: true,
+    });
+    expect(getScopedDomainState('cluster-config', scope).status).toBe('error');
+    clientMocks.fetchSnapshotMock.mockResolvedValue({ notModified: true });
+    for (let i = 0; i < 5; i++) {
+      await refreshOrchestrator.fetchScopedDomain('cluster-config', scope, { isManual: false });
+    }
+    expect(clientMocks.fetchSnapshotMock.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it('one-shot reads fetch a snapshot even when the base stream is already active', async () => {
+    registerStreamingClusterConfigDomain();
+    const scope = buildClusterScope('cluster-a', '');
+    eventBus.emit('cluster:lifecycle', { clusterId: 'cluster-a', state: 'loading' });
+    orchestratorInternals.context = {
+      currentView: 'cluster',
+      activeClusterView: 'config',
+      selectedClusterIds: ['cluster-a'],
+      objectPanel: { isOpen: false },
+    };
+    setRuntimeScopeEnabled('cluster-config', scope, true);
+    markResourceStreamActive('cluster-config', scope);
+    clientMocks.fetchSnapshotMock.mockResolvedValueOnce({ notModified: true });
+    await requestRefreshDomainState({ domain: 'cluster-config', scope, reason: 'user' });
+    expect(clientMocks.fetchSnapshotMock).toHaveBeenCalledOnce();
+    expect(resourceStreamMocks.refreshOnce).not.toHaveBeenCalled();
+  });
+
+  it('coalesces signal page reads and waits for the trailing snapshot', async () => {
+    registerStreamingClusterConfigDomain();
+    eventBus.emit('cluster:lifecycle', { clusterId: 'cluster-a', state: 'loading' });
+    const scope = buildClusterScope('cluster-a', '?limit=100');
+    const calls: Array<{ signal: AbortSignal; resolve: (value: unknown) => void }> = [];
+    clientMocks.fetchSnapshotMock.mockImplementation(
+      (_domain: string, args: { signal: AbortSignal }) =>
+        new Promise((resolve, reject) => {
+          calls.push({ signal: args.signal, resolve });
+          args.signal.addEventListener(
+            'abort',
+            () => reject(new DOMException('Aborted', 'AbortError')),
+            { once: true }
+          );
+        })
+    );
+    const first = requestRefreshDomainState({
+      domain: 'cluster-config',
+      scope,
+      reason: 'foreground',
+    });
+    await vi.waitFor(() => expect(calls.length).toBe(1));
+    let settled = false;
+    const second = requestRefreshDomainState({
+      domain: 'cluster-config',
+      scope,
+      reason: 'stream-signal',
+    }).then((response) => {
+      settled = true;
+      return response;
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    const settledBeforeData = settled;
+    calls[0].resolve({
+      snapshot: {
+        domain: 'cluster-config',
+        scope,
+        version: 1,
+        sequence: 1,
+        payload: { clusterId: 'cluster-a', rows: [], marker: 'old' },
+        stats: {},
+      },
+    });
+    await first;
+    await vi.waitFor(() => expect(calls.length).toBe(2));
+    calls[1].resolve({
+      snapshot: {
+        domain: 'cluster-config',
+        scope,
+        version: 2,
+        sequence: 2,
+        payload: { clusterId: 'cluster-a', rows: [], marker: 'new' },
+        stats: {},
+      },
+    });
+    const result = await second;
+    expect(settledBeforeData).toBe(false);
+    expect(calls[0].signal.aborted).toBe(false);
+    expect(result.data?.data).toEqual(expect.objectContaining({ marker: 'new' }));
+  });
+  it('coalesces overlapping user page reads without aborting either owner', async () => {
+    registerStreamingClusterConfigDomain();
+    eventBus.emit('cluster:lifecycle', { clusterId: 'cluster-a', state: 'loading' });
+    const scope = buildClusterScope('cluster-a', '?limit=100');
+    const calls: Array<{ signal: AbortSignal; resolve: (value: unknown) => void }> = [];
+    clientMocks.fetchSnapshotMock.mockImplementation(
+      (_domain: string, args: { signal: AbortSignal }) =>
+        new Promise((resolve, reject) => {
+          calls.push({ signal: args.signal, resolve });
+          args.signal.addEventListener(
+            'abort',
+            () => reject(new DOMException('Aborted', 'AbortError')),
+            { once: true }
+          );
+        })
+    );
+    const first = requestRefreshDomainState({ domain: 'cluster-config', scope, reason: 'user' });
+    await vi.waitFor(() => expect(calls.length).toBe(1));
+    let settled = false;
+    const second = requestRefreshDomainState({
+      domain: 'cluster-config',
+      scope,
+      reason: 'user',
+    }).then((response) => {
+      settled = true;
+      return response;
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    const settledBeforeData = settled;
+    calls[0].resolve({
+      snapshot: {
+        domain: 'cluster-config',
+        scope,
+        version: 1,
+        sequence: 1,
+        payload: { clusterId: 'cluster-a', rows: [], marker: 'old' },
+        stats: {},
+      },
+    });
+    await first;
+    await vi.waitFor(() => expect(calls.length).toBe(2));
+    calls[1].resolve({
+      snapshot: {
+        domain: 'cluster-config',
+        scope,
+        version: 2,
+        sequence: 2,
+        payload: { clusterId: 'cluster-a', rows: [], marker: 'new' },
+        stats: {},
+      },
+    });
+    const result = await second;
+    expect(settledBeforeData).toBe(false);
+    expect(calls[0].signal.aborted).toBe(false);
+    expect(result.data?.data).toEqual(expect.objectContaining({ marker: 'new' }));
   });
 });

--- a/frontend/src/core/refresh/orchestrator.ts
+++ b/frontend/src/core/refresh/orchestrator.ts
@@ -65,6 +65,8 @@ import { resourceStreamManager } from './streaming/resourceStreamManager';
 import type { DomainPayloadMap, RefreshDomain } from './types';
 
 type DomainFetchOptions = {
+  // One-shot page readers share work, including when initiated by the user.
+  coalesce?: boolean;
   isManual: boolean;
   correlationId?: string;
   signal?: AbortSignal;
@@ -81,6 +83,7 @@ type ScopedFetchExecution<K extends RefreshDomain> = {
   runtime: ClusterRefreshRuntime;
   scope: string;
   previousState: DomainSnapshotState<DomainPayloadMap[K]>;
+  complete: () => void;
   controller: AbortController;
   requestId: number;
   contextVersion: number;
@@ -151,6 +154,7 @@ class RefreshOrchestrator {
     eventBus.on('cluster:auth:failed', this.handleClusterAuthFailed);
     eventBus.on('cluster:auth:recovered', this.handleClusterAuthRecovered);
     eventBus.on('cluster:scope-changed', this.handleClusterScopeChanged);
+    eventBus.on('cluster:permissions-changed', this.handleClusterScopeChanged);
     clusterReadiness.onBecameServiceable((clusterId) =>
       this.handleClusterBecameServiceable(clusterId)
     );
@@ -175,7 +179,7 @@ class RefreshOrchestrator {
   private recordPendingClusterReadiness(
     domain: RefreshDomain,
     scope: string,
-    options?: Pick<DomainFetchOptions, 'isManual' | 'streamSignal' | 'queryReconcile'>
+    options?: Pick<DomainFetchOptions, 'isManual' | 'streamSignal' | 'queryReconcile' | 'coalesce'>
   ): void {
     for (const clusterId of parseClusterScopeList(scope).clusterIds) {
       this.getClusterRuntime(clusterId).deferUntilClusterReady({
@@ -184,6 +188,7 @@ class RefreshOrchestrator {
         isManual: Boolean(options?.isManual),
         streamSignal: Boolean(options?.streamSignal),
         queryReconcile: Boolean(options?.queryReconcile),
+        ...(options?.coalesce ? { coalesce: true } : {}),
       });
     }
   }
@@ -198,6 +203,7 @@ class RefreshOrchestrator {
       if (details.scope && this.isScopedDomainEnabledInternal(details.domain, details.scope)) {
         this.recordPendingClusterReadiness(details.domain, details.scope, {
           isManual: details.isManual,
+          coalesce: details.coalesce,
           streamSignal: Boolean(details.streamSignal || details.trailingStreamSignal),
         });
       }
@@ -225,6 +231,7 @@ class RefreshOrchestrator {
         }
         void this.fetchScopedDomain(domain, scope, {
           isManual: request.isManual,
+          ...(request.coalesce ? { coalesce: true } : {}),
           streamSignal: request.streamSignal,
           queryReconcile: request.queryReconcile,
         }).catch((error) => {
@@ -1175,10 +1182,6 @@ class RefreshOrchestrator {
     });
   }
 
-  private resetAllRuntimePermissionEpochs(): void {
-    this.forEachRuntime((runtime) => this.resetRuntimePermissionEpoch(runtime));
-  }
-
   private pruneRemovedClusterRuntimes(connectedClusterIds: string[]): void {
     const connected = new Set(
       connectedClusterIds.map((clusterId) => clusterId.trim()).filter(Boolean)
@@ -1312,7 +1315,7 @@ class RefreshOrchestrator {
   private async reconcileStreamingFetch(
     domain: RefreshDomain,
     scope: string,
-    options: { isManual?: boolean; streamSignal?: boolean },
+    options: { isManual?: boolean; streamSignal?: boolean; coalesce?: boolean },
     streaming: StreamingRegistration | undefined,
     runtime: ClusterRefreshRuntime
   ): Promise<boolean> {
@@ -1324,6 +1327,7 @@ class RefreshOrchestrator {
     if (
       shouldStream &&
       options.isManual &&
+      !options.coalesce &&
       isResourceStreamDomain(domain) &&
       this.isStreamingActive(domain, scope)
     ) {
@@ -1339,7 +1343,7 @@ class RefreshOrchestrator {
       scope,
       shouldStream,
       isManual: Boolean(options.isManual),
-      streamSignal: Boolean(options.streamSignal),
+      streamSignal: Boolean(options.streamSignal) || runtime.needsReconciliation(domain, scope),
       streamingHealthy: this.isStreamingHealthy(domain, scope),
       hasData: Boolean(getScopedDomainState(domain, scope).data),
     });
@@ -1359,6 +1363,7 @@ class RefreshOrchestrator {
       isManual?: boolean;
       streamSignal?: boolean;
       queryReconcile?: boolean;
+      coalesce?: boolean;
       correlationId?: string;
     } = {}
   ): Promise<void> {
@@ -1381,6 +1386,7 @@ class RefreshOrchestrator {
         isManual: Boolean(options.isManual),
         streamSignal: Boolean(options.streamSignal),
         queryReconcile: Boolean(options.queryReconcile),
+        ...(options.coalesce ? { coalesce: true } : {}),
       });
       return;
     }
@@ -1403,6 +1409,7 @@ class RefreshOrchestrator {
     }
 
     await this.performFetch(domain, normalizedScope, {
+      ...(options.coalesce ? { coalesce: true } : {}),
       isManual: options.isManual ?? true,
       signal: options.signal,
       streamSignal: Boolean(options.streamSignal),
@@ -1415,6 +1422,12 @@ class RefreshOrchestrator {
     scope: string,
     options: DomainFetchOptions
   ): boolean {
+    if (
+      !options.isManual &&
+      !this.getRuntimeForScope(domain, scope).canRetryReconciliation(domain, scope)
+    ) {
+      return false;
+    }
     if (options.signal?.aborted) {
       return false;
     }
@@ -1441,11 +1454,11 @@ class RefreshOrchestrator {
     if (!currentInFlight) {
       return true;
     }
-    if (options.isManual) {
+    if (options.isManual && !options.coalesce) {
       this.teardownInFlight(runtime, makeInFlightKey(domain, scope), currentInFlight);
       return true;
     }
-    if (options.streamSignal) {
+    if (options.streamSignal || options.coalesce) {
       // Coalesce doorbells arriving during the request into one trailing
       // refetch. Aborting here can starve a busy scope indefinitely.
       runtime.latchTrailingStreamSignal(domain, scope);
@@ -1475,10 +1488,16 @@ class RefreshOrchestrator {
     }
     const cleanup = this.forwardAbortSignal(options.signal, controller);
     const requestId = ++this.requestCounter;
+    let complete!: () => void;
+    const completion = new Promise<void>((resolve) => {
+      complete = resolve;
+    });
     const request: InFlightRequest = {
+      completion,
       controller,
       isManual: options.isManual,
       streamSignal: options.streamSignal,
+      coalesce: options.coalesce,
       requestId,
       cleanup,
       contextVersion,
@@ -1487,7 +1506,7 @@ class RefreshOrchestrator {
     };
     runtime.setInFlight(request);
     markPendingRequest(1);
-    return { runtime, scope, previousState, controller, requestId, contextVersion };
+    return { runtime, scope, previousState, controller, requestId, contextVersion, complete };
   }
 
   private forwardAbortSignal(
@@ -1517,6 +1536,7 @@ class RefreshOrchestrator {
     }
   ): void {
     const { scope } = execution;
+    execution.runtime.markReconciled(domain, scope);
     if (result.notModified || !result.snapshot) {
       if (
         !options.allowDisabledRetainedScope &&
@@ -1560,6 +1580,7 @@ class RefreshOrchestrator {
       // A typed 403 is a settled answer and bypasses startup network-error
       // suppression so automatic retries stop for this scope.
       execution.runtime.markPermissionDenied(domain, execution.scope);
+      execution.runtime.markReconciled(domain, execution.scope);
       setScopedDomainState(domain, execution.scope, (previous) => ({
         ...previous,
         status: 'error',
@@ -1570,6 +1591,7 @@ class RefreshOrchestrator {
       this.notifyRefreshError(domain, execution.scope, message, error, options.correlationId);
       return;
     }
+    execution.runtime.markReconciliationFailed(domain, execution.scope);
     if (this.errorNotifier.shouldSuppressNetworkError(message)) {
       setScopedDomainState(domain, execution.scope, (previous) => ({
         ...previous,
@@ -1622,14 +1644,21 @@ class RefreshOrchestrator {
 
     const runtime = this.getRuntimeForScope(domain, normalizedScope);
     if (!this.claimFetchSlot(domain, normalizedScope, options, runtime)) {
+      if (!options.coalesce) {
+        return;
+      }
+      const current = runtime.getInFlight(domain, normalizedScope);
+      await current?.completion;
+      // A signal arriving during a read requires its one trailing snapshot.
+      // Wait for that read, without following an unbounded chain of later signals.
+      await runtime.getInFlight(domain, normalizedScope)?.completion;
       return;
     }
 
     const previousState = getScopedDomainState(domain, normalizedScope);
     // A permission-denied scope is SETTLED: the backend refused it with a
-    // typed 403 and permission changes are not expected mid-session (the
-    // exceptions — a namespace-scope rebuild, and manual refresh below —
-    // clear the latch explicitly; see handleClusterScopeChanged). Background
+    // typed 403. A permission or namespace-scope rebuild, or manual refresh
+    // below, clears the latch explicitly; see handleClusterScopeChanged. Background
     // retries here caused a request every ~2s
     // (the no-data fetch clause) and flicked the state through 'loading' —
     // observed live as a spinner flashing over the permission message. Manual
@@ -1664,6 +1693,7 @@ class RefreshOrchestrator {
       this.handleFetchFailure(domain, execution, options, error);
     } finally {
       this.finishFetch(domain, execution);
+      execution.complete();
     }
   }
 
@@ -1935,27 +1965,27 @@ class RefreshOrchestrator {
   };
 
   private readonly handleClusterScopeChanged = (payload: { clusterId: string }) => {
-    // The cluster's namespace scope changed and the backend finished tearing
-    // down + rebuilding its refresh subsystem (docs/architecture/namespace-scope.md):
-    // every stream to that subsystem is dead and every cached snapshot is
-    // pre-rebuild. Resume exactly as auth recovery does (minus the pause
-    // bookkeeping — auth never went invalid).
-    logInfo('[refresh] namespace scope changed — restarting streams', {
-      clusterId: payload.clusterId,
+    const clusterId = payload.clusterId.trim();
+    if (!clusterId) {
+      return;
+    }
+    const runtime = this.clusterRuntimes.get(clusterId);
+    resetPermissionDeniedScopedDomainStates(clusterId);
+    if (!runtime) {
+      return;
+    }
+    logInfo('[refresh] access changed — restarting cluster streams', { clusterId });
+    this.stopRuntimeStreaming(runtime, false);
+    runtime.forEachInFlight((details, key) => this.teardownInFlight(runtime, key, details));
+    runtime.clearAsyncStreamingBookkeeping();
+    runtime.clearBlockedStreaming();
+    runtime.clearAllStreamHealth();
+    this.resetRuntimePermissionEpoch(runtime);
+    runtime.forEachScopedDomain((domain, scope) => {
+      this.errorNotifier.clear(domain, scope);
+      runtime.markReconciliationFailed(domain, scope);
     });
-    // Permission-denied scopes are settled for the session — EXCEPT across a
-    // scope rebuild, which is a real permission epoch change: domains denied
-    // cluster-wide may now be served per-namespace. Clear the latches so the
-    // affected scopes re-ask (they hold no data, so nothing blanks).
-    resetPermissionDeniedScopedDomainStates();
-    this.resetAllRuntimePermissionEpochs();
-    this.incrementContextVersion();
-    // Suppress transient errors while the rebuilt subsystem starts serving.
-    this.errorNotifier.suppressNetworkErrors(6000);
-    this.clearAllBlockedStreaming();
-    this.clearAllStreamHealth();
-    this.errorNotifier.clearAll();
-    this.handleStreamingScopeChanges();
+    this.handleStreamingScopeChanges([runtime]);
   };
 
   private readonly handleResetViews = () => {
@@ -1989,14 +2019,14 @@ class RefreshOrchestrator {
   };
 
   // Re-evaluate streaming for all scoped domains when the orchestrator context changes.
-  private handleStreamingScopeChanges(): void {
+  private handleStreamingScopeChanges(runtimes = this.getAllRuntimes()): void {
     this.configs.forEach((config, domain) => {
       const streaming = config.streaming;
       if (!streaming) {
         return;
       }
 
-      this.getAllRuntimes().forEach((runtime) => {
+      runtimes.forEach((runtime) => {
         runtime.forEachEnabledScope(domain, (scope) => {
           const shouldStream = this.shouldStreamScope(domain, scope);
           const scopeRuntime = this.getRuntimeForScope(domain, scope);

--- a/frontend/src/core/refresh/refreshRuntime.test.ts
+++ b/frontend/src/core/refresh/refreshRuntime.test.ts
@@ -68,12 +68,24 @@ describe('scoped readiness, permission, and cluster auth transitions', () => {
     );
     readiness = transitionScopedReadinessState(readiness, {
       type: 'request-deferred',
-      request: { ...first, isManual: true, streamSignal: false, queryReconcile: true },
+      request: {
+        ...first,
+        isManual: true,
+        streamSignal: false,
+        queryReconcile: true,
+        coalesce: true,
+      },
     });
 
     expect(readiness).toEqual({
       status: 'waiting',
-      request: { ...first, isManual: true, streamSignal: true, queryReconcile: true },
+      request: {
+        ...first,
+        isManual: true,
+        streamSignal: true,
+        queryReconcile: true,
+        coalesce: true,
+      },
     });
     expect(transitionScopedReadinessState(readiness, { type: 'cluster-ready' })).toEqual({
       status: 'ready',
@@ -546,5 +558,36 @@ describe('ClusterRefreshRuntime', () => {
       mode: 'skip',
       fallback: false,
     });
+  });
+});
+
+describe('failed reconciliation recovery', () => {
+  it('retains retry intent through stream health changes, bounds backoff, and clears it on success', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(1000);
+      const runtime = new ClusterRefreshRuntime('cluster-a');
+      const scope = 'cluster-a|';
+      runtime.markReconciliationFailed('pods', scope);
+      expect(runtime.canRetryReconciliation('pods', scope)).toBe(true);
+      runtime.markReconciliationFailed('pods', scope);
+      expect(runtime.canRetryReconciliation('pods', scope)).toBe(false);
+      vi.advanceTimersByTime(1000);
+      expect(runtime.canRetryReconciliation('pods', scope)).toBe(true);
+      for (let i = 0; i < 20; i++) {
+        runtime.markReconciliationFailed('pods', scope);
+      }
+      runtime.clearAllStreamHealth();
+      expect(runtime.needsReconciliation('pods', scope)).toBe(true);
+      expect(runtime.needsReconciliation('nodes', scope)).toBe(false);
+      vi.advanceTimersByTime(60000);
+      expect(runtime.canRetryReconciliation('pods', scope)).toBe(true);
+      runtime.markReconciled('pods', scope);
+      expect(runtime.needsReconciliation('pods', scope)).toBe(false);
+      runtime.markReconciliationFailed('pods', scope);
+      expect(runtime.canRetryReconciliation('pods', scope)).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/frontend/src/core/refresh/refreshRuntime.ts
+++ b/frontend/src/core/refresh/refreshRuntime.ts
@@ -7,8 +7,10 @@ export type InFlightRequest = {
   // Preserve the originating request intent if foreground activation aborts
   // this fetch and replays it after the cluster becomes serviceable.
   streamSignal?: boolean;
+  coalesce?: boolean;
   requestId: number;
   cleanup?: () => void;
+  completion?: Promise<void>;
   contextVersion: number;
   domain: RefreshDomain;
   scope?: string;
@@ -158,6 +160,7 @@ export const transitionScopedActivationState = (
 };
 
 export type PendingClusterReadinessRequest = {
+  coalesce?: boolean;
   domain: RefreshDomain;
   scope: string;
   isManual: boolean;
@@ -186,6 +189,7 @@ export const transitionScopedReadinessState = (
         status: 'waiting',
         request: {
           ...state.request,
+          ...(state.request.coalesce || event.request.coalesce ? { coalesce: true } : {}),
           isManual: state.request.isManual || event.request.isManual,
           streamSignal: state.request.streamSignal || event.request.streamSignal,
           queryReconcile: state.request.queryReconcile || event.request.queryReconcile,
@@ -457,6 +461,7 @@ export const transitionScopedStreamState = (
 type ScopedRefreshState = {
   domain: RefreshDomain;
   scope?: string;
+  reconciliation: { status: 'clean' } | { status: 'pending'; failures: number; retryAt: number };
   activation: ScopedActivationState;
   fetch: ScopedFetchState;
   readiness: ScopedReadinessState;
@@ -553,6 +558,7 @@ export class ClusterRefreshRuntime {
       this.scopedStates.get(makeInFlightKey(domain, scope)) ?? {
         domain,
         scope,
+        reconciliation: { status: 'clean' },
         activation: { status: 'untracked' },
         fetch: { status: 'idle' },
         readiness: { status: 'ready' },
@@ -565,6 +571,7 @@ export class ClusterRefreshRuntime {
   private storeScopeState(state: ScopedRefreshState): void {
     const key = makeInFlightKey(state.domain, state.scope);
     if (
+      state.reconciliation.status === 'clean' &&
       state.activation.status === 'untracked' &&
       state.fetch.status === 'idle' &&
       state.readiness.status === 'ready' &&
@@ -784,6 +791,31 @@ export class ClusterRefreshRuntime {
     return Array.from(this.scopedStates.values()).flatMap((state) =>
       state.readiness.status === 'waiting' ? [state.readiness.request] : []
     );
+  }
+
+  needsReconciliation(domain: RefreshDomain, scope: string): boolean {
+    return this.getScopeState(domain, scope).reconciliation.status === 'pending';
+  }
+
+  canRetryReconciliation(domain: RefreshDomain, scope: string, now = Date.now()): boolean {
+    const pending = this.getScopeState(domain, scope).reconciliation;
+    return pending.status === 'clean' || pending.retryAt <= now;
+  }
+
+  markReconciliationFailed(domain: RefreshDomain, scope: string): void {
+    const state = this.getScopeState(domain, scope);
+    const failures =
+      state.reconciliation.status === 'pending' ? state.reconciliation.failures + 1 : 1;
+    const delay = failures === 1 ? 0 : Math.min(60_000, 1000 * 2 ** Math.min(failures - 2, 6));
+    this.storeScopeState({
+      ...state,
+      reconciliation: { status: 'pending', failures, retryAt: Date.now() + delay },
+    });
+  }
+
+  markReconciled(domain: RefreshDomain, scope: string): void {
+    const state = this.getScopeState(domain, scope);
+    this.storeScopeState({ ...state, reconciliation: { status: 'clean' } });
   }
 
   isPermissionDenied(domain: RefreshDomain, scope: string): boolean {

--- a/frontend/src/core/refresh/store.test.ts
+++ b/frontend/src/core/refresh/store.test.ts
@@ -192,7 +192,13 @@ describe('resetPermissionDeniedScopedDomainStates', () => {
       status: 'ready',
     }));
 
-    resetPermissionDeniedScopedDomainStates();
+    setScopedDomainState('namespaces', 'cluster-b|', (prev) => ({
+      ...prev,
+      status: 'error',
+      permissionDenied: true,
+    }));
+    resetPermissionDeniedScopedDomainStates('cluster-a');
+    expect(getScopedDomainState('namespaces', 'cluster-b|').permissionDenied).toBe(true);
 
     expect(getScopedDomainState('namespaces', 'cluster-a|').permissionDenied).not.toBe(true);
     expect(getScopedDomainState('namespaces', 'cluster-a|').status).not.toBe('error');

--- a/frontend/src/core/refresh/store.ts
+++ b/frontend/src/core/refresh/store.ts
@@ -7,6 +7,7 @@
 
 import { useSyncExternalStore } from 'react';
 import type { SnapshotStats } from './client';
+import { parseClusterScope } from './clusterScope';
 import type { RefreshSourceClock } from './domainRegistry';
 import type { DomainPayloadMap, RefreshDomain } from './types';
 
@@ -27,9 +28,8 @@ export interface DomainSnapshotState<TPayload> {
   // fetch and CANNOT be a signal key — that was the echo-refetch bug).
   signalVersions?: Partial<Record<RefreshSourceClock, string>>;
   // The backend refused this scope for lack of RBAC permission (typed 403).
-  // TERMINAL for the session: background refetches skip the scope entirely
-  // (permission is checked once; recovery is an app restart). Cleared only by
-  // a successful fetch or a scoped-state reset.
+  // Background refetches skip denied scopes until manual refresh or the owning
+  // cluster's auth/scope/permission recovery starts a new permission epoch.
   permissionDenied?: boolean;
   checksum?: string;
   etag?: string;
@@ -309,22 +309,17 @@ export const resetAllScopedDomainStates = <K extends RefreshDomain>(domain: K): 
   notify();
 };
 
-/**
- * Drops every scoped domain state latched permission-denied, so those scopes
- * re-ask on their next (non-manual) refresh. Permission-denied is normally
- * settled for the session, but a namespace-scope rebuild
- * (docs/architecture/namespace-scope.md) is a real permission epoch change: domains
- * denied cluster-wide may now be served per-namespace. Denied scopes hold no
- * data, so dropping them never blanks a rendered view; every other scope
- * state is untouched.
- */
-export const resetPermissionDeniedScopedDomainStates = (): void => {
+/** Resets denied snapshots only for the cluster whose permission epoch changed. */
+export const resetPermissionDeniedScopedDomainStates = (clusterId: string): void => {
+  if (!clusterId.trim()) {
+    return;
+  }
   const denied: Array<{ domain: RefreshDomain; scope: string }> = [];
   for (const [domain, scopes] of Object.entries(state.scopedDomains)) {
     for (const [scope, snapshot] of Object.entries(
       scopes as Record<string, DomainSnapshotState<unknown>>
     )) {
-      if (snapshot.permissionDenied) {
+      if (snapshot.permissionDenied && parseClusterScope(scope).clusterId === clusterId) {
         denied.push({ domain: domain as RefreshDomain, scope });
       }
     }

--- a/frontend/src/modules/namespace/contexts/NamespaceContext.tsx
+++ b/frontend/src/modules/namespace/contexts/NamespaceContext.tsx
@@ -706,7 +706,10 @@ export const NamespaceProvider: React.FC<NamespaceProviderProps> = ({ children }
     // updated before this event is emitted. Derive the scope from the event's
     // clusterId and reconcile once without creating a ManualQueue job.
     const handleClusterScopeChanged = (payload: { clusterId: string }) => {
-      const scope = payload.clusterId ? buildClusterScope(payload.clusterId, '') : namespacesScope;
+      if (!payload.clusterId.trim()) {
+        return;
+      }
+      const scope = buildClusterScope(payload.clusterId, '');
       if (!scope) {
         return;
       }
@@ -718,6 +721,10 @@ export const NamespaceProvider: React.FC<NamespaceProviderProps> = ({ children }
     const unsubReset = eventBus.on('view:reset', handleResetViews);
     const unsubChanging = eventBus.on('kubeconfig:changing', handleKubeconfigChanging);
     const unsubChanged = eventBus.on('kubeconfig:changed', handleKubeconfigChanged);
+    const unsubPermissionsChanged = eventBus.on(
+      'cluster:permissions-changed',
+      handleClusterScopeChanged
+    );
     const unsubScopeChanged = eventBus.on('cluster:scope-changed', handleClusterScopeChanged);
 
     return () => {
@@ -725,8 +732,9 @@ export const NamespaceProvider: React.FC<NamespaceProviderProps> = ({ children }
       unsubChanging();
       unsubChanged();
       unsubScopeChanged();
+      unsubPermissionsChanged();
     };
-  }, [clearSelection, namespaceScopes, namespacesScope, updateNamespaces]);
+  }, [clearSelection, namespaceScopes, updateNamespaces]);
 
   // Structural flag stamped by the orchestrator from the typed 403 (checked
   // once per session; the scope is settled and background retries stop).

--- a/frontend/src/modules/resource-grid/useTypedResourceQuery.test.tsx
+++ b/frontend/src/modules/resource-grid/useTypedResourceQuery.test.tsx
@@ -1243,4 +1243,17 @@ describe('useTypedResourceQuery', () => {
     expect(result?.pageIndex).toBe(1);
     expect(result?.hasPrevious).toBe(false);
   });
+  it('surfaces a failed snapshot instead of treating it as warmup', async () => {
+    requestRefreshDomainStateMock.mockResolvedValue({
+      status: 'executed',
+      data: {
+        status: 'error',
+        data: null,
+        error: 'Snapshot request failed: 500 Internal Server Error',
+      },
+    });
+    await renderQuery();
+    expect(result?.error).toBe('Snapshot request failed: 500 Internal Server Error');
+    expect(result?.loaded).toBe(true);
+  });
 });

--- a/frontend/src/modules/resource-grid/useTypedResourceQuery.ts
+++ b/frontend/src/modules/resource-grid/useTypedResourceQuery.ts
@@ -242,13 +242,17 @@ const dispatchTypedQueryResult = <TPayload extends TypedQueryPayload>(
     callbacks.onWarmup();
     return;
   }
+  if (result.data?.permissionDenied) {
+    callbacks.onPermissionDenied(result.data.error ?? 'Insufficient permissions');
+    return;
+  }
+  if (result.data?.status === 'error') {
+    callbacks.onError(new Error(result.data.error ?? 'Snapshot request failed'));
+    return;
+  }
   const payload = result.data?.data as TPayload | null | undefined;
   if (!payload) {
-    if (result.data?.permissionDenied) {
-      callbacks.onPermissionDenied(result.data.error ?? 'Insufficient permissions');
-    } else {
-      callbacks.onWarmup();
-    }
+    callbacks.onWarmup();
     return;
   }
   if (payload.cursorInvalid) {

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.12.1
-	github.com/wailsapp/wails/v3 v3.0.0-beta.16
+	github.com/wailsapp/wails/v3 v3.0.0-beta.17
 	golang.org/x/mod v0.40.0
 	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0

--- a/go.sum
+++ b/go.sum
@@ -305,8 +305,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWDWE=
 github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
-github.com/wailsapp/wails/v3 v3.0.0-beta.16 h1:ud3YMzTbPPae4EP3Wls4qBVsESZwwAkEny1P/zzw6Tk=
-github.com/wailsapp/wails/v3 v3.0.0-beta.16/go.mod h1:zKZYhB3WjrN5LhJWbnOAVMN0Xf8qTozbw2nf5micKl4=
+github.com/wailsapp/wails/v3 v3.0.0-beta.17 h1:Bpnrv4EVmpgZI/qHuCh70nZCcGjgdgzHLPAUp+FWIO8=
+github.com/wailsapp/wails/v3 v3.0.0-beta.17/go.mod h1:zKZYhB3WjrN5LhJWbnOAVMN0Xf8qTozbw2nf5micKl4=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=

--- a/mise.toml
+++ b/mise.toml
@@ -6,7 +6,7 @@ node = "26.8.1"
 npm = "12.0.2"
 "go:honnef.co/go/tools/cmd/staticcheck" = "0.8.0"
 trivy = "0.74.0"
-"go:github.com/wailsapp/wails/v3/cmd/wails3" = "3.0.0-beta.16"
+"go:github.com/wailsapp/wails/v3/cmd/wails3" = "3.0.0-beta.17"
 
 [vars]
 # NSIS is installed by the Windows-specific release action rather than Mise.


### PR DESCRIPTION
- Refresh now recovers automatically when Kubernetes permissions are restored, without requiring an app restart.
- Failed data refreshes retry with backoff while retaining the last available data.
- Resource streams reconnect after delivery overflow; oversized reconnect replays request a fresh snapshot to avoid repeated disconnects.
- Replacing a cluster connection now stops the previous object catalog and releases its generation's resources.
